### PR TITLE
rgw_sal_motr: [CORTX-28693] Conditional Param support for GetObj

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1187,7 +1187,6 @@ bool MotrObject::is_expired() {
 // Taken from rgw_rados.cc
 void MotrObject::gen_rand_obj_instance_name()
 {
-#define OBJ_INSTANCE_LEN 32
   char buf[OBJ_INSTANCE_LEN + 1];
 
   gen_rand_alphanumeric_no_underscore(store->ctx(), buf, OBJ_INSTANCE_LEN);

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1187,6 +1187,7 @@ bool MotrObject::is_expired() {
 // Taken from rgw_rados.cc
 void MotrObject::gen_rand_obj_instance_name()
 {
+  enum {OBJ_INSTANCE_LEN = 32};
   char buf[OBJ_INSTANCE_LEN + 1];
 
   gen_rand_alphanumeric_no_underscore(store->ctx(), buf, OBJ_INSTANCE_LEN);

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1182,7 +1182,7 @@ bool MotrObject::is_expired() {
 // Taken from rgw_rados.cc
 void MotrObject::gen_rand_obj_instance_name()
 {
-  enum {OBJ_INSTANCE_LEN = 32};
+#define OBJ_INSTANCE_LEN 32
   char buf[OBJ_INSTANCE_LEN + 1];
 
   gen_rand_alphanumeric_no_underscore(store->ctx(), buf, OBJ_INSTANCE_LEN);
@@ -1274,6 +1274,54 @@ int MotrObject::MotrReadOp::prepare(optional_yield y, const DoutPrefixProvider* 
   source->set_obj_size(ent.meta.size);
   source->category = ent.meta.category;
   *params.lastmod = ent.meta.mtime;
+
+  if (params.mod_ptr || params.unmod_ptr) {
+    // Convert all times go GMT to make them compatible
+    obj_time_weight src_weight;
+    src_weight.init(*params.lastmod, params.mod_zone_id, params.mod_pg_ver);
+    src_weight.high_precision = params.high_precision_time;
+
+    obj_time_weight dest_weight;
+    dest_weight.high_precision = params.high_precision_time;
+
+    // Check if-modified-since condition
+    if (params.mod_ptr && !params.if_nomatch) {
+      dest_weight.init(*params.mod_ptr, params.mod_zone_id, params.mod_pg_ver);
+      ldpp_dout(dpp, 10) << "If-Modified-Since: " << dest_weight << " & "
+                         << "Last-Modified: " << src_weight << dendl;
+      if (!(dest_weight < src_weight)) {
+        return -ERR_NOT_MODIFIED;
+      }
+    }
+
+    // Check if-unmodified-since condition
+    if (params.unmod_ptr && !params.if_match) {
+      dest_weight.init(*params.unmod_ptr, params.mod_zone_id, params.mod_pg_ver);
+      ldpp_dout(dpp, 10) << "If-UnModified-Since: " << dest_weight << " & " 
+                         << "Last-Modified: " << src_weight << dendl;
+      if (dest_weight < src_weight) {
+        return -ERR_PRECONDITION_FAILED;
+      }
+    }
+  }
+  // Check if-match condition
+  if (params.if_match) {
+    string if_match_str = rgw_string_unquote(params.if_match);
+    ldpp_dout(dpp, 10) << "ETag: " << etag << " & "
+                       << "If-Match: " << if_match_str << dendl;     
+    if (if_match_str.compare(etag) != 0) {
+      return -ERR_PRECONDITION_FAILED;
+    }
+  }
+  // Check if-none-match condition
+  if (params.if_nomatch) {
+    string if_nomatch_str = rgw_string_unquote(params.if_nomatch);
+    ldpp_dout(dpp, 10) << "ETag: " << etag << " & "
+                       << "If-NoMatch: " << if_nomatch_str << dendl;
+    if (if_nomatch_str.compare(etag) == 0) {
+      return -ERR_NOT_MODIFIED;
+    }
+  }
 
   // Open the object here.
   if (source->category == RGWObjCategory::MultiMeta) {

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -471,7 +471,6 @@ class MotrObject : public Object {
     uint64_t part_off;
     uint64_t part_size;
     uint64_t part_num;
-    const int OBJ_INSTANCE_LEN;
 
   public:
 
@@ -539,9 +538,9 @@ class MotrObject : public Object {
     MotrObject() = default;
 
     MotrObject(MotrStore *_st, const rgw_obj_key& _k)
-      : Object(_k), store(_st), acls(), state(NULL), OBJ_INSTANCE_LEN(32) {}
+      : Object(_k), store(_st), acls(), state(NULL) {}
     MotrObject(MotrStore *_st, const rgw_obj_key& _k, Bucket* _b)
-      : Object(_k, _b), store(_st), acls(), state(NULL), OBJ_INSTANCE_LEN(32) {}
+      : Object(_k, _b), store(_st), acls(), state(NULL) {}
 
     MotrObject(MotrObject& _o) = default;
 

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -1002,4 +1002,77 @@ class MotrStore : public Store {
     MotrMetaCache* get_bucket_inst_cache() {return bucket_inst_cache;}
 };
 
+struct obj_time_weight {
+  real_time mtime;
+  uint32_t zone_short_id;
+  uint64_t pg_ver;
+  bool high_precision;
+
+  obj_time_weight() : zone_short_id(0), pg_ver(0), high_precision(false) {}
+
+  bool compare_low_precision(const obj_time_weight& rhs) {
+    struct timespec l = ceph::real_clock::to_timespec(mtime);
+    struct timespec r = ceph::real_clock::to_timespec(rhs.mtime);
+    l.tv_nsec = 0;
+    r.tv_nsec = 0;
+    if (l > r) {
+      return false;
+    }
+    if (l < r) {
+      return true;
+    }
+    if (!zone_short_id || !rhs.zone_short_id) {
+      /* don't compare zone ids, if one wasn't provided */
+      return false;
+    }
+    if (zone_short_id != rhs.zone_short_id) {
+      return (zone_short_id < rhs.zone_short_id);
+    }
+    return (pg_ver < rhs.pg_ver);
+
+  }
+
+  bool operator<(const obj_time_weight& rhs) {
+    if (!high_precision || !rhs.high_precision) {
+      return compare_low_precision(rhs);
+    }
+    if (mtime > rhs.mtime) {
+      return false;
+    }
+    if (mtime < rhs.mtime) {
+      return true;
+    }
+    if (!zone_short_id || !rhs.zone_short_id) {
+      /* don't compare zone ids, if one wasn't provided */
+      return false;
+    }
+    if (zone_short_id != rhs.zone_short_id) {
+      return (zone_short_id < rhs.zone_short_id);
+    }
+    return (pg_ver < rhs.pg_ver);
+  }
+
+  void init(const real_time& _mtime, uint32_t _short_id, uint64_t _pg_ver) {
+    mtime = _mtime;
+    zone_short_id = _short_id;
+    pg_ver = _pg_ver;
+  }
+
+  void init(RGWObjState *state) {
+    mtime = state->mtime;
+    zone_short_id = state->zone_short_id;
+    pg_ver = state->pg_ver;
+  }
+};
+
+inline std::ostream& operator<<(std::ostream& out, const obj_time_weight &o) {
+  out << o.mtime;
+
+  if (o.zone_short_id != 0 || o.pg_ver != 0) {
+    out << "[zid=" << o.zone_short_id << ", pgv=" << o.pg_ver << "]";
+  }
+
+  return out;
+}
+
 } // namespace rgw::sal

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -471,6 +471,7 @@ class MotrObject : public Object {
     uint64_t part_off;
     uint64_t part_size;
     uint64_t part_num;
+    const int OBJ_INSTANCE_LEN;
 
   public:
 
@@ -538,9 +539,9 @@ class MotrObject : public Object {
     MotrObject() = default;
 
     MotrObject(MotrStore *_st, const rgw_obj_key& _k)
-      : Object(_k), store(_st), acls(), state(NULL) {}
+      : Object(_k), store(_st), acls(), state(NULL), OBJ_INSTANCE_LEN(32) {}
     MotrObject(MotrStore *_st, const rgw_obj_key& _k, Bucket* _b)
-      : Object(_k, _b), store(_st), acls(), state(NULL) {}
+      : Object(_k, _b), store(_st), acls(), state(NULL), OBJ_INSTANCE_LEN(32) {}
 
     MotrObject(MotrObject& _o) = default;
 


### PR DESCRIPTION
Parent Ticket: https://jts.seagate.com/browse/CORTX-27526

Adding support for
1. [--if-match <value>]
2. [--if-modified-since <value>]
3. [--if-none-match <value>]
4. [--if-unmodified-since <value>]

The output of all 8 possible scenarios is captured [here](https://jts.seagate.com/browse/CORTX-27526).
<details>
<summary> --if-match </summary>
<br>

```bash
╭─root@ssc-vm-g4-rhev4-0318.colo.seagate.com ~/cortx/cortx-rgw/build  ‹main*›
╰─➤  aws s3 ls my-bkt/obj1
2022-02-14 04:14:08    1048576 obj1

╭─root@ssc-vm-g4-rhev4-0318.colo.seagate.com ~/cortx/cortx-rgw/build  ‹main*›
╰─➤  aws s3api get-object --bucket my-bkt --key obj1 --if-match b6d81b360a5672d80c27430f39153e2c ~/downloded.file
{
    "AcceptRanges": "bytes",
    "LastModified": "Mon, 14 Feb 2022 11:14:08 GMT",
    "ContentLength": 1048576,
    "ETag": "\"b6d81b360a5672d80c27430f39153e2c\"",
    "ContentType": "binary/octet-stream",
    "Metadata": {}
}

╭─root@ssc-vm-g4-rhev4-0318.colo.seagate.com ~/cortx/cortx-rgw/build  ‹main*›
╰─➤  aws s3api get-object --bucket my-bkt --key obj1 --if-match b6d81b360a5672d80c27430f39153e2d ~/downloded.file

An error occurred (PreconditionFailed) when calling the GetObject operation: Unknown
```

</details>


<details>
<summary> --if-none-match</summary>
<br>

```bash
╭─root@ssc-vm-g4-rhev4-0318.colo.seagate.com ~/cortx/cortx-rgw/build  ‹main*›
╰─➤  aws s3api get-object --bucket my-bkt --key obj1 --if-none-match b6d81b360a5672d80c27430f39153e2c ~/downloded.file

An error occurred (304) when calling the GetObject operation: Not Modified

╭─root@ssc-vm-g4-rhev4-0318.colo.seagate.com ~/cortx/cortx-rgw/build  ‹main*›
╰─➤  aws s3api get-object --bucket my-bkt --key obj1 --if-none-match b6d81b360a5672d80c27430f39153e2d ~/downloded.file
{
    "AcceptRanges": "bytes",
    "LastModified": "Mon, 14 Feb 2022 11:14:08 GMT",
    "ContentLength": 1048576,
    "ETag": "\"b6d81b360a5672d80c27430f39153e2c\"",
    "ContentType": "binary/octet-stream",
    "Metadata": {}
}
```

</details>

<details>
<summary> --if-modified-since </summary>
<br>

```bash
╭─root@ssc-vm-g4-rhev4-0318.colo.seagate.com ~/cortx/cortx-rgw/build  ‹main*›
╰─➤  aws s3 ls my-bkt/obj1
2022-02-14 04:14:08    1048576 obj1

╭─root@ssc-vm-g4-rhev4-0318.colo.seagate.com ~/cortx/cortx-rgw/build  ‹main*›
╰─➤  aws s3api get-object --bucket my-bkt --key obj1 --if-modified-since 2022-02-14 ~/downloded.file
{
    "AcceptRanges": "bytes",
    "LastModified": "Mon, 14 Feb 2022 11:14:08 GMT",
    "ContentLength": 1048576,
    "ETag": "\"b6d81b360a5672d80c27430f39153e2c\"",
    "ContentType": "binary/octet-stream",
    "Metadata": {}
}

╭─root@ssc-vm-g4-rhev4-0318.colo.seagate.com ~/cortx/cortx-rgw/build  ‹main*›
╰─➤  aws s3api get-object --bucket my-bkt --key obj1 --if-modified-since 2022-02-16 ~/downloded.file

An error occurred (304) when calling the GetObject operation: Not Modified
```

</details>

<details>
<summary>  --if-unmodified-since </summary>
<br>

```bash
╭─root@ssc-vm-g4-rhev4-0318.colo.seagate.com ~/cortx/cortx-rgw/build  ‹main*›
╰─➤  aws s3api get-object --bucket my-bkt --key obj1 --if-unmodified-since 2022-02-16 ~/downloded.file                                                
{
    "AcceptRanges": "bytes",
    "LastModified": "Mon, 14 Feb 2022 11:14:08 GMT",
    "ContentLength": 1048576,
    "ETag": "\"b6d81b360a5672d80c27430f39153e2c\"",
    "ContentType": "binary/octet-stream",
    "Metadata": {}
}

╭─root@ssc-vm-g4-rhev4-0318.colo.seagate.com ~/cortx/cortx-rgw/build  ‹main*›
╰─➤  aws s3api get-object --bucket my-bkt --key obj1 --if-unmodified-since 2022-02-14 ~/downloded.file

An error occurred (PreconditionFailed) when calling the GetObject operation: Unknown
```

</details>

<details>
<summary>  --if-match & --if-unmodified-since </summary>
<br>

```bash
╭─root@ssc-vm-g4-rhev4-0318.colo.seagate.com ~/cortx/cortx-rgw/build  ‹CORTX-28693-CondParams-getObj›
╰─➤  aws s3api get-object --bucket my-bkt --key obj1 --if-unmodified-since 2022-02-15 --if-match b6d81b360a5672d80c27430f39153e2d ~/downloded.file

An error occurred (PreconditionFailed) when calling the GetObject operation: Unknown

╭─root@ssc-vm-g4-rhev4-0318.colo.seagate.com ~/cortx/cortx-rgw/build  ‹CORTX-28693-CondParams-getObj›
╰─➤  aws s3api get-object --bucket my-bkt --key obj1 --if-unmodified-since 2022-02-13 --if-match b6d81b360a5672d80c27430f39153e2d ~/downloded.file    255 ↵

An error occurred (PreconditionFailed) when calling the GetObject operation: Unknown

╭─root@ssc-vm-g4-rhev4-0318.colo.seagate.com ~/cortx/cortx-rgw/build  ‹CORTX-28693-CondParams-getObj›
╰─➤  aws s3api get-object --bucket my-bkt --key obj1 --if-unmodified-since 2022-02-13 --if-match b6d81b360a5672d80c27430f39153e2c ~/downloded.file    255 ↵
{
    "AcceptRanges": "bytes",
    "LastModified": "Mon, 14 Feb 2022 11:14:08 GMT",
    "ContentLength": 1048576,
    "ETag": "\"b6d81b360a5672d80c27430f39153e2c\"",
    "ContentType": "binary/octet-stream",
    "Metadata": {}
}

╭─root@ssc-vm-g4-rhev4-0318.colo.seagate.com ~/cortx/cortx-rgw/build  ‹CORTX-28693-CondParams-getObj›
╰─➤  aws s3api get-object --bucket my-bkt --key obj1 --if-unmodified-since 2022-02-15 --if-match b6d81b360a5672d80c27430f39153e2c ~/downloded.file
{
    "AcceptRanges": "bytes",
    "LastModified": "Mon, 14 Feb 2022 11:14:08 GMT",
    "ContentLength": 1048576,
    "ETag": "\"b6d81b360a5672d80c27430f39153e2c\"",
    "ContentType": "binary/octet-stream",
    "Metadata": {}
}
```

</details>

<details>
<summary> --if-none-match & --if-modified-since </summary>
<br>

```bash
╭─root@ssc-vm-g4-rhev4-0318.colo.seagate.com ~/cortx/cortx-rgw/build  ‹CORTX-28693-CondParams-getObj›
╰─➤  aws s3api get-object --bucket my-bkt --key obj1 --if-modified-since 2022-02-13 --if-none-match b6d81b360a5672d80c27430f39153e2d ~/downloded.file
{
    "AcceptRanges": "bytes",
    "LastModified": "Mon, 14 Feb 2022 11:14:08 GMT",
    "ContentLength": 1048576,
    "ETag": "\"b6d81b360a5672d80c27430f39153e2c\"",
    "ContentType": "binary/octet-stream",
    "Metadata": {}
}
╭─root@ssc-vm-g4-rhev4-0318.colo.seagate.com ~/cortx/cortx-rgw/build  ‹CORTX-28693-CondParams-getObj›
╰─➤  aws s3api get-object --bucket my-bkt --key obj1 --if-modified-since 2022-02-15 --if-none-match b6d81b360a5672d80c27430f39153e2d ~/downloded.file
{
    "AcceptRanges": "bytes",
    "LastModified": "Mon, 14 Feb 2022 11:14:08 GMT",
    "ContentLength": 1048576,
    "ETag": "\"b6d81b360a5672d80c27430f39153e2c\"",
    "ContentType": "binary/octet-stream",
    "Metadata": {}
}

╭─root@ssc-vm-g4-rhev4-0318.colo.seagate.com ~/cortx/cortx-rgw/build  ‹CORTX-28693-CondParams-getObj›
╰─➤  aws s3api get-object --bucket my-bkt --key obj1 --if-modified-since 2022-02-15 --if-none-match b6d81b360a5672d80c27430f39153e2c ~/downloded.file

An error occurred (304) when calling the GetObject operation: Not Modified

╭─root@ssc-vm-g4-rhev4-0318.colo.seagate.com ~/cortx/cortx-rgw/build  ‹CORTX-28693-CondParams-getObj›
╰─➤  aws s3api get-object --bucket my-bkt --key obj1 --if-modified-since 2022-02-13 --if-none-match b6d81b360a5672d80c27430f39153e2c ~/downloded.file 255 ↵

An error occurred (304) when calling the GetObject operation: Not Modified
```

</details>

<details>
<summary> --if-modified-since & --if-match </summary>
<br>

```bash
╭─root@ssc-vm-g4-rhev4-0318.colo.seagate.com ~/cortx/cortx-rgw/build  ‹CORTX-28693-CondParams-getObj›
╰─➤  aws s3api get-object --bucket my-bkt --key obj1 --if-modified-since 2022-02-13 --if-match b6d81b360a5672d80c27430f39153e2c ~/downloded.file   
{
    "AcceptRanges": "bytes",
    "LastModified": "Mon, 14 Feb 2022 11:14:08 GMT",
    "ContentLength": 1048576,
    "ETag": "\"b6d81b360a5672d80c27430f39153e2c\"",
    "ContentType": "binary/octet-stream",
    "Metadata": {}
}

╭─root@ssc-vm-g4-rhev4-0318.colo.seagate.com ~/cortx/cortx-rgw/build  ‹CORTX-28693-CondParams-getObj›
╰─➤  aws s3api get-object --bucket my-bkt --key obj1 --if-modified-since 2022-02-15 --if-match b6d81b360a5672d80c27430f39153e2c ~/downloded.file

An error occurred (304) when calling the GetObject operation: Not Modified

╭─root@ssc-vm-g4-rhev4-0318.colo.seagate.com ~/cortx/cortx-rgw/build  ‹CORTX-28693-CondParams-getObj›
╰─➤  aws s3api get-object --bucket my-bkt --key obj1 --if-modified-since 2022-02-13 --if-match b6d81b360a5672d80c27430f39153e2d ~/downloded.file      255 ↵

An error occurred (PreconditionFailed) when calling the GetObject operation: Unknown

╭─root@ssc-vm-g4-rhev4-0318.colo.seagate.com ~/cortx/cortx-rgw/build  ‹CORTX-28693-CondParams-getObj›
╰─➤  aws s3api get-object --bucket my-bkt --key obj1 --if-modified-since 2022-02-15 --if-match b6d81b360a5672d80c27430f39153e2d ~/downloded.file     

An error occurred (304) when calling the GetObject operation: Not Modified
```

</details>

<details>
<summary>  --if-unmodified-since & --if-none-match </summary>
<br>

```bash
╭─root@ssc-vm-g4-rhev4-0318.colo.seagate.com ~/cortx/cortx-rgw/build  ‹CORTX-28693-CondParams-getObj›
╰─➤  aws s3api get-object --bucket my-bkt --key obj1 --if-unmodified-since 2022-02-15 --if-none-match b6d81b360a5672d80c27430f39153e2d ~/downloded.file
{
    "AcceptRanges": "bytes",
    "LastModified": "Mon, 14 Feb 2022 11:14:08 GMT",
    "ContentLength": 1048576,
    "ETag": "\"b6d81b360a5672d80c27430f39153e2c\"",
    "ContentType": "binary/octet-stream",
    "Metadata": {}
}

╭─root@ssc-vm-g4-rhev4-0318.colo.seagate.com ~/cortx/cortx-rgw/build  ‹CORTX-28693-CondParams-getObj›
╰─➤  aws s3api get-object --bucket my-bkt --key obj1 --if-unmodified-since 2022-02-13 --if-none-match b6d81b360a5672d80c27430f39153e2d ~/downloded.file

An error occurred (PreconditionFailed) when calling the GetObject operation: Unknown

╭─root@ssc-vm-g4-rhev4-0318.colo.seagate.com ~/cortx/cortx-rgw/build  ‹CORTX-28693-CondParams-getObj›
╰─➤  aws s3api get-object --bucket my-bkt --key obj1 --if-unmodified-since 2022-02-15 --if-none-match b6d81b360a5672d80c27430f39153e2c ~/downloded.file

An error occurred (304) when calling the GetObject operation: Not Modified

╭─root@ssc-vm-g4-rhev4-0318.colo.seagate.com ~/cortx/cortx-rgw/build  ‹CORTX-28693-CondParams-getObj›
╰─➤  aws s3api get-object --bucket my-bkt --key obj1 --if-unmodified-since 2022-02-13 --if-none-match b6d81b360a5672d80c27430f39153e2d ~/downloded.file

An error occurred (PreconditionFailed) when calling the GetObject operation: Unknown
```

</details>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
