### PR TITLE
rgw_sal_motr: fix possible memleak on put

### DIFF
--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -1369,7 +1369,11 @@ public:
   /** prepare to start processing object data */
   virtual int prepare(optional_yield y) = 0;
 
-  /** Process a buffer.  Called multiple times to write different buffers. */
+  /**
+   * Process a buffer. Called multiple times to write different buffers.
+   * data.length() == 0 indicates the last call and may be used to flush
+   * the data buffers.
+   */
   virtual int process(bufferlist&& data, uint64_t offset) = 0;
 
   /** complete the operation and make its result visible to clients */

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -123,7 +123,7 @@ int MotrMetaCache::remove(const DoutPrefixProvider *dpp,
   ObjectCacheInfo info;
   int rc = distribute_cache(dpp, name, info, INVALIDATE_OBJ);
   if (rc < 0) {
-    ldpp_dout(dpp, 0) << "ERROR: " << __func__ << "(): failed to distribute cache: rc =" << rc << dendl;
+    ldpp_dout(dpp, 0) << "ERROR: " <<__func__<< "(): failed to distribute cache: rc =" << rc << dendl;
   }
 
   ldpp_dout(dpp, 0) << "Remove from cache: name = " << name << dendl;
@@ -163,7 +163,7 @@ int MotrUser::list_buckets(const DoutPrefixProvider *dpp, const string& marker,
   vector<bufferlist> vals(max);
   bool is_truncated = false;
 
-  ldpp_dout(dpp, 20) << "DEBUG: list_user_buckets: marker=" << marker
+  ldpp_dout(dpp, 20) <<__func__<< ": list_user_buckets: marker=" << marker
                     << " end_marker=" << end_marker
                     << " max=" << max << dendl;
 
@@ -933,7 +933,7 @@ int MotrObject::get_obj_state(const DoutPrefixProvider* dpp, RGWObjectCtx* rctx,
   state->has_attrs = true;
   bufferlist etag_bl;
   string& etag = ent.meta.etag;
-  ldpp_dout(dpp, 20) << __func__ << ": object's etag:  " << ent.meta.etag << dendl;
+  ldpp_dout(dpp, 20) <<__func__<< ": object's etag:  " << ent.meta.etag << dendl;
   etag_bl.append(etag);
   state->attrset[RGW_ATTR_ETAG] = etag_bl;
 
@@ -958,7 +958,7 @@ MotrObject::~MotrObject() {
 int MotrObject::set_obj_attrs(const DoutPrefixProvider* dpp, RGWObjectCtx* rctx, Attrs* setattrs, Attrs* delattrs, optional_yield y, rgw_obj* target_obj)
 {
   // TODO: implement
-  ldpp_dout(dpp, 20) << "DEBUG: MotrObject::set_obj_attrs()" << dendl;
+  ldpp_dout(dpp, 20) <<__func__<< ": MotrObject::set_obj_attrs()" << dendl;
   return 0;
 }
 
@@ -1126,7 +1126,7 @@ MotrObject::MotrReadOp::MotrReadOp(MotrObject *_source, RGWObjectCtx *_rctx) :
 int MotrObject::MotrReadOp::prepare(optional_yield y, const DoutPrefixProvider* dpp)
 {
   int rc;
-  ldpp_dout(dpp, 20) << __func__ << ": bucket=" << source->get_bucket()->get_name() << dendl;
+  ldpp_dout(dpp, 20) <<__func__<< ": bucket=" << source->get_bucket()->get_name() << dendl;
 
   rgw_bucket_dir_entry ent;
   rc = source->get_bucket_dir_ent(dpp, ent);
@@ -1137,7 +1137,7 @@ int MotrObject::MotrReadOp::prepare(optional_yield y, const DoutPrefixProvider* 
   // in send_response_data() to set attributes, including etag.
   bufferlist etag_bl;
   string& etag = ent.meta.etag;
-  ldpp_dout(dpp, 20) << __func__ << ": object's etag: " << ent.meta.etag << dendl;
+  ldpp_dout(dpp, 20) <<__func__<< ": object's etag: " << ent.meta.etag << dendl;
   etag_bl.append(etag.c_str(), etag.size());
   source->get_attrs().emplace(std::move(RGW_ATTR_ETAG), std::move(etag_bl));
 
@@ -1147,12 +1147,12 @@ int MotrObject::MotrReadOp::prepare(optional_yield y, const DoutPrefixProvider* 
 
   // Open the object here.
   if (source->category == RGWObjCategory::MultiMeta) {
-    ldpp_dout(dpp, 20) << __func__ << ": open obj parts..." << dendl;
+    ldpp_dout(dpp, 20) <<__func__<< ": open obj parts..." << dendl;
     rc = source->get_part_objs(dpp, this->part_objs)? :
          source->open_part_objs(dpp, this->part_objs);
     return rc;
   } else {
-    ldpp_dout(dpp, 20) << __func__ << ": open object..." << dendl;
+    ldpp_dout(dpp, 20) <<__func__<< ": open object..." << dendl;
     return source->open_mobj(dpp);
   }
 }
@@ -1340,19 +1340,19 @@ int MotrAtomicWriter::prepare(optional_yield y)
 int MotrObject::create_mobj(const DoutPrefixProvider *dpp, uint64_t sz)
 {
   if (mobj != nullptr) {
-    ldpp_dout(dpp, 0) << __func__ << "ERROR: object is already opened" << dendl;
+    ldpp_dout(dpp, 0) <<__func__<< "ERROR: object is already opened" << dendl;
     return -EINVAL;
   }
 
   int rc = m0_ufid_next(&ufid_gr, 1, &meta.oid);
   if (rc != 0) {
-    ldpp_dout(dpp, 0) << __func__ << "ERROR: m0_ufid_next() failed: " << rc << dendl;
+    ldpp_dout(dpp, 0) <<__func__<< "ERROR: m0_ufid_next() failed: " << rc << dendl;
     return rc;
   }
 
   char fid_str[M0_FID_STR_LEN];
   snprintf(fid_str, ARRAY_SIZE(fid_str), U128X_F, U128_P(&meta.oid));
-  ldpp_dout(dpp, 20) << __func__ << ": sz=" << sz << " oid=" << fid_str << dendl;
+  ldpp_dout(dpp, 20) <<__func__<< ": sz=" << sz << " oid=" << fid_str << dendl;
 
   int64_t lid = m0_layout_find_by_objsz(store->instance, nullptr, sz);
   M0_ASSERT(lid > 0);
@@ -1369,7 +1369,7 @@ int MotrObject::create_mobj(const DoutPrefixProvider *dpp, uint64_t sz)
     ldpp_dout(dpp, 0) << "ERROR: m0_entity_create() failed: " << rc << dendl;
     return rc;
   }
-  ldpp_dout(dpp, 20) << __func__ << ": call m0_op_launch()..." << dendl;
+  ldpp_dout(dpp, 20) <<__func__<< ": call m0_op_launch()..." << dendl;
   m0_op_launch(&op, 1);
   rc = m0_op_wait(op, M0_BITS(M0_OS_FAILED, M0_OS_STABLE), M0_TIME_NEVER) ?:
        m0_rc(op);
@@ -1384,7 +1384,7 @@ int MotrObject::create_mobj(const DoutPrefixProvider *dpp, uint64_t sz)
 
   meta.layout_id = mobj->ob_attr.oa_layout_id;
   meta.pver      = mobj->ob_attr.oa_pver;
-  ldpp_dout(dpp, 20) << __func__ << ": lid=0x" << std::hex << meta.layout_id
+  ldpp_dout(dpp, 20) <<__func__<< ": lid=0x" << std::hex << meta.layout_id
                      << std::dec << " rc=" << rc << dendl;
 
   // TODO: add key:user+bucket+key+obj.meta.oid value:timestamp to
@@ -1397,7 +1397,7 @@ int MotrObject::open_mobj(const DoutPrefixProvider *dpp)
 {
   char fid_str[M0_FID_STR_LEN];
   snprintf(fid_str, ARRAY_SIZE(fid_str), U128X_F, U128_P(&meta.oid));
-  ldpp_dout(dpp, 20) << __func__ << ": oid=" << fid_str << dendl;
+  ldpp_dout(dpp, 20) <<__func__<< ": oid=" << fid_str << dendl;
 
   int rc;
   if (meta.layout_id == 0) {
@@ -1437,7 +1437,7 @@ int MotrObject::open_mobj(const DoutPrefixProvider *dpp)
     return rc;
   }
 
-  ldpp_dout(dpp, 20) << __func__ << ": rc=" << rc << dendl;
+  ldpp_dout(dpp, 20) <<__func__<< ": rc=" << rc << dendl;
 
   return 0;
 }
@@ -1506,7 +1506,7 @@ int MotrObject::write_mobj(const DoutPrefixProvider *dpp, bufferlist&& data, uin
     goto out;
 
   bs = this->get_optimal_bs(left);
-  ldpp_dout(dpp, 20) << "DEBUG: left=" << left << " bs=" << bs << dendl;
+  ldpp_dout(dpp, 20) <<__func__<< ": left=" << left << " bs=" << bs << dendl;
 
   start = data.c_str();
 
@@ -1643,7 +1643,7 @@ int MotrObject::get_bucket_dir_ent(const DoutPrefixProvider *dpp, rgw_bucket_dir
       }
     }
 
-    ldpp_dout(dpp, 20) << __func__ << ": versioned bucket!" << dendl;
+    ldpp_dout(dpp, 20) <<__func__<< ": versioned bucket!" << dendl;
     keys[0] = this->get_name();
     rc = store->next_query_by_name(bucket_index_iname, keys, vals);
     if (rc < 0) {
@@ -1659,7 +1659,7 @@ int MotrObject::get_bucket_dir_ent(const DoutPrefixProvider *dpp, rgw_bucket_dir
       iter = bl.cbegin();
       ent_to_check.decode(iter);
       if (ent_to_check.is_current()) {
-        ldpp_dout(dpp, 20) << __func__ << ": found current version!" << dendl;
+        ldpp_dout(dpp, 20) <<__func__<< ": found current version!" << dendl;
         ent = ent_to_check;
         rc = 0;
 
@@ -1670,7 +1670,7 @@ int MotrObject::get_bucket_dir_ent(const DoutPrefixProvider *dpp, rgw_bucket_dir
     }
   } else {
     if (this->store->get_obj_meta_cache()->get(dpp, this->get_key().to_str(), bl)) {
-      ldpp_dout(dpp, 20) << __func__ << ": non-versioned bucket!" << dendl;
+      ldpp_dout(dpp, 20) <<__func__<< ": non-versioned bucket!" << dendl;
       rc = this->store->do_idx_op_by_name(bucket_index_iname,
                                           M0_IC_GET, this->get_key().to_str(), bl);
       if (rc < 0) {
@@ -1691,9 +1691,9 @@ out:
     sal::Attrs dummy;
     decode(dummy, iter);
     meta.decode(iter);
-    ldpp_dout(dpp, 20) << __func__ << ": lid=0x" << std::hex << meta.layout_id << dendl;
+    ldpp_dout(dpp, 20) <<__func__<< ": lid=0x" << std::hex << meta.layout_id << dendl;
   } else
-    ldpp_dout(dpp, 0) << __func__ << ": rc=" << rc << dendl;
+    ldpp_dout(dpp, 0) <<__func__<< ": rc=" << rc << dendl;
 
   return rc;
 }
@@ -1922,7 +1922,7 @@ void MotrAtomicWriter::cleanup()
   m0_indexvec_free(&ext);
   m0_bufvec_free(&attr);
   m0_bufvec_free2(&buf);
-  acc_bl.clear();
+  acc_data.clear();
   obj.close_mobj();
 }
 
@@ -1955,7 +1955,7 @@ int MotrAtomicWriter::write()
   struct m0_op *op;
   bufferlist::iterator bi;
 
-  left = acc_bl.length();
+  left = acc_data.length();
 
   if (!obj.is_opened()) {
     rc = obj.create_mobj(dpp, left);
@@ -1975,20 +1975,20 @@ int MotrAtomicWriter::write()
   total_data_size += left;
 
   bs = obj.get_optimal_bs(left);
-  ldpp_dout(dpp, 20) << "DEBUG: left=" << left << " bs=" << bs << dendl;
+  ldpp_dout(dpp, 20) <<__func__<< ": left=" << left << " bs=" << bs << dendl;
 
-  bi = acc_bl.begin();
+  bi = acc_data.begin();
   while (left > 0) {
     if (left < bs)
       bs = obj.get_optimal_bs(left);
     if (left < bs) {
-      acc_bl.append_zero(bs - left);
+      acc_data.append_zero(bs - left);
       auto off = bi.get_off();
       bufferlist tmp;
-      acc_bl.splice(off, bs, &tmp);
-      acc_bl.clear();
-      acc_bl.append(tmp.c_str(), bs); // make it a single buf
-      bi = acc_bl.begin();
+      acc_data.splice(off, bs, &tmp);
+      acc_data.clear();
+      acc_data.append(tmp.c_str(), bs); // make it a single buf
+      bi = acc_data.begin();
       left = bs;
     }
 
@@ -2006,7 +2006,7 @@ int MotrAtomicWriter::write()
     if (rc != 0)
       goto err;
   }
-  acc_bl.clear();
+  acc_data.clear();
 
   return 0;
 
@@ -2026,11 +2026,11 @@ int MotrAtomicWriter::process(bufferlist&& data, uint64_t offset)
   if (data.length() == 0)
     return 0;
 
-  if (acc_bl.length() == 0)
+  if (acc_data.length() == 0)
     acc_off = offset;
 
-  acc_bl.append(std::move(data));
-  if (acc_bl.length() < MAX_ACC_SIZE)
+  acc_data.append(std::move(data));
+  if (acc_data.length() < MAX_ACC_SIZE)
     return 0;
 
   return this->write();
@@ -2047,7 +2047,7 @@ int MotrAtomicWriter::complete(size_t accounted_size, const std::string& etag,
 {
   int rc = 0;
 
-  if (acc_bl.length() != 0)
+  if (acc_data.length() != 0)
     rc = this->write();
 
   this->cleanup();
@@ -2075,7 +2075,7 @@ int MotrAtomicWriter::complete(size_t accounted_size, const std::string& etag,
   bool is_versioned = obj.get_key().have_instance();
   if (is_versioned)
     ent.flags = rgw_bucket_dir_entry::FLAG_VER | rgw_bucket_dir_entry::FLAG_CURRENT;
-  ldpp_dout(dpp, 20) << __func__ << ": key=" << obj.get_key().to_str()
+  ldpp_dout(dpp, 20) <<__func__<< ": key=" << obj.get_key().to_str()
                     << " etag: " << etag << " user_data=" << user_data << dendl;
   if (user_data)
     ent.meta.user_data = *user_data;
@@ -2095,7 +2095,7 @@ int MotrAtomicWriter::complete(size_t accounted_size, const std::string& etag,
   }
   encode(attrs, bl);
   obj.meta.encode(bl);
-  ldpp_dout(dpp, 20) << __func__ << ": lid=0x" << std::hex << obj.meta.layout_id
+  ldpp_dout(dpp, 20) <<__func__<< ": lid=0x" << std::hex << obj.meta.layout_id
                                                            << dendl;
   if (is_versioned) {
     // get the list of all versioned objects with the same key and
@@ -3204,7 +3204,7 @@ int MotrStore::next_query_by_name(string idx_name,
 
   // Only the first element for keys needs to be set for NEXT query.
   // The keys will be set will the returned keys from motr index.
-  ldout(cctx, 20) << "DEBUG: next_query_by_name(): index=" << idx_name
+  ldout(cctx, 20) <<__func__<< ": next_query_by_name(): index=" << idx_name
                   << " prefix=" << prefix << " delim=" << delim << dendl;
   keys[0].assign(key_out[0].begin(), key_out[0].end());
   for (i = 0; i < (int)val_out.size(); i += k, k = 0) {
@@ -3337,7 +3337,7 @@ int MotrStore::do_idx_op_by_name(string idx_name, enum m0_idx_opcode opcode,
   if (opcode == M0_IC_PUT)
     val.assign(bl.c_str(), bl.c_str() + bl.length());
 
-  ldout(cctx, 20) << "DEBUG: do_idx_op_by_name(): op="
+  ldout(cctx, 20) <<__func__<< ": do_idx_op_by_name(): op="
                  << (opcode == M0_IC_PUT ? "PUT" : "GET")
                  << " idx=" << idx_name << " key=" << key_str << dendl;
   rc = do_idx_op(&idx, opcode, key, val, update);

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -629,7 +629,7 @@ class MotrAtomicWriter : public Writer {
   const std::string& unique_tag;
   MotrObject obj;
   uint64_t total_data_size; // for total data being uploaded
-  bufferlist acc_bl;  // accumulated data
+  bufferlist acc_data;  // accumulated data
   uint64_t   acc_off; // accumulated data offset
 
   struct m0_bufvec buf;


### PR DESCRIPTION
Currently, the MotrAtomicWriter::cleanup() is called from
MotrAtomicWriter::commit(), which may not be called at all
by rgw in case of md5 checksum failure.

Solution: call cleanup() from process() when data is zero.
rgw calls Writer::process(data, off) with zero data at the
end of the loop to allow writes to flush the data. From:
src/rgw/rgw_op.cc:RGWPutObj::execute():

      op_ret = filter->process(std::move(data), ofs);
      ...
      ofs += len;
    } while (len > 0);

    // flush any data in filters
    op_ret = filter->process({}, ofs);

Closes #70.