### PR TITLE
rgw/motr: fix concurrent obj puts

### DIFF
--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -253,11 +253,10 @@ endif()
 
 if(WITH_RADOSGW_MOTR)
   target_include_directories(rgw_common PRIVATE "/usr/include/motr")
-  target_compile_options(rgw_common
-    PRIVATE "-Wno-attributes")
+  target_compile_options(rgw_common PRIVATE "-Wno-attributes")
   target_compile_definitions(rgw_common
     PRIVATE "M0_EXTERN=extern" "M0_INTERNAL=")
-  target_link_libraries(rgw_common PRIVATE "motr")
+  target_link_libraries(rgw_common PRIVATE motr motr-helpers)
 endif()
 
 set(rgw_a_srcs

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1329,22 +1329,6 @@ int MotrAtomicWriter::prepare(optional_yield y)
   return rc;
 }
 
-void MotrObject::obj_name_to_motr_fid(struct m0_uint128 *obj_fid)
-{
-  // calculate FID from the object name (key) and its bucket marker
-  MD5 hash;
-  // Allow use of MD5 digest in FIPS mode for non-cryptographic purposes
-  hash.SetFlags(EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
-  hash.Update((const unsigned char *)this->get_key().to_str().c_str(),
-  this->get_key().to_str().length());
-  hash.Update((const unsigned char *)this->get_bucket()->get_name().c_str(),
-  this->get_bucket()->get_name().length());
-  unsigned char md5[CEPH_CRYPTO_MD5_DIGESTSIZE];
-  hash.Final(md5);
-
-  memcpy(obj_fid, md5, sizeof *obj_fid);
-}
-
 int MotrObject::create_mobj(const DoutPrefixProvider *dpp, uint64_t sz)
 {
   if (mobj != nullptr) {

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -591,7 +591,6 @@ class MotrObject : public Object {
     int write_mobj(const DoutPrefixProvider *dpp, bufferlist&& data, uint64_t offset);
     int read_mobj(const DoutPrefixProvider* dpp, int64_t off, int64_t end, RGWGetDataCB* cb);
     unsigned get_optimal_bs(unsigned len);
-    void obj_name_to_motr_fid(struct m0_uint128 *obj_fid);
 
     int get_part_objs(const DoutPrefixProvider *dpp,
                       std::map<int, std::unique_ptr<MotrObject>>& part_objs);

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -438,12 +438,15 @@ class MotrObject : public Object {
 
     // motr object metadata stored in index
     struct Meta {
+      struct m0_uint128 oid = {};
       struct m0_fid pver = {};
       uint64_t layout_id = 0;
 
       void encode(bufferlist& bl) const
       {
-        ENCODE_START(3, 3, bl);
+        ENCODE_START(5, 5, bl);
+        encode(oid.u_hi, bl);
+        encode(oid.u_lo, bl);
         encode(pver.f_container, bl);
         encode(pver.f_key, bl);
         encode(layout_id, bl);
@@ -452,7 +455,9 @@ class MotrObject : public Object {
 
       void decode(bufferlist::const_iterator& bl)
       {
-        DECODE_START(3, bl);
+        DECODE_START(5, bl);
+        decode(oid.u_hi, bl);
+        decode(oid.u_lo, bl);
         decode(pver.f_container, bl);
         decode(pver.f_key, bl);
         decode(layout_id, bl);
@@ -461,7 +466,6 @@ class MotrObject : public Object {
     };
 
     struct m0_obj     *mobj = NULL;
-    struct m0_uint128  fid;
     Meta               meta;
 
     struct MotrReadOp : public ReadOp {
@@ -952,7 +956,7 @@ class MotrStore : public Store {
     int create_motr_idx_by_name(std::string iname);
     int delete_motr_idx_by_name(std::string iname);
     int do_idx_op_by_name(std::string idx_name, enum m0_idx_opcode opcode,
-                          std::string key_str, bufferlist &bl);
+                          std::string key_str, bufferlist &bl, bool update=true);
     int check_n_create_global_indices();
 
     int init_metadata_cache(const DoutPrefixProvider *dpp, CephContext *cct);


### PR DESCRIPTION
Always generate new motr fid for objects, even for the same
S3 objects. This way even the same S3 object can be concurrently
written to motr. But only one of them is stored, for the other one
the error is returned, according to S3 API spec.

Closes #5.