### PR TITLE
rgw_sal_motr: implement watch-notify using Motr FDMI

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -3284,6 +3284,14 @@ options:
   default: false
   services:
   - rgw
+- name: motr_cache_fdmi_filter_id
+  type: str
+  level: advanced
+  desc: experimental Option to set Motr FDMI filter fid for cache watch-notify
+  long_desc: example value 0x6c00000000000001:0x51
+  default: 0x6c00000000000001:0x51
+  services:
+  - rgw
 - name: rgw_luarocks_location
   type: str
   level: advanced


### PR DESCRIPTION
The watch-notify mechanism can be used to watch (monitor) any update on objects. A notification is sent (to all rgw instances) by a notifier if an object is changed, such as object size, object content etc. The notification sent contains a marker for a watcher to pick it up and it also includes required information for the watcher to act accordingly.

This PoC shows how to implement the watch-notify mechanism using Motr FDMI. We also show its usage in object metadata cache to update/invalidate the cached items among rgw instances.