### PR TITLE
rgw_sal_motr: [CORTX-29094] Improve ListObjs / ListObjsV2 API

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -3643,8 +3643,7 @@ int MotrStore::next_query_by_name(string idx_name,
       ++k;
     }
 
-    int keys_left = val_out.size() - (i+k);  // i+k gives next index.
-    if (rc < (int)nr_kvp || keys_left <= 0)  // No more keys to fetch
+    if (rc < (int)nr_kvp) // there are no more keys to fetch
       break;
 
     string next_key;
@@ -3653,12 +3652,14 @@ int MotrStore::next_query_by_name(string idx_name,
     else
       next_key = key_out[i + k - 1] + " ";
     ldout(cctx, 0) << "do_idx_next_op(): next_key=" << next_key << dendl;
+    keys[0].assign(next_key.begin(), next_key.end());
+
+    int keys_left = val_out.size() - (i + k);  // i + k gives next index.
     // Resizing keys & vals vector when `keys_left < batch size`.
-    if(keys_left < (int)nr_kvp) {
+    if (keys_left < (int)nr_kvp) {
       keys.resize(keys_left);
       vals.resize(keys_left);
     }
-    keys[0].assign(next_key.begin(), next_key.end());
   }
 
 out:

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -3624,7 +3624,8 @@ int MotrStore::next_query_by_name(string idx_name,
       ++k;
     }
 
-    if (rc < (int)nr_kvp) // there are no more keys to fetch
+    int keys_left = val_out.size() - (i+k);  // i+k gives next index.
+    if (rc < (int)nr_kvp || keys_left <= 0)  // No more keys to fetch
       break;
 
     string next_key;
@@ -3633,6 +3634,11 @@ int MotrStore::next_query_by_name(string idx_name,
     else
       next_key = key_out[i + k - 1] + " ";
     ldout(cctx, 0) << "do_idx_next_op(): next_key=" << next_key << dendl;
+    // Resizing keys & vals vector when `keys_left < batch size`.
+    if(keys_left < (int)nr_kvp) {
+      keys.resize(keys_left);
+      vals.resize(keys_left);
+    }
     keys[0].assign(next_key.begin(), next_key.end());
   }
 

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -938,7 +938,7 @@ std::unique_ptr<Object> MotrBucket::get_object(const rgw_obj_key& k)
 int MotrBucket::list(const DoutPrefixProvider *dpp, ListParams& params, int max, ListResults& results, optional_yield y)
 {
   int rc;
-  if (max <= 0)  // Return an emtpy response.
+  if (max == 0)  // Return an emtpy response.
     return 0;
   max++;  // Fetch an extra key if available to ensure presence of next obj.
   vector<string> keys(max);


### PR DESCRIPTION
Issue Fixes:
1. RGW crashes when a delimiter is used with max-keys. (in a specific scenario)
    <details><summary>Issue observation</summary></br>
   
    ```bash
    ╭─root@ssc-vm-g4-rhev4-0318.colo.seagate.com ~/cortx/cortx-rgw/build  ‹CORTX-29094-fixListObjParams*›
    ╰─➤  aws s3api list-objects-v2 --bucket mybkt --max-keys 3 --delimiter /  --continuation-token output.file
   
    Could not connect to the endpoint URL: "http://localhost:8000/mybkt?list-type=2&delimiter=%2F&max-keys=3&continuation-token=output.file&encoding-type=url"
    ```
    Logs:
    ```bash
    1137  20 req 0 0.007000023s s3:list_bucket bucket=mybkt prefix= marker=output.file max=     3
    1138  20 id = 0xd45ec53807bb2c24:0x8786bc02fd5ae88e
    1139  20 converted id = 0x7800000007bb2c24:0x8786bc02fd5ae88e
    1140  20 next_query_by_name: next_query_by_name(): index=motr.rgw.bucket.index.mybkt pr     efix= delim=/
    1141  20 do_idx_next_op() = 3
    1142   0 do_idx_next_op(): next_key=seagate/ÿ
    1143  20 do_idx_next_op() = 3
    1144  -1 *** Caught signal (Aborted) **
    1145  in thread 7fb58a21e700thread_name:radosgw
    1146
    1147  ceph version 17.0.0-10263-g16ae66b7605 (16ae66b760521f993efd470cebe9334626cbe23e) quincy (dev)
    1148  1: /lib64/libpthread.so.0(+0x12c20) [0x7fb5c8107c20]
    1149  2: gsignal()
    1150  3: abort()
    1151  4: (std::char_traits<char>::length(char const*)+0) [0x55eba9214280]
    1152  5: (rgw::sal::MotrStore::next_query_by_name(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::     vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<c     har, std::char_traits<char>, std::allocator<char> > > >&, std::vector<ceph::buffer::v15_2_0::list, std::allocator<ceph::buffer::v15     _2_0::list> >&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, s     td::char_traits<char>, std::allocator<char> >)+0xa73) [0x7fb5cb6d98f5]
    ```

    </details>

    <details><summary>RCA & Solution</summary>
      <b>RCA:</b> </br>
      Let the max-keys requested be 3, thus batch size is 3.</br>
      * <code>{"asdfg", "foo/bar", "foo/bar-1"}</code> are the keys extracted in the first batch. </br>
      * <code>{"foo/bar", "fool/bar-1"}</code> are combined as <code>{"foo/"}</code> resulting in get of 2 keys, 1 key needs to be retrieved yet. </br>
      * Batch size is still 3, so next 3 values are fetch. But since the output vector is only of size 3, and we are trying to assign values at index 2, 3, & 4 respectively now, the exception occurs and radosgw crashes.

      **Solution:** </br>
      If keys left to fetch are less than batch size, then resize the keys & vals vector to the count of keys left, to extract exactly those number of keys.
    </details>

    <details><summary>Output</summary></br>
    
    ```bash
    ╰─➤  aws s3api list-objects-v2 --bucket mybkt --max-keys 3 --delimiter /  --continuation-token output.file
    {
        "IsTruncated": true,
        "Contents": [
            {
                "Key": "output.file",
                "LastModified": "2022-02-24T05:35:41.686Z",
                "ETag": "\"b6d81b360a5672d80c27430f39153e2c\"",
                "Size": 1048576,
                "StorageClass": "STANDARD"
            },
            {
                "Key": "zero2",
                "LastModified": "2022-02-25T06:06:19.763Z",
                "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
                "Size": 0,
                "StorageClass": "STANDARD"
            }
        ],
        "Name": "mybkt",
        "Prefix": "",
        "Delimiter": "/",
        "MaxKeys": 3,
        "CommonPrefixes": [
            {
                "Prefix": "seagate/"
            }
        ],
        "EncodingType": "url",
        "KeyCount": 3,
        "ContinuationToken": "output.file",
        "NextContinuationToken": "zero2 "
    }
    ```

    </details>

2. Is_truncated is set true with next_continuation_token even when there are no objects ahead.  
   <details><summary>Issue observation</summary></br>
   
    ```bash
    ╰─➤  aws s3 ls s3://mybkt2
    2022-03-03 22:47:04       1024 obj1
    2022-03-03 22:47:07       1024 obj2

    ╰─➤  aws s3api list-objects-v2 --bucket mybkt2 --max-keys 2
    {
        "IsTruncated": true,
        "Contents": [
            {
                "Key": "obj1",
                "LastModified": "2022-03-04T05:47:04.067Z",
                "ETag": "\"fb92234566bc9f01b853318711106da7\"",
                "Size": 1024,
                "StorageClass": "STANDARD"
            },
            {
                "Key": "obj2",
                "LastModified": "2022-03-04T05:47:07.251Z",
                "ETag": "\"fb92234566bc9f01b853318711106da7\"",
                "Size": 1024,
                "StorageClass": "STANDARD"
            }
        ],
        "Name": "mybkt2",
        "Prefix": "",
        "MaxKeys": 2,
        "EncodingType": "url",
        "KeyCount": 2,
        "NextContinuationToken": "obj2 "
    }
    ```

   </details>
   
   <details><summary>RCA & solution</summary></br>
   <b>RCA:</b> </br>
   We were deciding whether to show the last key as next_marker to the user based on whether the number of keys retreived are equal to or less than the max-key mark set.
   If the retrieved number of keys is equal to the max-key mark we show the next_marker & this logic creates the wrong behavior.

   **Solution:** </br>
   Fetch one extra key than max-key constraint to confirm if we have next key in the bucket or not.
   </details>

   <details><summary>Output</summary></br>

    ```bash
    ╰─➤  aws s3 ls s3://mybkt2
    2022-03-03 22:47:04       1024 obj1
    2022-03-03 22:47:07       1024 obj2

    ╰─➤  aws s3api list-objects-v2 --bucket mybkt2 --max-keys 2
    {
        "IsTruncated": false,
        "Contents": [
            {
                "Key": "obj1",
                "LastModified": "2022-03-04T05:47:04.067Z",
                "ETag": "\"fb92234566bc9f01b853318711106da7\"",
                "Size": 1024,
                "StorageClass": "STANDARD"
            },
            {
                "Key": "obj2",
                "LastModified": "2022-03-04T05:47:07.251Z",
                "ETag": "\"fb92234566bc9f01b853318711106da7\"",
                "Size": 1024,
                "StorageClass": "STANDARD"
            }
        ],
        "Name": "mybkt2",
        "Prefix": "",
        "MaxKeys": 2,
        "EncodingType": "url",
        "KeyCount": 2
    }
    ```

   </details>
3. Continuation-token / marker is repeated in the response. (if not appended by user with " " char) </br>
   Same behavior is observed in case of directory type marker as well.

    <details><summary>Issue Observations</summary></br>

    ```bash
    ## For normal key without delimiter
    ╰─➤  aws s3api list-objects-v2 --bucket mybkt --max-keys 2 --continuation-token obj1
    {
        "IsTruncated": true,
        "Contents": [
            {
                "Key": "obj1",
                "LastModified": "2022-02-24T10:45:20.274Z",
                "ETag": "\"fb92234566bc9f01b853318711106da7\"",
                "Size": 1024,
                "StorageClass": "STANDARD"
            },
            {
                "Key": "obj2",
                "LastModified": "2022-02-24T10:45:24.041Z",
                "ETag": "\"fb92234566bc9f01b853318711106da7\"",
                "Size": 1024,
                "StorageClass": "STANDARD"
            }
        ],
        "Name": "mybkt",
        "Prefix": "",
        "MaxKeys": 2,
        "EncodingType": "url",
        "KeyCount": 2,
        "ContinuationToken": "obj1",
        "NextContinuationToken": "obj2 "
    }

    ## For keys with delimiter at the end
    ╰─➤  aws s3api list-objects-v2 --bucket mybkt --max-keys 2 --delimiter / --continuation-token seagate/                              2 ↵
    {
        "IsTruncated": true,
        "Contents": [
            {
                "Key": "zero2",
                "LastModified": "2022-02-25T06:06:19.763Z",
                "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
                "Size": 0,
                "StorageClass": "STANDARD"
            }
        ],
        "Name": "mybkt",
        "Prefix": "",
        "Delimiter": "/",
        "MaxKeys": 2,
        "CommonPrefixes": [
            {
                "Prefix": "seagate/"
            }
        ],
        "EncodingType": "url",
        "KeyCount": 2,
        "ContinuationToken": "seagate/",
        "NextContinuationToken": "zero2 "
    }

    ```

    </details>

    <details><summary>RCA & solution</summary></br>
      <pre><ul><li>The normal marker key needs to be appended with " " to get the correct next key.
      <li>The dir type marker key needs to be appended with "\xff" to skip the dir entries in the next run.
      </ul>Currently NextMarker is appended with these chars, instead Marker should be processed after its acceptance.</pre>
    </details>

    <details><summary>Output</summary></br>
      
      ```bash
      ## For normal key without delimiter
      ╰─➤  aws s3api list-objects-v2 --bucket mybkt --max-keys 2 --continuation-token obj1
      {
          "IsTruncated": true,
          "Contents": [
              {
                  "Key": "obj2",
                  "LastModified": "2022-02-24T10:45:24.041Z",
                  "ETag": "\"fb92234566bc9f01b853318711106da7\"",
                  "Size": 1024,
                  "StorageClass": "STANDARD"
              },
              {
                  "Key": "obj3",
                  "LastModified": "2022-02-24T10:45:27.054Z",
                  "ETag": "\"fb92234566bc9f01b853318711106da7\"",
                  "Size": 1024,
                  "StorageClass": "STANDARD"
              }
          ],
          "Name": "mybkt",
          "Prefix": "",
          "MaxKeys": 2,
          "EncodingType": "url",
          "KeyCount": 2,
          "ContinuationToken": "obj1",
          "NextContinuationToken": "obj3"
      }

      # For keys with delimiter at the end
      ╰─➤  aws s3api list-objects-v2 --bucket mybkt --max-keys 2 --delimiter / --continuation-token seagate/
      {
          "IsTruncated": true,
          "Contents": [
              {
                  "Key": "zero2",
                  "LastModified": "2022-02-25T06:06:19.763Z",
                  "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
                  "Size": 0,
                  "StorageClass": "STANDARD"
              },
              {
                  "Key": "zero3",
                  "LastModified": "2022-02-25T06:16:45.250Z",
                  "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
                  "Size": 0,
                  "StorageClass": "STANDARD"
              }
          ],
          "Name": "mybkt",
          "Prefix": "",
          "Delimiter": "/",
          "MaxKeys": 2,
          "EncodingType": "url",
          "KeyCount": 2,
          "ContinuationToken": "seagate/",
          "NextContinuationToken": "zero3"
      }
      ```

    </details>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
