### PR TITLE
CORTX-28052: Create User for same UID with different Tenant

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -170,7 +170,7 @@ int MotrUser::list_buckets(const DoutPrefixProvider *dpp, const string& marker,
 
   // Retrieve all `max` number of pairs.
   buckets.clear();
-  string user_info_iname = "motr.rgw.user.info." + info.user_id.id;
+  string user_info_iname = "motr.rgw.user.info." + info.user_id.to_str();
   keys[0] = marker;
   rc = store->next_query_by_name(user_info_iname, keys, vals);
   if (rc < 0) {
@@ -337,7 +337,7 @@ static int load_user_from_idx(const DoutPrefixProvider *dpp,
   if (store->get_user_cache()->get(dpp, info.user_id.id, bl)) {
     // Cache misses
     int rc = store->do_idx_op_by_name(RGW_MOTR_USERS_IDX_NAME,
-                                      M0_IC_GET, info.user_id.id, bl);
+                                      M0_IC_GET, info.user_id.to_str(), bl);
     ldpp_dout(dpp, 20) << "do_idx_op_by_name() = "  << rc << dendl;
     if (rc < 0)
         return rc;
@@ -367,7 +367,7 @@ int MotrUser::load_user(const DoutPrefixProvider *dpp,
 
 int MotrUser::create_user_info_idx()
 {
-  string user_info_iname = "motr.rgw.user.info." + info.user_id.id;
+  string user_info_iname = "motr.rgw.user.info." + info.user_id.to_str();
   return store->create_motr_idx_by_name(user_info_iname);
 }
 
@@ -396,11 +396,11 @@ int MotrUser::store_user(const DoutPrefixProvider* dpp,
     const RGWAccessKey& k = iter->second;
     access_key = k.id;
     secret_key = k.key;
-    MotrAccessKey MGWUserKeys(access_key, secret_key, info.user_id.id);
+    MotrAccessKey MGWUserKeys(access_key, secret_key, info.user_id.to_str());
     store->store_access_key(dpp, y, MGWUserKeys);
   }
 
-  orig_info.user_id.id = info.user_id.id;
+  orig_info.user_id = info.user_id;
   // XXX: we open and close motr idx 2 times in this method:
   // 1) on load_user_from_idx() here and 2) on do_idx_op_by_name(PUT) below.
   // Maybe this can be optimised later somewhow.
@@ -434,7 +434,7 @@ int MotrUser::store_user(const DoutPrefixProvider* dpp,
   muinfo.user_version = obj_ver;
   muinfo.encode(bl);
   rc = store->do_idx_op_by_name(RGW_MOTR_USERS_IDX_NAME,
-                                M0_IC_PUT, info.user_id.id, bl);
+                                M0_IC_PUT, info.user_id.to_str(), bl);
   ldpp_dout(dpp, 10) << "Store user to motr index: rc = " << rc << dendl;
   if (rc == 0) {
     objv_tracker.read_version = obj_ver;
@@ -665,7 +665,7 @@ int MotrBucket::link_user(const DoutPrefixProvider* dpp, User* new_user, optiona
   ldpp_dout(dpp, 20) << "got creation time: << " << std::put_time(std::localtime(&ctime), "%F %T") << dendl;
 
   // Insert the user into the user info index.
-  string user_info_idx_name = "motr.rgw.user.info." + new_user->get_info().user_id.id;
+  string user_info_idx_name = "motr.rgw.user.info." + new_user->get_info().user_id.to_str();
   return store->do_idx_op_by_name(user_info_idx_name,
                                   M0_IC_PUT, info.bucket.name, bl);
 
@@ -675,7 +675,7 @@ int MotrBucket::unlink_user(const DoutPrefixProvider* dpp, User* new_user, optio
 {
   // Remove the user into the user info index.
   bufferlist bl;
-  string user_info_idx_name = "motr.rgw.user.info." + new_user->get_info().user_id.id;
+  string user_info_idx_name = "motr.rgw.user.info." + new_user->get_info().user_id.to_str();
   return store->do_idx_op_by_name(user_info_idx_name,
                                   M0_IC_DEL, info.bucket.name, bl);
 }
@@ -2950,7 +2950,7 @@ int MotrStore::get_user_by_access_key(const DoutPrefixProvider *dpp, const std::
   auto iter = blr.cbegin();
   access_key.decode(iter);
 
-  uinfo.user_id.id = access_key.user_id;
+  uinfo.user_id.from_str(access_key.user_id);
   ldout(cctx, 0) << "Loading user: " << uinfo.user_id.id << dendl;
   rc = load_user_from_idx(dpp, this, uinfo, nullptr, nullptr);
   if (rc < 0){


### PR DESCRIPTION
…ackend.

Signed-off-by: Diwakar92 <diwakar.kumar@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
