### PR TITLE
rgw_sal_motr: [EOS-27563] Initiate default values for Zonegroup

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -895,7 +895,7 @@ bool MotrZone::get_redirect_endpoint(std::string* endpoint)
 
 bool MotrZone::has_zonegroup_api(const std::string& api) const
 {
-  return false;
+  return (zonegroup->api_name == api);
 }
 
 const std::string& MotrZone::get_current_period_id()

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -392,6 +392,7 @@ class MotrZone : public Zone {
     MotrZone(MotrStore* _store) : store(_store) {
       realm = new RGWRealm();
       zonegroup = new RGWZoneGroup();
+      // TODO: fetch zonegroup params (eg. id) from provisioner config.
       zonegroup->set_id("0956b174-fe14-4f97-8b50-bb7ec5e1cf62");
       zonegroup->api_name = "default";
       zone_public_config = new RGWZone();

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -392,6 +392,8 @@ class MotrZone : public Zone {
     MotrZone(MotrStore* _store) : store(_store) {
       realm = new RGWRealm();
       zonegroup = new RGWZoneGroup();
+      zonegroup->set_id("0956b174-fe14-4f97-8b50-bb7ec5e1cf62");
+      zonegroup->api_name = "default";
       zone_public_config = new RGWZone();
       zone_params = new RGWZoneParams();
       current_period = new RGWPeriod();


### PR DESCRIPTION
Signed-off-by: Sumedh A. Kulkarni <sumedh.a.kulkarni@seagate.com>

Added the default zone group api_name and id, so that each new bucket will have zonegroup_id in its metadata, and get_location API will return the zone group of a particular bucket.

```bash
->  aws s3api create-bucket \                                                         
    --bucket my-bucket2 \
    --region default \
    --create-bucket-configuration LocationConstraint=default \
     --endpoint=http://localhost:8000
 

->  aws s3api create-bucket \                 
    --bucket my-bucket2 \
    --region default1 \
    --create-bucket-configuration LocationConstraint=default1 \
    --endpoint=http://localhost:8000

An error occurred (InvalidLocationConstraint) when calling the CreateBucket operation: The specified location-constraint is not valid


->  aws s3api get-bucket-location --bucket mybkt16 --endpoint=http://localhost:8000
{
    "LocationConstraint": "default"
}


->  s3cmd --no-ssl info s3://mybkt16
s3://mybkt16/ (bucket):
   Location:  default
   Payer:     BucketOwner
   Expiration Rule: none
   Policy:    none
   CORS:      none
   ACL:       Motr Explorer: FULL_CONTROL
 ```


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
