### PR TITLE
rgw_sal_motr: [CORTX-28987] Fix object deletion with null version

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1500,6 +1500,12 @@ MotrObject::MotrDeleteOp::MotrDeleteOp(MotrObject *_source, RGWObjectCtx *_rctx)
 // 2. Delete an object when its versioning is turned on.
 int MotrObject::MotrDeleteOp::delete_obj(const DoutPrefixProvider* dpp, optional_yield y)
 {
+  if (source->have_instance()) {
+    rgw_obj_key& key = source->get_key();
+    if (key.have_null_instance())
+      key.instance.clear();
+  }
+
   ldpp_dout(dpp, 20) << "delete " << source->get_key().to_str() << " from " << source->get_bucket()->get_name() << dendl;
 
   rgw_bucket_dir_entry ent;


### PR DESCRIPTION
# Change Summary

**Problem :** If version id parameter is passed as null to delete-object
API in case of unversioned bucket for deletion of simple object,
then object deletion does not happen.

**Implementation :** If instance is set to "null" we clear this string
in delete_object implementation. This implementation is similar to
what is done in rados.

## Parent Story
_[CORTX-28987](https://jts.seagate.com/browse/CORTX-28987):_
_Deletion of simple object with null version id._

## Sub Tasks covered in this PR
NA

## Exclusions in Implementation :
Multipart object not tested.

## Testing Done : 

<details>
  <summary> **Case 1 : Deleting Simple Object in unversioned bucket** </summary>
  

> [root@ssc-vm-g4-rhev4-0344 build]# aws s3 mb s3://unversionedtestbucket --endpoint-url http://127.0.0.1:8000
> make_bucket: unversionedtestbucket
> [root@ssc-vm-g4-rhev4-0344 build]# aws s3 cp 1mfile s3://unversionedtestbucket --endpoint-url http://127.0.0.1:8000
> upload: ./1mfile to s3://unversionedtestbucket/1mfile
> [root@ssc-vm-g4-rhev4-0344 build]# aws s3api list-object-versions --bucket unversionedtestbucket --endpoint-url http://127.0.0.1:8000
> {
>     "Versions": [
>         {
>             "ETag": "\"b6d81b360a5672d80c27430f39153e2c\"",
>             "Size": 1048576,
>             "StorageClass": "STANDARD",
>             "Key": "1mfile",
>             "VersionId": "null",
>             "IsLatest": true,
>             "LastModified": "2022-02-28T07:22:50.630Z",
>             "Owner": {
>                 "DisplayName": "mgwuser1",
>                 "ID": "mgwuser1"
>             }
>         }
>     ]
> }
> [root@ssc-vm-g4-rhev4-0344 build]# aws s3api delete-object --bucket unversionedtestbucket --key 1mfile --endpoint-url http://127.0.0.1:8000 --version-id null
> 
> An error occurred (InvalidArgument) when calling the DeleteObject operation: Unknown
> [root@ssc-vm-g4-rhev4-0344 build]# aws s3api delete-object --bucket unversionedtestbucket --key 1mfile --endpoint-url http://127.0.0.1:8000 --version-id null
> [root@ssc-vm-g4-rhev4-0344 build]# aws s3 ls s3://unversionedtestbucket --endpoint-url http://127.0.0.1:8000
> [root@ssc-vm-g4-rhev4-0344 build]#

</details>

<details>
  <summary> **Case 2 : Deleting Simple Object in versioned bucket** </summary>

> [root@ssc-vm-g4-rhev4-0344 build]# aws s3 mb s3://versionedtestbucket --endpoint-url http://127.0.0.1:8000
> make_bucket: versionedtestbucket
> [root@ssc-vm-g4-rhev4-0344 build]# aws s3api put-bucket-versioning --bucket versionedtestbucket --versioning-configuration Status=Enabled --endpoint-url http://127.0.0.1:8000
> [root@ssc-vm-g4-rhev4-0344 build]# aws s3api get-bucket-versioning --bucket versionedtestbucket --endpoint-url http://127.0.0.1:8000
> {
>     "Status": "Enabled",
>     "MFADelete": "Disabled"
> }
> [root@ssc-vm-g4-rhev4-0344 build]# aws s3 cp 1mfile s3://versionedtestbucket --endpoint-url http://127.0.0.1:8000
> upload: ./1mfile to s3://versionedtestbucket/1mfile
> [root@ssc-vm-g4-rhev4-0344 build]# aws s3api list-object-versions --bucket versionedtestbucket --endpoint-url http://127.0.0.1:8000
> {
>     "Versions": [
>         {
>             "ETag": "\"b6d81b360a5672d80c27430f39153e2c\"",
>             "Size": 1048576,
>             "StorageClass": "STANDARD",
>             "Key": "1mfile",
>             "VersionId": "uKMNszkMI9VYw0gLhGzMoeVkCu.y7-F",
>             "IsLatest": true,
>             "LastModified": "2022-02-28T07:33:09.817Z",
>             "Owner": {
>                 "DisplayName": "mgwuser1",
>                 "ID": "mgwuser1"
>             }
>         }
>     ]
> }
> [root@ssc-vm-g4-rhev4-0344 build]# aws s3api delete-object --bucket versionedtestbucket --key 1mfile --endpoint-url http://127.0.0.1:8000 --version-id uKMNszkMI9VYw0gLhGzMoeVkCu.y7-F
> 
> An error occurred (InvalidArgument) when calling the DeleteObject operation: Unknown
> [root@ssc-vm-g4-rhev4-0344 build]# aws s3api delete-object --bucket versionedtestbucket --key 1mfile --endpoint-url http://127.0.0.1:8000 --version-id uKMNszkMI9VYw0gLhGzMoeVkCu.y7-F
> [root@ssc-vm-g4-rhev4-0344 build]# aws s3 ls s3://versionedtestbucket --endpoint-url http://127.0.0.1:8000
> [root@ssc-vm-g4-rhev4-0344 build]#

</details>

Signed-off-by: Deepak Mahale <deepak.mahale@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
