### PR TITLE
rgw_sal_motr: [CORTX-28960] fix for get zero-byte obj failure.

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1379,6 +1379,10 @@ int MotrObject::MotrReadOp::prepare(optional_yield y, const DoutPrefixProvider* 
     }
   }
 
+  // Skip opening an empty object.
+  if(source->get_obj_size() == 0)
+    return 0;
+
   // Open the object here.
   if (source->category == RGWObjCategory::MultiMeta) {
     ldpp_dout(dpp, 20) <<__func__<< ": open obj parts..." << dendl;


### PR DESCRIPTION
**Bug:** https://jts.seagate.com/browse/CORTX-28960, get of zero-byte objects fails with NoSuchKey error.
GET-Object operation is successful for non-zero size objects . Issue seen only with zero size object.
Console output Logs :
```bash
[root@ssc-vm-g4-rhev4-0935 ~]# touch abc.txt
[root@ssc-vm-g4-rhev4-0935 ~]# aws s3 cp abc.txt s3://bkt --endpoint http://localhost:8000
upload: ./abc.txt to s3://bkt/abc.txt
[root@ssc-vm-g4-rhev4-0935 ~]#
[root@ssc-vm-g4-rhev4-0935 ~]# aws s3api get-object --bucket bkt --key abc.txt abcout.txt --endpoint http://localhost:8000

An error occurred (NoSuchKey) when calling the GetObject operation: Unknown
```
**Bug Analysis:** 
In open_mobj we have a following check
```c++
  if (meta.layout_id == 0)
    return -ENOENT;
```
This check for zero-byte objects results in the failure of GetObj.

**Resolution:** since opening an empty obj is causing an issue we can skip opening an empty object, since there is nothing to open and read.

**Output:**
```bash
╭─root@ssc-vm-g4-rhev4-0318.colo.seagate.com ~/cortx/cortx-rgw/build  ‹CORTX-28960-FixGetZeroByteObj*›
╰─➤  aws s3api head-object --bucket mybkt --key zerosize.file
{
    "AcceptRanges": "bytes",
    "LastModified": "Thu, 24 Feb 2022 05:35:53 GMT",
    "ContentLength": 0,
    "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
    "ContentType": "binary/octet-stream",
    "Metadata": {}
}
╭─root@ssc-vm-g4-rhev4-0318.colo.seagate.com ~/cortx/cortx-rgw/build  ‹CORTX-28960-FixGetZeroByteObj*›
╰─➤  aws s3api get-object --bucket mybkt --key zerosize.file ~/testfiles/zeroclone.file
{
    "AcceptRanges": "bytes",
    "LastModified": "Thu, 24 Feb 2022 05:35:53 GMT",
    "ContentLength": 0,
    "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
    "ContentType": "binary/octet-stream",
    "Metadata": {}
}
```



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
