### PR TITLE
rgw_sal_motr: [CORTX-28690] Fix for incorrect LastModified time in GetObj API

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1273,6 +1273,7 @@ int MotrObject::MotrReadOp::prepare(optional_yield y, const DoutPrefixProvider* 
   source->set_key(ent.key);
   source->set_obj_size(ent.meta.size);
   source->category = ent.meta.category;
+  *params.lastmod = ent.meta.mtime;
 
   // Open the object here.
   if (source->category == RGWObjCategory::MultiMeta) {


### PR DESCRIPTION
**Parent Ticket:** [CORTX-27526](https://jts.seagate.com/browse/CORTX-27526)

**Problem statement:** Incorrect LastModified Date in GetObj API.
```bash 
╭─root@ssc-vm-g4-rhev4-0318.colo.seagate.com ~/cortx/cortx-rgw/build  ‹main*›
╰─➤  aws s3api get-object --bucket my-bkt --key output.file stdout                                                      2 ↵
{
    "AcceptRanges": "bytes",
    "LastModified": "Thu, 01 Jan 1970 00:00:00 GMT",
    "ContentLength": 1048576,
    "ETag": "\"b6d81b360a5672d80c27430f39153e2c\"",
    "ContentType": "binary/octet-stream",
    "Metadata": {}
}
```
**Problem Analysis & Solution:**
In `RGWGetObj::execute()` method `MotrReadOp read_op` obj is created.
`read_op->prepare()` is supposed to set the `lastmod` time for this object,
which is missing in `MotrReadOp::prepare()` method, adding the same.
```bash 
╭─root@ssc-vm-g4-rhev4-0318.colo.seagate.com ~/cortx/cortx-rgw/build  ‹CORTX-28690-get-obj-lastmod-fix*›
╰─➤  aws s3 cp ~/output.file s3://my-bkt/obj2
upload: ../../../output.file to s3://my-bkt/obj2

╭─root@ssc-vm-g4-rhev4-0318.colo.seagate.com ~/cortx/cortx-rgw/build  ‹CORTX-28690-get-obj-lastmod-fix*›
╰─➤  aws s3api get-object --bucket my-bkt --key obj2 ~/downloded.file
{
    "AcceptRanges": "bytes",
    "LastModified": "Mon, 14 Feb 2022 13:43:20 GMT",
    "ContentLength": 1048576,
    "ETag": "\"b6d81b360a5672d80c27430f39153e2c\"",
    "ContentType": "binary/octet-stream",
    "Metadata": {}
}
```

Signed-off-by: Sumedh A. Kulkarni <sumedh.a.kulkarni@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
