### PR TITLE
rgw_sal_motr: [CORTX-27528] Fixing issue with delete object.

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1446,19 +1446,31 @@ int MotrObject::MotrDeleteOp::delete_obj(const DoutPrefixProvider* dpp, optional
 {
   ldpp_dout(dpp, 20) << "delete " << source->get_key().to_str() << " from " << source->get_bucket()->get_name() << dendl;
 
+  rgw_bucket_dir_entry ent;
+  int rc = source->get_bucket_dir_ent(dpp, ent);
+  if (rc < 0) {
+    return rc;
+  }
+
+  //TODO: When integrating with background GC for object deletion,
+  // we should consider adding object entry to GC before deleting the metadata.
   // Delete from the cache first.
   source->store->get_obj_meta_cache()->remove(dpp, source->get_key().to_str());
 
   // Delete the object's entry from the bucket index.
   bufferlist bl;
   string bucket_index_iname = "motr.rgw.bucket.index." + source->get_bucket()->get_name();
-  int rc = source->store->do_idx_op_by_name(bucket_index_iname,
+  rc = source->store->do_idx_op_by_name(bucket_index_iname,
                                             M0_IC_DEL, source->get_key().to_str(), bl);
   if (rc < 0) {
     ldpp_dout(dpp, 0) << "Failed to del object's entry from bucket index. " << dendl;
     return rc;
   }
 
+  if (ent.meta.size == 0) {
+    ldpp_dout(dpp, 0) << __func__ << ": Object size is 0, not deleting motr object." << dendl;
+    return 0;
+  }
   // Remove the motr objects.
   if (source->category == RGWObjCategory::MultiMeta)
     rc = source->delete_part_objs(dpp);
@@ -1895,7 +1907,7 @@ int MotrObject::get_bucket_dir_ent(const DoutPrefixProvider *dpp, rgw_bucket_dir
     keys[0] = this->get_name();
     rc = store->next_query_by_name(bucket_index_iname, keys, vals);
     if (rc < 0) {
-      ldpp_dout(dpp, 0) << "ERROR: NEXT query failed. " << rc << dendl;
+      ldpp_dout(dpp, 0) << __func__ << "ERROR: NEXT query failed. " << rc << dendl;
       return rc;
     }
 
@@ -1922,7 +1934,7 @@ int MotrObject::get_bucket_dir_ent(const DoutPrefixProvider *dpp, rgw_bucket_dir
       rc = this->store->do_idx_op_by_name(bucket_index_iname,
                                           M0_IC_GET, this->get_key().to_str(), bl);
       if (rc < 0) {
-        ldpp_dout(dpp, 0) << "ERROR: failed to get object's entry from bucket index: rc="
+        ldpp_dout(dpp, 0) << __func__ << "ERROR: failed to get object's entry from bucket index: rc="
                           << rc << dendl;
         return rc;
       }


### PR DESCRIPTION
### Parent Story
 - https://jts.seagate.com/browse/CORTX-27528

#### Sub-tasks covered
 - https://jts.seagate.com/browse/CORTX-29114

**Problem:** 
 - MotrDeleteOp::delete_obj api was trying to delete the object without opening it first because of that mobj was not initialized with the object oid.
 - Deleting an zero size object fails while deleting motr object.

**Fix:** 
 - Doing a get_bucket_dir_ent() on object before trying to delete it, it will do a lookup on object and initialize it as well.
 - Checking object size before trying delete the motr object.

Signed-off-by: saurabh jain <saurabh.jain2@seagate.com>

###  Testing done 
<details><summary> Test 1: </summary>

>[root@ssc-vm-g4-rhev4-0499 ~]# aws s3 ls s3://buck
>2022-02-24 05:47:46   16778808 large
>2022-02-24 05:45:29   10227542 small
>2022-02-23 03:27:29   10210440 vmlinux
>2022-02-27 22:35:33          0 zero
>[root@ssc-vm-g4-rhev4-0499 ~]# aws s3api delete-object --bucket buck --key large
>[root@ssc-vm-g4-rhev4-0499 ~]#
>[root@ssc-vm-g4-rhev4-0499 ~]# aws s3 ls s3://buck
>2022-02-24 05:45:29   10227542 small
>2022-02-23 03:27:29   10210440 vmlinux
>2022-02-27 22:35:33          0 zero

#### Logs:
```
2022-02-28T07:07:50.422-0700 7f425f791700  2 req 0 0.008999994s s3:delete_obj executing
2022-02-28T07:07:50.422-0700 7f425f791700 10 req 0 0.008999994s s3:delete_obj cache get: name=large1 : miss
2022-02-28T07:07:50.422-0700 7f425f791700  0 req 0 0.008999994s s3:delete_obj Cache miss: name = large1, rc = -2
2022-02-28T07:07:50.422-0700 7f425f791700 20 id = 0x4931753ec1376776:0x71d7e7612e1824e2
2022-02-28T07:07:50.422-0700 7f425f791700 20 converted id = 0x78000000c1376776:0x71d7e7612e1824e2
2022-02-28T07:07:50.422-0700 7f425f791700 20 do_idx_op_by_name: do_idx_op_by_name(): op=GET idx=motr.rgw.bucket.index.buck1 key=large1
2022-02-28T07:07:50.426-0700 7f425f791700  0 req 0 0.012999992s s3:delete_obj Put into cache: name = large1
2022-02-28T07:07:50.426-0700 7f425f791700 10 req 0 0.012999992s s3:delete_obj cache put: name=large1 info.flags=0x1
2022-02-28T07:07:50.426-0700 7f425f791700 10 req 0 0.012999992s s3:delete_obj adding large1 to cache LRU end
2022-02-28T07:07:50.426-0700 7f425f791700 20 req 0 0.012999992s s3:delete_obj get_obj_state: object's etag:  d87ab5b563250c162adf77b1d3a3b816
2022-02-28T07:07:50.426-0700 7f425f791700 20 req 0 0.012999992s s3:delete_obj delete large1 from buck1
2022-02-28T07:07:50.426-0700 7f425f791700 10 req 0 0.012999992s s3:delete_obj cache get: name=large1 : hit (requested=0x1, cached=0x1)
2022-02-28T07:07:50.426-0700 7f425f791700  0 req 0 0.012999992s s3:delete_obj Cache hit: name = large1
2022-02-28T07:07:50.426-0700 7f425f791700 20 req 0 0.012999992s s3:delete_obj get_bucket_dir_ent: lid=0xb
2022-02-28T07:07:50.427-0700 7f425f791700 10 req 0 0.013999991s s3:delete_obj removing large1 from cache
2022-02-28T07:07:50.427-0700 7f425f791700  0 req 0 0.013999991s s3:delete_obj Remove from cache: name = large1
2022-02-28T07:07:50.427-0700 7f425f791700 20 id = 0x4931753ec1376776:0x71d7e7612e1824e2
2022-02-28T07:07:50.427-0700 7f425f791700 20 converted id = 0x78000000c1376776:0x71d7e7612e1824e2
2022-02-28T07:07:50.427-0700 7f425f791700 20 do_idx_op_by_name: do_idx_op_by_name(): op=GET idx=motr.rgw.bucket.index.buck1 key=large1
2022-02-28T07:07:50.430-0700 7f425f791700 20 req 0 0.016999988s **s3:delete_obj delete_mobj: deleting motr object oid=2bf0f9c:7ae000001b00003**
2022-02-28T07:07:50.430-0700 7f425f791700 20 req 0 0.016999988s s3:delete_obj open_mobj: oid=2bf0f9c:7ae000001b00003
2022-02-28T07:07:50.430-0700 7f425f791700 20 req 0 0.016999988s s3:delete_obj open_mobj: rc=0
2022-02-28T07:07:50.441-0700 7f425f791700  2 req 0 0.027999984s s3:delete_obj completing
2022-02-28T07:07:50.441-0700 7f425f791700  2 req 0 0.027999984s s3:delete_obj op status=0
2022-02-28T07:07:50.441-0700 7f425f791700  2 req 0 0.027999984s s3:delete_obj http status=204
2022-02-28T07:07:50.441-0700 7f425f791700  1 ====== req done req=0x7f4298ed3780 op status=0 http_status=204 latency=0.027999984s ======
2022-02-28T07:07:50.442-0700 7f425f791700  1 beast: 0x7f4298ed3780: ::1 - mgwuser [28/Feb/2022:07:07:50.413 -0700] "DELETE /buck1/large1 HTTP/1.1" 204 0 - "aws-cli/1.22.45 Python/3.6.8 Linux/4.18.0-348.2.1.el8_5.x86_64 botocore/1.23.45" - latency=0.027999984s
```
</details>

<details><summary> Test 2: </summary>

```
[root@ssc-vm-g4-rhev4-0499 ~]# aws s3 ls s3://buck
2022-02-22 06:00:31   10210440 vmlinux2
2022-02-28 23:49:31          0 zero
[root@ssc-vm-g4-rhev4-0499 ~]# aws s3api delete-object --bucket buck --key zero
[root@ssc-vm-g4-rhev4-0499 ~]# aws s3 ls s3://buck
2022-02-22 06:00:31   10210440 vmlinux2
```


**Logs:**
```
2022-03-01T00:11:00.126-0700 7f4e0e7dd700  2 req 0 0.010999989s s3:delete_obj executing
2022-03-01T00:11:00.126-0700 7f4e0e7dd700 10 req 0 0.010999989s s3:delete_obj cache get: name=zero : hit (requested=0x1, cached=0x1)
2022-03-01T00:11:00.126-0700 7f4e0e7dd700  0 req 0 0.010999989s s3:delete_obj Cache hit: name = zero
2022-03-01T00:11:00.126-0700 7f4e0e7dd700 20 req 0 0.010999989s s3:delete_obj get_obj_state: object's etag:  d41d8cd98f00b204e9800998ecf8427e
2022-03-01T00:11:00.126-0700 7f4e0e7dd700 20 req 0 0.010999989s s3:delete_obj delete zero from buck
2022-03-01T00:11:00.126-0700 7f4e0e7dd700 10 req 0 0.010999989s s3:delete_obj cache get: name=zero : hit (requested=0x1, cached=0x1)
2022-03-01T00:11:00.126-0700 7f4e0e7dd700  0 req 0 0.010999989s s3:delete_obj Cache hit: name = zero
2022-03-01T00:11:00.126-0700 7f4e0e7dd700 20 req 0 0.010999989s s3:delete_obj get_bucket_dir_ent: lid=0x0
2022-03-01T00:11:00.126-0700 7f4e0e7dd700 10 req 0 0.010999989s s3:delete_obj removing zero from cache
2022-03-01T00:11:00.126-0700 7f4e0e7dd700  0 req 0 0.010999989s s3:delete_obj Remove from cache: name = zero
2022-03-01T00:11:00.126-0700 7f4e0e7dd700 20 id = 0x621b1683c5ae9113:0x43fdb4fe222bf95c
2022-03-01T00:11:00.126-0700 7f4e0e7dd700 20 converted id = 0x78000000c5ae9113:0x43fdb4fe222bf95c
2022-03-01T00:11:00.126-0700 7f4e0e7dd700 20 do_idx_op_by_name: do_idx_op_by_name(): op=GET idx=motr.rgw.bucket.index.buck key=zero
2022-03-01T00:11:00.130-0700 7f4e0e7dd700  0 req 0 0.014999985s s3:delete_obj delete_obj: Object size is 0. Not deleting motr object.
2022-03-01T00:11:00.130-0700 7f4e0e7dd700  2 req 0 0.014999985s s3:delete_obj completing
2022-03-01T00:11:00.131-0700 7f4e0e7dd700  2 req 0 0.015999984s s3:delete_obj op status=0
2022-03-01T00:11:00.131-0700 7f4e0e7dd700  2 req 0 0.015999984s s3:delete_obj http status=204
2022-03-01T00:11:00.131-0700 7f4e0e7dd700  1 ====== req done req=0x7f4e6ff6f780 op status=0 http_status=204 latency=0.015999984s ======
2022-03-01T00:11:00.131-0700 7f4e0e7dd700  1 beast: 0x7f4e6ff6f780: ::1 - mgwuser [01/Mar/2022:00:11:00.114 -0700] "DELETE /buck/zero HTTP/1.1" 204 0 - "aws-cli/1.22.45 Python/3.6.8 Linux/4.18.0-348.2.1.el8_5.x86_64 botocore/1.23.45" - latency=0.015999984s
```

</details>
<details><summary> Test 3: </summary>

```
[root@ssc-vm-g4-rhev4-0499 ~]# aws s3 ls s3://buck
2022-02-22 06:00:31   10210440 vmlinux2
[root@ssc-vm-g4-rhev4-0499 ~]# aws s3 rm s3://buck/vmlinux2
delete: s3://buck/vmlinux2
```

```
[root@ssc-vm-g4-rhev4-0499 ~]# aws s3 ls s3://buck/zero
2022-03-01 00:10:16          0 zero
[root@ssc-vm-g4-rhev4-0499 ~]# aws s3 rm s3://buck/zero
delete: s3://buck/zero
```

</details>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
