### PR TITLE
rgw_sal_motr: [CORTX-28060] Delete access key for an IAM user

### DIFF
--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -206,6 +206,7 @@ class MotrUser : public User {
     struct m0_idx      idx;
 
   public:
+    std::set<std::string> access_key_tracker;
     MotrUser(MotrStore *_st, const rgw_user& _u) : User(_u), store(_st) { }
     MotrUser(MotrStore *_st, const RGWUserInfo& _i) : User(_i), store(_st) { }
     MotrUser(MotrStore *_st) : store(_st) { }
@@ -1023,6 +1024,7 @@ class MotrStore : public Store {
                           std::string key_str, bufferlist &bl, bool update=true);
     int check_n_create_global_indices();
     int store_access_key(const DoutPrefixProvider *dpp, optional_yield y, MotrAccessKey access_key);
+    int delete_access_key(const DoutPrefixProvider *dpp, optional_yield y, std::string access_key);
     int store_email_info(const DoutPrefixProvider *dpp, optional_yield y, MotrEmailInfo& email_info);
 
     int init_metadata_cache(const DoutPrefixProvider *dpp, CephContext *cct);


### PR DESCRIPTION
## Parent Ticket
[CORTX-28060](https://jts.seagate.com/browse/CORTX-28060)

## Description
Implementation of deletion of a specified access key for a user who owns multiple access keys.

## Exclusions
N/A

## Implementation
Access keys are stored in user info as well as in access key index table. `access_key_tracker` keeps track of access keys of current user. When key deletion is requested, RGW code takes care of deleting the specified key from user info. This creates a mismatch between access keys in user info and access keys tracked by `access_key_tracker` which triggers key deletion from access key index table. 

Following command is enabled:

```
radosgw-admin key rm <access-key>
```

Signed-off-by: Jeet Jain <jeet.jain@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
