### PR TITLE
rgw_sal_motr: implement watch-notify mechanism using Motr FDMI

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -3284,6 +3284,14 @@ options:
   default: false
   services:
   - rgw
+- name: motr_cache_fdmi_filter_id
+  type: str
+  level: advanced
+  desc: experimental Option to set Motr FDMI filter fid for cache watch-notify
+  long_desc: example value 0x6c00000000000001:0x51
+  default: 0x6c00000000000001:0x51
+  services:
+  - rgw
 - name: rgw_luarocks_location
   type: str
   level: advanced

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -25,6 +25,10 @@ extern "C" {
 #include "lib/trace.h"   // m0_trace_set_mmapped_buffer
 #include "motr/layout.h" // M0_OBJ_LAYOUT_ID
 #include "helpers/helpers.h" // m0_ufid_next
+#include "fid/fid.h"
+#include "fdmi/fdmi.h"
+#include "fdmi/plugin_dock.h"
+#include "fdmi/service.h"
 }
 
 #include "common/Clock.h"
@@ -56,6 +60,165 @@ static std::string motr_global_indices[] = {
   RGW_MOTR_BUCKET_INST_IDX_NAME,
   RGW_MOTR_BUCKET_HD_IDX_NAME
 };
+
+struct MotrFidComparator {
+  bool operator()(const struct m0_fid& left, const struct m0_fid& right) const {
+    return left.f_container < right.f_container ||
+	   (left.f_container == right.f_container && left.f_key < right.f_key);
+  }
+};
+static map<struct m0_fid, MotrWatcher*, MotrFidComparator> motr_watchers;
+
+// process_fdmi_record() can't be implemented as MotrWatcher's member function
+// as the function pointer to a member funciton is a different type to fdmi's
+// callback function.
+static int process_fdmi_record(struct m0_uint128 *rec_id,
+                               struct m0_buf fdmi_rec,
+                               struct m0_fid filter_id)
+{
+  int rc;
+  int len;
+  struct m0_fol_rec fol_rec;
+  struct m0_fol_frag *frag;
+  struct m0_fop_fol_frag *fp_frag;
+  struct m0_cas_op *cas_op;
+  struct m0_cas_recv cg_rec;
+  struct m0_cas_rec *cr_rec;
+  char *addr;
+  void *next;
+  const struct m0_tl *head = &fol_rec.fr_frags;
+
+  std::cout << "fdmi cb: process_fdmi_record() enter. " << std::endl;
+
+  auto iter = motr_watchers.find(filter_id);
+  if (iter == motr_watchers.end())
+    return -EINVAL;
+  MotrWatcher* watcher = iter->second;
+
+  m0_fol_rec_init(&fol_rec, NULL);
+  rc = m0_fol_rec_decode(&fol_rec, &fdmi_rec);
+  if (rc != 0)
+    goto out;
+
+  // C++ doesn't allow assigning void* to pointer of other type, so
+  // m0_tl_for can't be used here.
+  // error: invalid conversion from ‘void*’ to ‘m0_fol_frag*’ ...
+  // m0_tl_for(m0_rec_frag, &fol_rec.fr_frags, frag) {
+
+  for (frag = (struct m0_fol_frag *)m0_tlist_head(&m0_rec_frag_tl, head);
+       frag != NULL &&	((void)(next = m0_tlist_next(&m0_rec_frag_tl, head, frag)), true);
+       frag = (struct m0_fol_frag *) next)
+  {
+    fp_frag = (struct m0_fop_fol_frag *) frag->rp_data;
+    cas_op = (struct m0_cas_op *) fp_frag->ffrp_fop;
+    cg_rec = cas_op->cg_rec;
+    cr_rec = cg_rec.cr_rec;
+
+    for (uint64_t i = 0; i < cg_rec.cr_nr; i++) {
+      len  = cr_rec[i].cr_val.u.ab_buf.b_nob;
+      addr = (char *) cr_rec[i].cr_val.u.ab_buf.b_addr;
+      bufferlist bl;
+      bl.append(addr, len);
+      rc = watcher->watch_cb(bl);
+      if (rc < 0)
+        goto out;
+    }
+  } //m0_tl_endfor;
+
+out:
+  m0_fol_rec_fini(&fol_rec);
+  std::cout << "fdmi cb: process_fdmi_record() leave rc =  " << rc << std::endl;
+  return rc;
+}
+
+int MotrWatcher::init_fdmi_plugin(const DoutPrefixProvider *dpp)
+{
+  int rc;
+  this->fdmi_dock_ops = m0_fdmi_plugin_dock_api_get();
+  std::cout << "init_fdmi_plugin " << std::endl;
+
+  const auto& filter_id = g_conf().get_val<std::string>("motr_cache_fdmi_filter_id");
+  rc = m0_fid_sscanf(filter_id.c_str(), &this->fdmi_plugin_fid);
+  if (rc < 0)
+    return rc;
+  this->fdmi_plugin_cb.po_fdmi_rec = process_fdmi_record;
+  const struct m0_fdmi_filter_desc fd;
+  ldpp_dout(dpp, 0) << "register filter " << dendl;
+  rc = this->fdmi_dock_ops->fpo_register_filter(&this->fdmi_plugin_fid, &fd,
+                                                &this->fdmi_plugin_cb);
+  if (rc != 0)
+    return rc;
+
+  ldpp_dout(dpp, 0) << "enable filter " << dendl;
+  this->fdmi_dock_ops->fpo_enable_filters(true, &this->fdmi_plugin_fid, 1);
+  motr_watchers.emplace(this->fdmi_plugin_fid, this);
+  return rc;
+}
+
+int MotrNotifier::init(const DoutPrefixProvider *dpp)
+{
+  int rc = 0;
+  char buf[32 + 1];
+
+  gen_rand_alphanumeric_no_underscore(this->store->ctx(), buf, 32);
+  this->instance.assign(buf);
+
+  for (int i = 0; i < nr_notif_indices; i++) {
+    char i_str[16];
+    snprintf(i_str, sizeof(i_str), "%08d", i);
+    string iname = "rgw.motr." + this->name + '.' + i_str;
+    ldpp_dout(dpp, 0) << "create watch_notif index = " << iname << dendl;
+    rc = store->create_motr_idx_by_name(iname);
+    if (rc < 0 && rc != -EEXIST)
+      break;
+    rc = 0;
+  }
+
+  return rc;
+}
+
+int MotrNotifier::notify(const DoutPrefixProvider *dpp, const std::string& key,
+                         MotrWatchNotifyMsg& msg)
+{
+  uint32_t h = ceph_str_hash_linux(key.c_str(), key.size());
+  char h_str[16];
+  snprintf(h_str, sizeof(h_str), "%08d", h % this->nr_notif_indices);
+  string iname = "rgw.motr." + this->name + '.' + h_str;
+
+  bufferlist bl;
+  msg.encode(bl);
+  ldpp_dout(dpp, 0) << "send notification:  " << bl.c_str() << dendl;
+  return store->do_idx_op_by_name(iname, M0_IC_PUT, key, bl);
+}
+
+int MotrCacheWatcher::watch_cb(bufferlist& bl)
+{
+  ldout(this->cctx, 20) << "watch cb: enter " << dendl;
+
+  MotrCacheNotif cnotif;
+  auto iter = bl.cbegin();
+  cnotif.decode(iter);
+  std::string& obj_name = cnotif.get_key();
+  int op = cnotif.get_op();
+  ldout(this->cctx, 20) << "watch cb: obj_name = " << obj_name << dendl;
+  ldout(this->cctx, 20) << "watch cb: notifier = " << cnotif.get_notifier() << dendl;
+  if (this->is_excluded_notifier(cnotif.get_notifier())) {
+    ldout(this->cctx, 20) << "watch cb: notification from my friend, do nothing " << dendl;
+    return 0;
+  }
+
+  switch (op) {
+  case UPDATE_OBJ:
+  case INVALIDATE_OBJ:
+    ldout(this->cctx, 20) << "watch cb: cache invalid " << dendl;
+    return 0;
+    this->cache->invalid(nullptr, obj_name);
+    break;
+  default:
+    return -EOPNOTSUPP;
+  }
+  return 0;
+}
 
 void MotrMetaCache::invalid(const DoutPrefixProvider *dpp,
                            const string& name)
@@ -128,19 +291,15 @@ int MotrMetaCache::remove(const DoutPrefixProvider *dpp,
 }
 
 int MotrMetaCache::distribute_cache(const DoutPrefixProvider *dpp,
-                                    const string& normal_name,
+                                    const std::string& name,
                                     ObjectCacheInfo& obj_info, int op)
 {
-  return 0;
-}
+  if (this->notifier == nullptr)
+    return 0;
 
-int MotrMetaCache::watch_cb(const DoutPrefixProvider *dpp,
-                            uint64_t notify_id,
-                            uint64_t cookie,
-                            uint64_t notifier_id,
-                            bufferlist& bl)
-{
-  return 0;
+  MotrCacheNotif cnotif(RGW_MOTR_CACHE_FDMI_FILTER_MARKER,
+                        this->notifier->get_key(), name, op);
+  return this->notifier->notify(dpp, name, cnotif);
 }
 
 void MotrMetaCache::set_enabled(bool status)
@@ -3400,6 +3559,8 @@ int MotrStore::init_metadata_cache(const DoutPrefixProvider *dpp,
 {
   this->obj_meta_cache = new MotrMetaCache(dpp, cct);
   this->get_obj_meta_cache()->set_enabled(true);
+  //Set watcher & notifier for object metadata cache.
+  this->get_obj_meta_cache()->init_watcher_notifier(dpp, cct, this, 4, "obj.meta.cache.notifier");
 
   this->user_cache = new MotrMetaCache(dpp, cct);
   this->get_user_cache()->set_enabled(true);
@@ -3408,6 +3569,50 @@ int MotrStore::init_metadata_cache(const DoutPrefixProvider *dpp,
   this->get_bucket_inst_cache()->set_enabled(true);
 
   return 0;
+}
+
+int MotrStore::fdmi_service_start(struct m0_client *m0c)
+{
+  struct m0_reqh *reqh = &m0c->m0c_reqh;
+  struct m0_reqh_service_type *stype;
+  bool start_service = false;
+  int rc = 0;
+
+  stype = m0_reqh_service_type_find("M0_CST_FDMI");
+  ldout(cctx, 0) << "m0_reqh_service_type_find() "  << dendl;
+  if (stype == NULL) {
+    return-EINVAL;
+   }
+
+   fdmi_service = m0_reqh_service_find(stype, reqh);
+   if (fdmi_service == NULL) {
+     ldout(cctx, 0) << "m0_reqh_service_find(): fdmi_service == NULL, allocate "  << dendl;
+     rc = m0_reqh_service_allocate(&fdmi_service, &m0_fdmi_service_type, NULL);
+     if (rc != 0)
+       return rc;
+     ldout(cctx, 0) << "m0_reqh_service_init() "  << dendl;
+     m0_reqh_service_init(fdmi_service, reqh, NULL);
+     start_service = true;
+    }
+
+    if (start_service) {
+      rc = m0_reqh_service_start(fdmi_service);
+      ldout(cctx, 0) << "m0_reqh_service_start(): rc =  " << rc << dendl;
+    }
+    return rc;
+}
+
+void MotrStore::fdmi_service_stop(struct m0_client *m0c)
+{
+  struct m0_reqh *reqh = &m0c->m0c_reqh;
+
+  if (fdmi_service != NULL) {
+    m0_reqh_service_prepare_to_stop(fdmi_service);
+    m0_reqh_idle_wait_for(reqh, fdmi_service);
+    m0_reqh_service_stop(fdmi_service);
+    m0_reqh_service_fini(fdmi_service);
+    fdmi_service = NULL;
+  }
 }
 
 } // namespace rgw::sal
@@ -3464,6 +3669,12 @@ void *newMotrStore(CephContext *cct)
     rc = m0_ufid_init(store->instance, &ufid_gr);
     if (rc != 0) {
       ldout(cct, 0) << "ERROR: m0_ufid_init() failed: " << rc << dendl;
+      goto out;
+    }
+
+    rc = store->fdmi_service_start(store->instance);
+    if (rc != 0) {
+      ldout(cct, 0) << "ERROR: fdmi_service_start() failed: " << rc << dendl;
       goto out;
     }
 

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -20,6 +20,9 @@
 extern "C" {
 #include "motr/config.h"
 #include "motr/client.h"
+#include "fdmi/fdmi.h"
+#include "fdmi/plugin_dock.h"
+#include "fdmi/service.h"
 }
 
 #include "rgw_sal.h"
@@ -39,6 +42,177 @@ class MotrStore;
 #define RGW_MOTR_BUCKET_INST_IDX_NAME "motr.rgw.bucket.instances"
 #define RGW_MOTR_BUCKET_HD_IDX_NAME   "motr.rgw.bucket.headers"
 //#define RGW_MOTR_BUCKET_ACL_IDX_NAME  "motr.rgw.bucket.acls"
+
+// Implement watch-notify using Motr FDMI.
+// (1) A set of global indices, notify_watch_indices
+// (2) For each object to be watched, hash(obj_name) is used to pick which
+//     index in notifiy_watch_indices to insert a new key/value record,
+//     key = unique_fid(obj_name), value = marker (for fdmi filter) + notification msg.
+//     If multiple rgw instances are trying to write the same objects at the same time,
+//     we assume that Motr index is updated atomically.
+// (3) When the index is written, an FDMI record with a special marker is generated and
+//     picked up by the filter and delivered to our fdmi application, watcher.
+// (4) The embedded notification message is then processed to get object name and index
+//     opcode. These info are sent to cache layer.
+// (5) Update cache item accordingly and release notification(fdmi record).
+
+#define RGW_MOTR_CACHE_FDMI_FILTER_MARKER "rgw.motr.cache.fdmi.marker"
+
+// Notification message.
+class MotrWatchNotifyMsg {
+protected:
+  // The marker is used by FDMI to filter out the notification.
+  std::string marker;
+  std::string sender;
+
+public:
+  MotrWatchNotifyMsg(std::string _marker, std::string _sender) : marker(_marker), sender(_sender) {}
+  MotrWatchNotifyMsg(std::string _marker) : marker(_marker) {}
+  MotrWatchNotifyMsg() {}
+  virtual ~MotrWatchNotifyMsg() = default;
+  virtual void encode(bufferlist& bl) const {
+    // Add raw marker string at the begining to let FDMI filter
+    // catch it easily and make the header readable. Encoding marker
+    // with sender like the uncommented code below also works (and has
+    // been tested).
+    uint32_t marker_len = marker.length();
+    char len_str[16];
+    snprintf(len_str, sizeof(len_str), "%08d", marker_len);
+    std::string head = std::string(len_str) + '.' + marker;
+    bl.append(head);
+
+    ENCODE_START(2, 2, bl);
+    //encode(marker, bl);
+    encode(sender, bl);
+    ENCODE_FINISH(bl);
+  }
+  virtual void decode(bufferlist::const_iterator& bl) {
+    uint32_t marker_len;
+    char len_str[16];
+    bl.copy(8, (char *)len_str);
+    marker_len = std::stoul(len_str, nullptr, 10);
+    marker.clear();
+    bl.copy(marker_len + 1, marker);
+    marker.erase(0, 1);
+
+    DECODE_START(2, bl);
+    //decode(marker, bl);
+    decode(sender, bl);
+    DECODE_FINISH(bl);
+  }
+};
+WRITE_CLASS_ENCODER(MotrWatchNotifyMsg)
+
+class MotrCacheNotif : public MotrWatchNotifyMsg {
+protected:
+  // Key of the cache item.
+  std::string key;
+  // Op to the cached item.
+  int op;
+
+public:
+  MotrCacheNotif(std::string _maker, std::string _sender, const std::string& name, int cache_op) :
+    MotrWatchNotifyMsg(_maker, _sender)
+  {
+    key.assign(name);
+    op = cache_op;
+  }
+  MotrCacheNotif(std::string _marker) : MotrWatchNotifyMsg(_marker) {}
+  MotrCacheNotif() {}
+
+  virtual void encode(bufferlist& bl) const {
+    MotrWatchNotifyMsg::encode(bl);
+
+    ENCODE_START(2, 2, bl);
+    encode(key, bl);
+    encode(op, bl);
+    ENCODE_FINISH(bl);
+  };
+
+  virtual void decode(bufferlist::const_iterator& bl) {
+    MotrWatchNotifyMsg::decode(bl);
+
+    DECODE_START(2, bl);
+    decode(key, bl);
+    decode(op, bl);
+    DECODE_FINISH(bl);
+  }
+
+  std::string& get_key() { return key; }
+  int get_op() { return op; }
+  std::string& get_notifier() { return this->sender; }
+};
+WRITE_CLASS_ENCODER(MotrCacheNotif)
+
+// MotrWatcher registers a FDMI filter and a FDMI callback function.
+// When FDMI records (picked up by the filter) arrive, the callback function
+// process the records and retrieve the information sent by the notifier.
+class MotrWatcher {
+protected:
+  CephContext *cctx{nullptr};
+  const struct m0_fdmi_pd_ops *fdmi_dock_ops{nullptr};
+  struct m0_fid fdmi_plugin_fid;
+  struct m0_fdmi_plugin_ops fdmi_plugin_cb;
+
+  // The list of notifiers that it doesn't want to receive notifications
+  // from. For example, a metadata cache has a pair of notifier and watcher.
+  // The watcher has to exclude the notifications sent by its friend notifier.
+  std::list<std::string> excluded_notifiers;
+
+public:
+  MotrWatcher(CephContext *_cctx) : cctx(_cctx) {}
+  MotrWatcher() {}
+  virtual ~MotrWatcher() {}
+  // Callback function of the watcher's user. For example, if watcher is
+  // user by object metadata cache, this callback function is called to
+  // trigger corresponding cache actions.
+  virtual int watch_cb(bufferlist& bl) = 0;
+  int init_fdmi_plugin(const DoutPrefixProvider *dpp);
+
+  void exclude_notifier(std::string notifier) {
+    excluded_notifiers.push_back(notifier);
+  }
+
+  bool is_excluded_notifier(std::string& notifier) {
+    auto iter = std::find(excluded_notifiers.begin(), excluded_notifiers.end(), notifier);
+    return iter == excluded_notifiers.end()? false : true;
+  }
+};
+
+class MotrMetaCache;
+class MotrCacheWatcher : public MotrWatcher {
+protected:
+  MotrMetaCache *cache;
+
+public:
+  MotrCacheWatcher(CephContext *_cctx, MotrMetaCache* _cache) : MotrWatcher(_cctx), cache(_cache){}
+  virtual int watch_cb(bufferlist& bl) override;
+};
+
+class MotrStore;
+class MotrNotifier {
+protected:
+  MotrStore *store;
+
+  int nr_notif_indices;
+  struct m0_fid *notif_indices;
+
+  // instance is a random string, name + instance uniquely
+  // identifier a notifier.
+  std::string name;
+  std::string instance;
+
+public:
+  MotrNotifier(MotrStore* _store, int _nr_indices, const std::string& _name) {
+    store = _store;
+    nr_notif_indices = _nr_indices;
+    name.assign(_name);
+  }
+  int init(const DoutPrefixProvider *dpp);
+  int notify(const DoutPrefixProvider *dpp, const std::string& key, MotrWatchNotifyMsg& msg);
+  std::string& get_name() { return name; }
+  std::string get_key() { return name + instance; }
+};
 
 // A simplified metadata cache implementation.
 // Note: MotrObjMetaCache doesn't handle the IO operations to Motr. A proxy
@@ -63,13 +237,13 @@ protected:
   // of RGW instances under heavy use. If you would like to turn off cache expiry,
   // set this value to zero.
   //
-  // Currently POC hasn't implemented the watch-notify menchanism yet. So the
-  // current implementation is similar to cortx-s3server which is based on expiry
-  // time. TODO: see comments on distribute_cache).
+  // POC implemented a simple watch-notify menchanism using FDMI.
   //
   // Beaware: Motr object data is not cached in current POC as RGW!
   // RGW caches the first chunk (4MB by default).
   ObjectCache cache;
+  MotrCacheWatcher *watcher{nullptr};
+  MotrNotifier *notifier{nullptr};
 
 public:
   // Lookup a cache entry.
@@ -85,25 +259,31 @@ public:
   // Make the local cache entry invalid.
   void invalid(const DoutPrefixProvider *dpp, const std::string& name);
 
-  // TODO: Distribute_cache() and watch_cb() now are only place holder functions.
-  // Checkout services/svc_sys_obj_cache.h/cc for reference.
-  // These 2 functions are designed to notify or to act on cache notification.
-  // It is feasible to implement the functionality using Motr's FDMI after discussing
-  // with Hua.
-  int distribute_cache(const DoutPrefixProvider *dpp,
-                       const std::string& normal_name,
-                       ObjectCacheInfo& obj_info, int op);
-  int watch_cb(const DoutPrefixProvider *dpp,
-               uint64_t notify_id,
-               uint64_t cookie,
-               uint64_t notifier_id,
-               bufferlist& bl);
-
   void set_enabled(bool status);
 
-  MotrMetaCache(const DoutPrefixProvider *dpp, CephContext *cct) {
-    cache.set_ctx(cct);
+  // distribute_cache() is to notify any update on the cached metadata.
+  // The notification is monitored by watchers of other RGW instance. Once
+  // receiving the notifcation, the callback function of the watcher is invoked.
+  int distribute_cache(const DoutPrefixProvider *dpp,
+                       const std::string& name,
+                       ObjectCacheInfo& obj_info, int op);
+
+  int init_watcher_notifier(const DoutPrefixProvider *dpp, CephContext *cctx,
+                            MotrStore *store, int nr_indices, const std::string notifier_name)
+  {
+    watcher = new MotrCacheWatcher(cctx, this);
+    notifier = new MotrNotifier(store, nr_indices, notifier_name);
+
+    int rc = watcher->init_fdmi_plugin(dpp)? : notifier->init(dpp);
+    if (rc == 0)
+      watcher->exclude_notifier(notifier->get_key());
+    return rc;
   }
+
+  MotrMetaCache(const DoutPrefixProvider *dpp, CephContext *cctx) {
+    cache.set_ctx(cctx);
+  }
+
 };
 
 struct MotrUserInfo {
@@ -821,6 +1001,7 @@ class MotrStore : public Store {
     struct m0_realm     uber_realm;
     struct m0_config    conf = {};
     struct m0_idx_dix_config dix_conf = {};
+    struct m0_reqh_service *fdmi_service;
 
     MotrStore(CephContext *c): zone(this), cctx(c) {}
     ~MotrStore() {
@@ -962,6 +1143,9 @@ class MotrStore : public Store {
     MotrMetaCache* get_obj_meta_cache() {return obj_meta_cache;}
     MotrMetaCache* get_user_cache() {return user_cache;}
     MotrMetaCache* get_bucket_inst_cache() {return bucket_inst_cache;}
+
+    int fdmi_service_start(struct m0_client *m0c);
+    void fdmi_service_stop(struct m0_client *m0c);
 };
 
 } // namespace rgw::sal


### PR DESCRIPTION
The watch-notify can be used to watch (monitor) any update on objects.
A notification is sent (to all rgw instances) by a notifier if an object
is changed, such as object size, object content etc. The notification sent
contains marker for a watcher to pick it up and it also includes required
information for the watcher to act accordingly.

This POC shows how to implement the watch-notify mechanism using FDMI as
messge passing, filtering and notifying. We also show its usage in object
metadata cache uses where it is used to inform object changes and takes
action on cache items.

Signed-off-by: Sining Wu <sining.wu@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
