### PR TITLE
rgw_sal_motr: [CORTX-27650] Creating bucket with same name does not fail

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -232,7 +232,20 @@ int MotrUser::create_bucket(const DoutPrefixProvider* dpp,
 
   if (ret != -ENOENT) {
     *existed = true;
-    return -EEXIST;
+    // if (swift_ver_location.empty()) {
+    //   swift_ver_location = bucket->get_info().swift_ver_location;
+    // }
+    // placement_rule.inherit_from(bucket->get_info().placement_rule);
+
+    // TODO: ACL policy
+    // // don't allow changes to the acl policy
+    //RGWAccessControlPolicy old_policy(ctx());
+    //int rc = rgw_op_get_bucket_policy_from_attr(
+    //           dpp, this, u, bucket->get_attrs(), &old_policy, y);
+    //if (rc >= 0 && old_policy != policy) {
+    //    bucket_out->swap(bucket);
+    //    return -EEXIST;
+    //}
   } else {
 
     placement_rule.name = "default";
@@ -240,7 +253,9 @@ int MotrUser::create_bucket(const DoutPrefixProvider* dpp,
     bucket = std::make_unique<MotrBucket>(store, b, this);
     bucket->set_attrs(attrs);
     *existed = false;
+  }
 
+  if (!*existed){
     // TODO: how to handle zone and multi-site.
     info.placement_rule = placement_rule;
     info.bucket = b;
@@ -264,6 +279,10 @@ int MotrUser::create_bucket(const DoutPrefixProvider* dpp,
      ret = mbucket->link_user(dpp, this, y);
      if (ret < 0)
        ldpp_dout(dpp, 0) << "ERROR: failed to add bucket entry! " << ret << dendl;
+  } else {
+    return -EEXIST;
+    // bucket->set_version(ep_objv);
+    // bucket->get_info() = info;
   }
 
   bucket_out->swap(bucket);

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -232,32 +232,16 @@ int MotrUser::create_bucket(const DoutPrefixProvider* dpp,
 
   if (ret != -ENOENT) {
     *existed = true;
-    if (swift_ver_location.empty()) {
-      swift_ver_location = bucket->get_info().swift_ver_location;
-    }
-    placement_rule.inherit_from(bucket->get_info().placement_rule);
-
-    // TODO: ACL policy
-    // // don't allow changes to the acl policy
-    //RGWAccessControlPolicy old_policy(ctx());
-    //int rc = rgw_op_get_bucket_policy_from_attr(
-    //           dpp, this, u, bucket->get_attrs(), &old_policy, y);
-    //if (rc >= 0 && old_policy != policy) {
-    //    bucket_out->swap(bucket);
-    //    return -EEXIST;
-    //}
+    return -EEXIST;
   } else {
+
     placement_rule.name = "default";
     placement_rule.storage_class = "STANDARD";
     bucket = std::make_unique<MotrBucket>(store, b, this);
     bucket->set_attrs(attrs);
-
     *existed = false;
-  }
 
-  // TODO: how to handle zone and multi-site.
-
-  if (!*existed) {
+    // TODO: how to handle zone and multi-site.
     info.placement_rule = placement_rule;
     info.bucket = b;
     info.owner = this->get_info().user_id;
@@ -280,9 +264,6 @@ int MotrUser::create_bucket(const DoutPrefixProvider* dpp,
      ret = mbucket->link_user(dpp, this, y);
      if (ret < 0)
        ldpp_dout(dpp, 0) << "ERROR: failed to add bucket entry! " << ret << dendl;
-  } else {
-    bucket->set_version(ep_objv);
-    bucket->get_info() = info;
   }
 
   bucket_out->swap(bucket);


### PR DESCRIPTION
# Change Summary

## Parent Story
_[CORTX-27650](https://jts.seagate.com/browse/CORTX-27650):_
_Fix create bucket API issues with ceph and splunk test suite._

## Sub Tasks covered in this PR
_[CORTX-28758](https://jts.seagate.com/browse/CORTX-28758):_
_Fix Remaining create bucket tests._

## Exclusions in Implementation :
N/A

## Implementation/Current Flow :
1. If get_bucket returns ENOENT, then create bucket.
2. If get_bucket returns 0, then send -EEXIST error.

## Testing Done : 

<details>
  <summary> **Case 1 : Create Bucket with same name** </summary>

> [root@ssc-vm-g4-rhev4-0344 build]# s3cmd --no-ssl mb s3://testbucket3
> ERROR: Bucket 'testbucket3' already exists
> ERROR: S3 error: 409 (BucketAlreadyExists)

</details>

<details>
  <summary> **Ceph Tests V4** </summary>

> (virtualenv) [root@ssc-vm-g4-rhev4-0344 s3-tests]# S3TEST_CONF=./s3tests.conf ./virtualenv/bin/nosetests s3tests_boto3.functional.test_s3:test_bucket_create_delete -vv nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']
> s3tests_boto3.functional.test_s3.test_bucket_create_delete ... ok
> 
> ----------------------------------------------------------------------
> Ran 1 test in 0.374s
> 
> OK
> (virtualenv) [root@ssc-vm-g4-rhev4-0344 s3-tests]# S3TEST_CONF=./s3tests.conf ./virtualenv/bin/nosetests s3tests.functional.test_s3:test_atomic_write_bucket_gone -vv
> nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']
> s3tests.functional.test_s3.test_atomic_write_bucket_gone ... ok
> 
> ----------------------------------------------------------------------
> Ran 1 test in 0.180s
> 
> OK
> (virtualenv) [root@ssc-vm-g4-rhev4-0344 s3-tests]# S3TEST_CONF=./s3tests.conf ./virtualenv/bin/nosetests s3tests.functional.test_s3:test_bucket_create_naming_bad_punctuation -vv
> nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']
> s3tests.functional.test_s3.test_bucket_create_naming_bad_punctuation ... ok
> 
> ----------------------------------------------------------------------
> Ran 1 test in 0.160s
> 
> OK
> 
> (virtualenv) [root@ssc-vm-g4-rhev4-0344 s3-tests]# S3TEST_CONF=./s3tests.conf ./virtualenv/bin/nosetests s3tests.functional.test_headers:test_bucket_create_bad_date_none_aws2 -vv
> nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']
> s3tests.functional.test_headers.test_bucket_create_bad_date_none_aws2 ... SKIP
> 
> ----------------------------------------------------------------------
> Ran 1 test in 0.140s
> 
> OK (SKIP=1)
> 
> (virtualenv) [root@ssc-vm-g4-rhev4-0344 s3-tests]# S3TEST_CONF=./s3tests.conf ./virtualenv/bin/nosetests s3tests.functional.test_headers:test_bucket_create_bad_authorization_empty -vv
> 
> nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']
> s3tests.functional.test_headers.test_bucket_create_bad_authorization_empty ... ok
> 
> ----------------------------------------------------------------------
> Ran 1 test in 0.163s
> 
> OK
> 
> (virtualenv) [root@ssc-vm-g4-rhev4-0344 s3-tests]# S3TEST_CONF=./s3tests.conf ./virtualenv/bin/nosetests s3tests.functional.test_headers:test_bucket_create_bad_authorization_invalid_aws2 -vv
> nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']
> s3tests.functional.test_headers.test_bucket_create_bad_authorization_invalid_aws2 ... SKIP
> 
> ----------------------------------------------------------------------
> Ran 1 test in 0.162s
> 
> OK (SKIP=1)
> 
> (virtualenv) [root@ssc-vm-g4-rhev4-0344 s3-tests]# S3TEST_CONF=./s3tests.conf ./virtualenv/bin/nosetests s3tests.functional.test_headers:test_bucket_create_bad_authorization_none -vv
> 
> nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']
> s3tests.functional.test_headers.test_bucket_create_bad_authorization_none ... ok
> 
> ----------------------------------------------------------------------
> Ran 1 test in 0.159s
> 
> OK
> (virtualenv) [root@ssc-vm-g4-rhev4-0344 s3-tests]# S3TEST_CONF=./s3tests.conf ./virtualenv/bin/nosetests s3tests.functional.test_headers:test_bucket_create_bad_authorization_empty -vv
> nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']
> s3tests.functional.test_headers.test_bucket_create_bad_authorization_empty ... ok
> 
> ----------------------------------------------------------------------
> Ran 1 test in 0.154s
> 
> OK
> (virtualenv) [root@ssc-vm-g4-rhev4-0344 s3-tests]# S3TEST_CONF=./s3tests.conf ./virtualenv/bin/nosetests s3tests.functional.test_headers:test_bucket_create_bad_contentlength_none -vv
> nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']
> s3tests.functional.test_headers.test_bucket_create_bad_contentlength_none ... ok
> 
> ----------------------------------------------------------------------
> Ran 1 test in 0.227s
> 
> OK
> (virtualenv) [root@ssc-vm-g4-rhev4-0344 s3-tests]# S3TEST_CONF=./s3tests.conf ./virtualenv/bin/nosetests s3tests.functional.test_headers:test_bucket_create_bad_contentlength_empty -vv
> nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']
> s3tests.functional.test_headers.test_bucket_create_bad_contentlength_empty ... ok
> 
> ----------------------------------------------------------------------
> Ran 1 test in 0.118s
> 
> OK
> (virtualenv) [root@ssc-vm-g4-rhev4-0344 s3-tests]# S3TEST_CONF=./s3tests.conf ./virtualenv/bin/nosetests s3tests.functional.test_headers:test_bucket_create_contentlength_none -vv
> nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']
> s3tests.functional.test_headers.test_bucket_create_contentlength_none ... ok
> 
> ----------------------------------------------------------------------
> Ran 1 test in 0.222s
> 
> OK
> 
> (virtualenv) [root@ssc-vm-g4-rhev4-0344 s3-tests]# S3TEST_CONF=./s3tests.conf ./virtualenv/bin/nosetests s3tests_boto3.functional.test_s3:test_bucket_create_exists_nonowner -vv
> nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']
> s3tests_boto3.functional.test_s3.test_bucket_create_exists_nonowner ... ok
> 
> ----------------------------------------------------------------------
> Ran 1 test in 0.446s
> 
> OK

</details>

<details>
  <summary> **Ceph Tests V2** </summary>

> (virtualenv) [root@ssc-vm-g4-rhev4-0344 s3-tests]# S3TEST_CONF=./s3tests.conf ./virtualenv/bin/nosetests s3tests_boto3.functional.test_s3:test_bucket_create_exists_nonowner -vv
> nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']
> s3tests_boto3.functional.test_s3.test_bucket_create_exists_nonowner ... ok
> 
> ----------------------------------------------------------------------
> Ran 1 test in 0.454s
> 
> OK
> (virtualenv) [root@ssc-vm-g4-rhev4-0344 s3-tests]# S3TEST_CONF=./s3tests.conf ./virtualenv/bin/nosetests s3tests_boto3.functional.test_s3:test_bucket_create_delete -vv nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']
> s3tests_boto3.functional.test_s3.test_bucket_create_delete ... ok
> 
> ----------------------------------------------------------------------
> Ran 1 test in 0.388s
> 
> OK
> (virtualenv) [root@ssc-vm-g4-rhev4-0344 s3-tests]# S3TEST_CONF=./s3tests.conf ./virtualenv/bin/nosetests s3tests.functional.test_s3:test_atomic_write_bucket_gone -vv
> nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']
> s3tests.functional.test_s3.test_atomic_write_bucket_gone ... ok
> 
> ----------------------------------------------------------------------
> Ran 1 test in 0.268s
> 
> OK
> (virtualenv) [root@ssc-vm-g4-rhev4-0344 s3-tests]# S3TEST_CONF=./s3tests.conf ./virtualenv/bin/nosetests s3tests.functional.test_s3:test_bucket_create_naming_bad_punctuation -vv
> nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']
> s3tests.functional.test_s3.test_bucket_create_naming_bad_punctuation ... ok
> 
> ----------------------------------------------------------------------
> Ran 1 test in 0.200s
> 
> OK
> (virtualenv) [root@ssc-vm-g4-rhev4-0344 s3-tests]# S3TEST_CONF=./s3tests.conf ./virtualenv/bin/nosetests s3tests.functional.test_headers:test_bucket_create_bad_date_none_aws2 -vv
> nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']
> s3tests.functional.test_headers.test_bucket_create_bad_date_none_aws2 ... SKIP
> 
> ----------------------------------------------------------------------
> Ran 1 test in 0.109s
> 
> OK (SKIP=1)
> (virtualenv) [root@ssc-vm-g4-rhev4-0344 s3-tests]# S3TEST_CONF=./s3tests.conf ./virtualenv/bin/nosetests s3tests.functional.test_headers:test_bucket_create_bad_authorization_empty -vv
> nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']
> s3tests.functional.test_headers.test_bucket_create_bad_authorization_empty ... ok
> 
> ----------------------------------------------------------------------
> Ran 1 test in 0.340s
> 
> OK
> (virtualenv) [root@ssc-vm-g4-rhev4-0344 s3-tests]# S3TEST_CONF=./s3tests.conf ./virtualenv/bin/nosetests s3tests.functional.test_headers:test_bucket_create_bad_authorization_invalid_aws2 -vv
> nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']
> s3tests.functional.test_headers.test_bucket_create_bad_authorization_invalid_aws2 ... SKIP
> 
> ----------------------------------------------------------------------
> Ran 1 test in 0.148s
> 
> OK (SKIP=1)
> (virtualenv) [root@ssc-vm-g4-rhev4-0344 s3-tests]# S3TEST_CONF=./s3tests.conf ./virtualenv/bin/nosetests s3tests.functional.test_headers:test_bucket_create_bad_authorization_none -vv
> nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']
> s3tests.functional.test_headers.test_bucket_create_bad_authorization_none ... ok
> 
> ----------------------------------------------------------------------
> Ran 1 test in 0.168s
> 
> OK
> (virtualenv) [root@ssc-vm-g4-rhev4-0344 s3-tests]# S3TEST_CONF=./s3tests.conf ./virtualenv/bin/nosetests s3tests.functional.test_headers:test_bucket_create_bad_authorization_empty -vv
> nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']
> s3tests.functional.test_headers.test_bucket_create_bad_authorization_empty ... ok
> 
> ----------------------------------------------------------------------
> Ran 1 test in 0.139s
> 
> OK
> (virtualenv) [root@ssc-vm-g4-rhev4-0344 s3-tests]# S3TEST_CONF=./s3tests.conf ./virtualenv/bin/nosetests s3tests.functional.test_headers:test_bucket_create_bad_contentlength_none -vv
> nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']
> s3tests.functional.test_headers.test_bucket_create_bad_contentlength_none ... ok
> 
> ----------------------------------------------------------------------
> Ran 1 test in 0.252s
> 
> OK
> (virtualenv) [root@ssc-vm-g4-rhev4-0344 s3-tests]# S3TEST_CONF=./s3tests.conf ./virtualenv/bin/nosetests s3tests.functional.test_headers:test_bucket_create_bad_contentlength_empty -vv
> nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']
> s3tests.functional.test_headers.test_bucket_create_bad_contentlength_empty ... ok
> 
> ----------------------------------------------------------------------
> Ran 1 test in 0.128s
> 
> OK
> (virtualenv) [root@ssc-vm-g4-rhev4-0344 s3-tests]# S3TEST_CONF=./s3tests.conf ./virtualenv/bin/nosetests s3tests.functional.test_headers:test_bucket_create_contentlength_none -vv
> nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']
> s3tests.functional.test_headers.test_bucket_create_contentlength_none ... ok
> 
> ----------------------------------------------------------------------
> Ran 1 test in 0.254s
> 
> OK
> 

</details>




Signed-off-by: Deepak Mahale <deepak.mahale@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
