### PR TITLE
rgw_sal_motr: [EOS-27516] Handling object overwrite during put-object

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -2280,6 +2280,9 @@ int MotrAtomicWriter::complete(size_t accounted_size, const std::string& etag,
     // Delete old object data if exists.
     old_obj.delete_mobj(dpp);
   }
+
+  // TODO: We need to handle the object leak caused by parallel object upload by
+  // making use of background gc, which is currently not enabled for motr.
   return rc;
 }
 

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1447,7 +1447,8 @@ MotrAtomicWriter::MotrAtomicWriter(const DoutPrefixProvider *dpp,
               ptail_placement_rule(_ptail_placement_rule),
               olh_epoch(_olh_epoch),
               unique_tag(_unique_tag),
-              obj(_store, _head_obj->get_key(), _head_obj->get_bucket()) {}
+              obj(_store, _head_obj->get_key(), _head_obj->get_bucket()),
+              old_obj(_store, _head_obj->get_key(), _head_obj->get_bucket()) {}
 
 static const unsigned MAX_BUFVEC_NR = 256;
 
@@ -1458,7 +1459,13 @@ int MotrAtomicWriter::prepare(optional_yield y)
   if (obj.is_opened())
     return 0;
 
-  int rc = m0_bufvec_empty_alloc(&buf, MAX_BUFVEC_NR) ?:
+  rgw_bucket_dir_entry ent;
+  int rc = old_obj.get_bucket_dir_ent(dpp, ent);
+  if (rc == 0) {
+    ldpp_dout(dpp, 20) << __func__ << ": object exists." << dendl;
+  }
+
+  rc = m0_bufvec_empty_alloc(&buf, MAX_BUFVEC_NR) ?:
            m0_bufvec_alloc(&attr, MAX_BUFVEC_NR, 1) ?:
            m0_indexvec_alloc(&ext, MAX_BUFVEC_NR);
   if (rc != 0)
@@ -1575,6 +1582,13 @@ int MotrObject::open_mobj(const DoutPrefixProvider *dpp)
 int MotrObject::delete_mobj(const DoutPrefixProvider *dpp)
 {
   int rc;
+  char fid_str[M0_FID_STR_LEN];
+  snprintf(fid_str, ARRAY_SIZE(fid_str), U128X_F, U128_P(&meta.oid));
+  if (!meta.oid.u_hi || !meta.oid.u_lo) {
+    ldpp_dout(dpp, 20) << __func__ << ": invalid motr object oid=" << fid_str << dendl;
+    return -EINVAL;
+  }
+  ldpp_dout(dpp, 20) << __func__ << ": deleting motr object oid=" << fid_str << dendl;
 
   // Open the object.
   if (mobj == nullptr) {
@@ -1822,6 +1836,9 @@ out:
     decode(dummy, iter);
     meta.decode(iter);
     ldpp_dout(dpp, 20) <<__func__<< ": lid=0x" << std::hex << meta.layout_id << dendl;
+    char fid_str[M0_FID_STR_LEN];
+    snprintf(fid_str, ARRAY_SIZE(fid_str), U128X_F, U128_P(&meta.oid));
+    ldpp_dout(dpp, 70) << __func__ << ": oid=" << fid_str << dendl;
   } else
     ldpp_dout(dpp, 0) <<__func__<< ": rc=" << rc << dendl;
 
@@ -2054,6 +2071,7 @@ void MotrAtomicWriter::cleanup()
   m0_bufvec_free2(&buf);
   acc_data.clear();
   obj.close_mobj();
+  old_obj.close_mobj();
 }
 
 unsigned MotrAtomicWriter::populate_bvec(unsigned len, bufferlist::iterator &bi)
@@ -2258,6 +2276,10 @@ int MotrAtomicWriter::complete(size_t accounted_size, const std::string& etag,
   if (rc == 0)
     store->get_obj_meta_cache()->put(dpp, obj.get_key().to_str(), bl);
 
+  if (old_obj.get_bucket()->get_info().versioning_status() != BUCKET_VERSIONED) {
+    // Delete old object data if exists.
+    old_obj.delete_mobj(dpp);
+  }
   return rc;
 }
 

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -660,6 +660,7 @@ class MotrAtomicWriter : public Writer {
   uint64_t olh_epoch;
   const std::string& unique_tag;
   MotrObject obj;
+  MotrObject old_obj;
   uint64_t total_data_size; // for total data being uploaded
   bufferlist acc_data;  // accumulated data
   uint64_t   acc_off; // accumulated data offset


### PR DESCRIPTION
# Change Summery
## Parent Story
[CORTX-27516](https://jts.seagate.com/browse/CORTX-27516):
_PutObject API in RGW+Motr_

### Sub-tasks covered 
[CORTX-28765](https://jts.seagate.com/browse/CORTX-28765) - _Handle object overwrite_
**Changes:** Initialing existing object before creating new object. Once new objects is written successfully, deleting previous object's data in motr.

[CORTX-28776](https://jts.seagate.com/browse/CORTX-28776) - _Verify Parallel uploads_
**Changes:** Found object leak during parallel upload which we will be properly design and fixed in Jira : [CORTX-28825](https://jts.seagate.com/browse/CORTX-28825). For now, added a TODO comment in the code.

## Testing done:
<details><summary>Overwrite object</summary>

#### Command line:

> [root@ssc-vm-g4-rhev4-0499 ~]# md5sum testfile
> 8e5daee75e9a4bb3d912168d5c14f960  testfile
> [root@ssc-vm-g4-rhev4-0499 ~]# aws s3api put-object --bucket testbuck --key testfile --body testfile
> {
>     "ETag": "\"8e5daee75e9a4bb3d912168d5c14f960\""
> }
> [root@ssc-vm-g4-rhev4-0499 ~]# md5sum testfile1
> 99cf4f4bd357c9bee5daba4a4d28f5ac  testfile1
> [root@ssc-vm-g4-rhev4-0499 ~]# aws s3api put-object --bucket testbuck --key testfile --body testfile1
> {
>     "ETag": "\"99cf4f4bd357c9bee5daba4a4d28f5ac\""
> }

#### Logs:
> 2022-02-16T22:39:14.466-0700 7fae5030f700 20 req 0 0.097999923s s3:put_obj complete: key=testfile etag: 99cf4f4bd357c9bee5daba4a4d28f5ac user_data=0
> 2022-02-16T22:39:14.466-0700 7fae5030f700 20 req 0 0.097999923s s3:put_obj complete: lid=0xb
> 2022-02-16T22:39:14.466-0700 7fae5030f700 20 id = 0xfcf2de2ca1f09a18:0x7b51163e8d1e8fe3
> 2022-02-16T22:39:14.466-0700 7fae5030f700 20 converted id = 0x78000000a1f09a18:0x7b51163e8d1e8fe3
> 2022-02-16T22:39:14.466-0700 7fae5030f700 20 do_idx_op_by_name: do_idx_op_by_name(): op=PUT idx=motr.rgw.bucket.index.testbuck key=testfile
> 2022-02-16T22:39:14.469-0700 7fae5030f700  0 req 0 0.100999922s s3:put_obj Put into cache: name = testfile
> 2022-02-16T22:39:14.469-0700 7fae5030f700 10 req 0 0.100999922s s3:put_obj cache put: name=testfile info.flags=0x1
> 2022-02-16T22:39:14.469-0700 7fae5030f700 10 req 0 0.100999922s s3:put_obj moving testfile to cache LRU end
> 2022-02-16T22:39:14.469-0700 7fae5030f700 20 req 0 0.100999922s **s3:put_obj delete_mobj: deleting motr object oid=6580f88:b018000002b00001**
> 2022-02-16T22:39:14.469-0700 7fae5030f700 20 req 0 0.100999922s s3:put_obj open_mobj: oid=6580f88:b018000002b00001
> 2022-02-16T22:39:14.469-0700 7fae5030f700 20 req 0 0.100999922s s3:put_obj open_mobj: rc=0
> 2022-02-16T22:39:14.475-0700 7fae5030f700  2 req 0 0.106999911s s3:put_obj completing
> 2022-02-16T22:39:14.475-0700 7fae5030f700  2 req 0 0.106999911s s3:put_obj op status=0
> 2022-02-16T22:39:14.475-0700 7fae5030f700  2 req 0 0.106999911s s3:put_obj http status=200
> 2022-02-16T22:39:14.475-0700 7fae5030f700  1 ====== req done req=0x7faf35ba6780 op status=0 http_status=200 latency=0.106999911s ======

</details>


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
