### PR TITLE
rgw_sal_motr:[CORTX-27698] Checksum mismatch for GET API

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1843,7 +1843,6 @@ int MotrObject::read_mobj(const DoutPrefixProvider* dpp, int64_t off, int64_t en
     if (left < bs)
       bs = this->get_optimal_bs(left);
     actual = bs;
-    //bs may remain same, and hence this additional check
     if (left < bs)
       actual = left;
     ldpp_dout(dpp, 20) << "MotrObject::read_mobj(): off=" << off <<

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1808,7 +1808,7 @@ out:
 int MotrObject::read_mobj(const DoutPrefixProvider* dpp, int64_t off, int64_t end, RGWGetDataCB* cb)
 {
   int rc;
-  unsigned bs, actual;
+  unsigned bs, actual, left;
   struct m0_op *op;
   struct m0_bufvec buf;
   struct m0_bufvec attr;
@@ -1838,10 +1838,14 @@ int MotrObject::read_mobj(const DoutPrefixProvider* dpp, int64_t off, int64_t en
   if (rc < 0)
     goto out;
 
-  actual = bs;
-  for (; off < end; off += actual) {
-    if (end - off < bs)
-        actual = end - off;
+  left = end - off;
+  for (; left > 0; off += actual) {
+    if (left < bs)
+      bs = this->get_optimal_bs(left);
+    actual = bs;
+    //bs may remain same, and hence this additional check
+    if (left < bs)
+      actual = left;
     ldpp_dout(dpp, 20) << "MotrObject::read_mobj(): off=" << off <<
                                             " actual=" << actual << dendl;
     bufferlist bl;
@@ -1851,23 +1855,27 @@ int MotrObject::read_mobj(const DoutPrefixProvider* dpp, int64_t off, int64_t en
     ext.iv_vec.v_count[0] = bs;
     attr.ov_vec.v_count[0] = 0;
 
+    left -= actual;
     // Read from Motr.
     op = nullptr;
     rc = m0_obj_op(this->mobj, M0_OC_READ, &ext, &buf, &attr, 0, 0, &op);
     ldpp_dout(dpp, 20) << "MotrObject::read_mobj(): init read op rc=" << rc << dendl;
-    if (rc != 0)
+    if (rc != 0) {
+      ldpp_dout(dpp, 0) << __func__ << ": read failed during m0_obj_op, rc=" << rc << dendl;
       goto out;
+    }
     m0_op_launch(&op, 1);
     rc = m0_op_wait(op, M0_BITS(M0_OS_FAILED, M0_OS_STABLE), M0_TIME_NEVER) ?:
          m0_rc(op);
     m0_op_fini(op);
     m0_op_free(op);
-    if (rc != 0)
+    if (rc != 0) {
+      ldpp_dout(dpp, 0) << __func__ << ": read failed, m0_op_wait rc=" << rc << dendl;
       goto out;
-
+    }
     // Call `cb` to process returned data.
     ldpp_dout(dpp, 20) << "MotrObject::read_mobj(): call cb to process data" << dendl;
-    cb->handle_data(bl, off, actual);
+    cb->handle_data(bl, 0, actual);
   }
 
 out:


### PR DESCRIPTION
Signed-off-by: dharmendra-jyani <dharmendra.jyani@seagate.com>

### Problem Statement
Get object for s3cmd is giving checksum mismatch warning during getting the data from s3.

[root@ssc-vm-g3-rhev4-2880 ~]# s3cmd --no-ssl get s3://testbucket3/vmlinux vmlinux
download: 's3://testbucket3/vmlinux' -> 'vmlinux' [1 of 1]
10210440 of 10210440 100% in 0s 134.52 MB/s done
WARNING: MD5 signatures do not match: computed=92326b2cc6b6898b4c3f238dff8c0b10, received=f9c5cc6840ab0093475b3b0699f4e58b

### Fix
Bl is initialized in every iteration. So the new data is stored from the 0th index every time in bl. But in code we are passing 'off' to handle_data function. This is result in writing from different index and result in checksum mismatch, we have to pass 0 in place of off in handle_data function
 
### Parent Story
[https://jts.seagate.com/browse/CORTX-27698](url)
Checksum mismatch for GET API

### Subtask Covered
[https://jts.seagate.com/browse/CORTX-28762](url)
Reproduce issue of checksum mismatch error

[https://jts.seagate.com/browse/CORTX-28763](url)
Find RCA of issue

[https://jts.seagate.com/browse/CORTX-28764](url)
Implement fix for the issue

### Testing done

1. Object size 10 MB
[root@ssc-vm-g4-rhev4-0761 ~]# s3cmd --no-ssl get s3://testbucket3/test11 test11
download: 's3://testbucket3/test11' -> 'test11'  [1 of 1]
 10210455 of 10210455   100% in    0s    47.47 MB/s  done
[root@ssc-vm-g4-rhev4-0761 ~]#

2.  Object size 16 MB 
[root@ssc-vm-g4-rhev4-0761 ~]# s3cmd --no-ssl get s3://testbucket3/test99 test99
download: 's3://testbucket3/test99' -> 'test99'  [1 of 1]
 16777216 of 16777216   100% in    0s    96.83 MB/s  done

3. Object size 100 MB
[root@ssc-vm-g4-rhev4-0761 ~]# s3cmd --no-ssl get s3://testbucket3/test111 test111
download: 's3://testbucket3/test111' -> 'test111'  [1 of 1]
 104857600 of 104857600   100% in    0s   111.99 MB/s  done
[root@ssc-vm-g4-rhev4-0761 ~]#

4. Object size 130 MB
[root@ssc-vm-g4-rhev4-0761 ~]# s3cmd --no-ssl get s3://testbucket3/test112 test112
download: 's3://testbucket3/test112' -> 'test112'  [1 of 1]
 136314880 of 136314880   100% in    1s   117.55 MB/s  done
[root@ssc-vm-g4-rhev4-0761 ~]#
 



## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests

