### PR TITLE
rgw_sal_motr: [CORTX-29158] return HostID/RequestID in error responses

### DIFF
--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -119,6 +119,7 @@ set(librgw_common_srcs
   rgw_putobj_processor.cc
   rgw_quota.cc
   rgw_rados.cc
+  rgw_motr.cc
   rgw_resolve.cc
   rgw_rest.cc
   rgw_rest_client.cc

--- a/src/rgw/rgw_motr.cc
+++ b/src/rgw/rgw_motr.cc
@@ -1,0 +1,133 @@
+#include "include/compat.h"
+#include <errno.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sstream>
+
+#include <boost/algorithm/string.hpp>
+#include <string_view>
+
+#include <boost/container/flat_set.hpp>
+#include <boost/format.hpp>
+#include <boost/optional.hpp>
+#include <boost/utility/in_place_factory.hpp>
+
+#include "common/ceph_json.h"
+
+#include "common/errno.h"
+#include "common/Formatter.h"
+#include "common/Throttle.h"
+
+#include "rgw_sal.h"
+#include "rgw_zone.h"
+#include "rgw_cache.h"
+#include "rgw_acl.h"
+#include "rgw_acl_s3.h" /* for dumping s3policy in debug log */
+#include "rgw_aio_throttle.h"
+#include "rgw_bucket.h"
+#include "rgw_rest_conn.h"
+#include "rgw_cr_rados.h"
+#include "rgw_cr_rest.h"
+#include "rgw_datalog.h"
+#include "rgw_putobj_processor.h"
+#include "rgw_motr.h"
+
+#include "cls/rgw/cls_rgw_ops.h"
+#include "cls/rgw/cls_rgw_client.h"
+#include "cls/rgw/cls_rgw_const.h"
+#include "cls/refcount/cls_refcount_client.h"
+#include "cls/version/cls_version_client.h"
+#include "osd/osd_types.h"
+
+#include "rgw_tools.h"
+#include "rgw_coroutine.h"
+#include "rgw_compression.h"
+#include "rgw_etag_verifier.h"
+#include "rgw_worker.h"
+#include "rgw_notify.h"
+
+#undef fork // fails to compile RGWPeriod::fork() below
+
+#include "common/Clock.h"
+#include <string>
+#include <iostream>
+#include <vector>
+#include <atomic>
+#include <list>
+#include <map>
+#include "include/random.h"
+
+#include "rgw_gc.h"
+#include "rgw_lc.h"
+
+#include "rgw_object_expirer_core.h"
+#include "rgw_sync.h"
+#include "rgw_sync_counters.h"
+#include "rgw_sync_trace.h"
+#include "rgw_trim_datalog.h"
+#include "rgw_trim_mdlog.h"
+#include "rgw_data_sync.h"
+#include "rgw_realm_watcher.h"
+#include "rgw_reshard.h"
+
+#include "services/svc_zone.h"
+#include "services/svc_zone_utils.h"
+#include "services/svc_quota.h"
+#include "services/svc_sync_modules.h"
+#include "services/svc_sys_obj.h"
+#include "services/svc_sys_obj_cache.h"
+#include "services/svc_bucket.h"
+#include "services/svc_mdlog.h"
+
+#include "compressor/Compressor.h"
+
+#include "rgw_d3n_datacache.h"
+
+int RGWMotr::initialize(const DoutPrefixProvider *dpp)
+{
+  int ret;
+  ret = init_svc(true, dpp);
+  if (ret < 0) {
+    ldpp_dout(dpp, 0) << "ERROR: failed to init services (ret=" << cpp_strerror(-ret) << ")" << dendl;
+    return ret;
+  }
+  ret = init_ctl(dpp);
+  if (ret < 0) {
+    ldpp_dout(dpp, 0) << "ERROR: failed to init ctls (ret=" << cpp_strerror(-ret) << ")" << dendl;
+    return ret;
+  }
+
+  return ret;
+
+  //return init_complete(dpp);
+}
+
+std::string RGWMotr::get_host_id()
+{
+  return svc.zone_utils->gen_host_id();
+}
+
+std::string RGWMotr::zone_unique_id(uint64_t unique_num)
+{
+  return svc.zone_utils->unique_id(unique_num);
+}
+
+std::string RGWMotr::zone_unique_trans_id(const uint64_t unique_num)
+{
+  return svc.zone_utils->unique_trans_id(unique_num);
+}
+
+int RGWMotr::init_svc(bool raw, const DoutPrefixProvider *dpp)
+{
+  if (raw) {
+    return svc.init_raw(cct, false, null_yield, dpp);
+  }
+
+  return svc.init(cct, false, run_sync_thread, null_yield, dpp);
+}
+
+int RGWMotr::init_ctl(const DoutPrefixProvider *dpp)
+{
+  return ctl.init(&svc, dpp);
+}
+

--- a/src/rgw/rgw_motr.cc
+++ b/src/rgw/rgw_motr.cc
@@ -123,7 +123,7 @@ int RGWMotr::init_svc(bool raw, const DoutPrefixProvider *dpp)
     return svc.init_raw(cct, false, null_yield, dpp);
   }
 
-  return svc.init(cct, false, run_sync_thread, null_yield, dpp);
+  return svc.init(cct, false, false, null_yield, dpp);
 }
 
 int RGWMotr::init_ctl(const DoutPrefixProvider *dpp)

--- a/src/rgw/rgw_motr.h
+++ b/src/rgw/rgw_motr.h
@@ -36,21 +36,13 @@
 
 class RGWMotr
 {
-  bool use_gc_thread;
-  bool use_lc_thread;
-  bool quota_threads;
-  bool run_sync_thread;
-  bool run_reshard_thread;
 protected:
   CephContext *cct;
-    bool use_cache{false};
-  bool use_gc{true};
-  bool use_datacache{false};
  public:
   RGWMotr():cct(NULL),
                pctl(&ctl)
                 {} 
-   std::string host_id ="";
+  std::string host_id ="";
   int initialize(CephContext *_cct, const DoutPrefixProvider *dpp) {
     set_context(_cct);
     return initialize(dpp);
@@ -59,56 +51,12 @@ protected:
     cct = _cct;
   }
   int initialize(const DoutPrefixProvider *dpp);
-    RGWServices svc;
+  RGWServices svc;
   RGWCtl ctl;
 
   RGWCtl *pctl{nullptr};
-    int init_svc(bool raw, const DoutPrefixProvider *dpp);
+  int init_svc(bool raw, const DoutPrefixProvider *dpp);
   int init_ctl(const DoutPrefixProvider *dpp);
-
-    RGWMotr& set_use_cache(bool status) {
-    use_cache = status;
-    return *this;
-  }
-
-  RGWMotr& set_use_gc(bool status) {
-    use_gc = status;
-    return *this;
-  }
-
-  RGWMotr& set_use_datacache(bool status) {
-    use_datacache = status;
-    return *this;
-  }
-
-  bool get_use_datacache() {
-    return use_datacache;
-  }
-
-  RGWMotr& set_run_gc_thread(bool _use_gc_thread) {
-    use_gc_thread = _use_gc_thread;
-    return *this;
-  }
-
-  RGWMotr& set_run_lc_thread(bool _use_lc_thread) {
-    use_lc_thread = _use_lc_thread;
-    return *this;
-  }
-
-  RGWMotr& set_run_quota_threads(bool _run_quota_threads) {
-    quota_threads = _run_quota_threads;
-    return *this;
-  }
-
-  RGWMotr& set_run_sync_thread(bool _run_sync_thread) {
-    run_sync_thread = _run_sync_thread;
-    return *this;
-  }
-
-  RGWMotr& set_run_reshard_thread(bool _run_reshard_thread) {
-    run_reshard_thread = _run_reshard_thread;
-    return *this;
-  }
 
   uint64_t get_new_req_id() {
     return ceph::util::generate_random_number<uint64_t>();

--- a/src/rgw/rgw_motr.h
+++ b/src/rgw/rgw_motr.h
@@ -1,0 +1,122 @@
+#ifndef CEPH_RGWMOTR_H
+#define CEPH_RGWMOTR_H
+#include <functional>
+#include <boost/container/flat_map.hpp>
+
+#include "include/rados/librados.hpp"
+#include "include/Context.h"
+#include "include/random.h"
+#include "common/RefCountedObj.h"
+#include "common/ceph_time.h"
+#include "common/Timer.h"
+#include "rgw_common.h"
+#include "cls/rgw/cls_rgw_types.h"
+#include "cls/version/cls_version_types.h"
+#include "cls/log/cls_log_types.h"
+#include "cls/timeindex/cls_timeindex_types.h"
+#include "cls/otp/cls_otp_types.h"
+#include "rgw_log.h"
+#include "rgw_metadata.h"
+#include "rgw_meta_sync_status.h"
+#include "rgw_period_puller.h"
+#include "rgw_obj_manifest.h"
+#include "rgw_sync_module.h"
+#include "rgw_trim_bilog.h"
+#include "rgw_service.h"
+#include "rgw_sal.h"
+#include "rgw_aio.h"
+#include "rgw_d3n_cacherequest.h"
+
+#include "services/svc_rados.h"
+#include "services/svc_bi_rados.h"
+#include "common/Throttle.h"
+#include "common/ceph_mutex.h"
+#include "rgw_cache.h"
+
+
+class RGWMotr
+{
+  bool use_gc_thread;
+  bool use_lc_thread;
+  bool quota_threads;
+  bool run_sync_thread;
+  bool run_reshard_thread;
+protected:
+  CephContext *cct;
+    bool use_cache{false};
+  bool use_gc{true};
+  bool use_datacache{false};
+ public:
+  RGWMotr():cct(NULL),
+               pctl(&ctl)
+                {} 
+   std::string host_id ="";
+  int initialize(CephContext *_cct, const DoutPrefixProvider *dpp) {
+    set_context(_cct);
+    return initialize(dpp);
+  }
+    void set_context(CephContext *_cct) {
+    cct = _cct;
+  }
+  int initialize(const DoutPrefixProvider *dpp);
+    RGWServices svc;
+  RGWCtl ctl;
+
+  RGWCtl *pctl{nullptr};
+    int init_svc(bool raw, const DoutPrefixProvider *dpp);
+  int init_ctl(const DoutPrefixProvider *dpp);
+
+    RGWMotr& set_use_cache(bool status) {
+    use_cache = status;
+    return *this;
+  }
+
+  RGWMotr& set_use_gc(bool status) {
+    use_gc = status;
+    return *this;
+  }
+
+  RGWMotr& set_use_datacache(bool status) {
+    use_datacache = status;
+    return *this;
+  }
+
+  bool get_use_datacache() {
+    return use_datacache;
+  }
+
+  RGWMotr& set_run_gc_thread(bool _use_gc_thread) {
+    use_gc_thread = _use_gc_thread;
+    return *this;
+  }
+
+  RGWMotr& set_run_lc_thread(bool _use_lc_thread) {
+    use_lc_thread = _use_lc_thread;
+    return *this;
+  }
+
+  RGWMotr& set_run_quota_threads(bool _run_quota_threads) {
+    quota_threads = _run_quota_threads;
+    return *this;
+  }
+
+  RGWMotr& set_run_sync_thread(bool _run_sync_thread) {
+    run_sync_thread = _run_sync_thread;
+    return *this;
+  }
+
+  RGWMotr& set_run_reshard_thread(bool _run_reshard_thread) {
+    run_reshard_thread = _run_reshard_thread;
+    return *this;
+  }
+
+  uint64_t get_new_req_id() {
+    return ceph::util::generate_random_number<uint64_t>();
+  }
+  std::string zone_unique_id(uint64_t unique_num);
+  std::string zone_unique_trans_id(const uint64_t unique_num);
+  std::string get_host_id();
+
+};
+
+#endif

--- a/src/rgw/rgw_sal.cc
+++ b/src/rgw/rgw_sal.cc
@@ -118,7 +118,18 @@ rgw::sal::Store* StoreManager::init_storage_provider(const DoutPrefixProvider* d
       return store;
     }
     ((rgw::sal::MotrStore *)store)->init_metadata_cache(dpp, cct);
-
+    RGWMotr* motr = static_cast<rgw::sal::MotrStore* >(store)->getMotr();
+    if ((*motr).set_use_cache(use_cache)
+                .set_use_datacache(false)
+                .set_use_gc(use_gc)
+                .set_run_gc_thread(use_gc_thread)
+                .set_run_lc_thread(use_lc_thread)
+                .set_run_quota_threads(quota_threads)
+                .set_run_sync_thread(run_sync_thread)
+                .set_run_reshard_thread(run_reshard_thread)
+                .initialize(cct, dpp) < 0) {
+      delete store; store = nullptr;
+    }
     return store;
   }
 #endif

--- a/src/rgw/rgw_sal.cc
+++ b/src/rgw/rgw_sal.cc
@@ -119,16 +119,8 @@ rgw::sal::Store* StoreManager::init_storage_provider(const DoutPrefixProvider* d
     }
     ((rgw::sal::MotrStore *)store)->init_metadata_cache(dpp, cct);
     RGWMotr* motr = static_cast<rgw::sal::MotrStore* >(store)->getMotr();
-    if ((*motr).set_use_cache(use_cache)
-                .set_use_datacache(false)
-                .set_use_gc(use_gc)
-                .set_run_gc_thread(use_gc_thread)
-                .set_run_lc_thread(use_lc_thread)
-                .set_run_quota_threads(quota_threads)
-                .set_run_sync_thread(run_sync_thread)
-                .set_run_reshard_thread(run_reshard_thread)
-                .initialize(cct, dpp) < 0) {
-      delete store; store = nullptr;
+    if ((*motr).initialize(cct, dpp) < 0) {
+	    delete store; store = nullptr;
     }
     return store;
   }

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -491,6 +491,15 @@ int MotrUser::remove_user(const DoutPrefixProvider* dpp, optional_yield y)
       }
     }
   }
+
+  //Delete email id 
+  if (!info.user_email.empty()) {
+    rc = store->do_idx_op_by_name(RGW_IAM_MOTR_EMAIL_KEY,
+		             M0_IC_DEL, info.user_email, bl);
+    if (rc < 0 && rc != -ENOENT) {
+       ldpp_dout(dpp, 0) << "Unable to delete email id " << rc << dendl;
+    }
+  }
   
   // Delete user info index
   string user_info_iname = "motr.rgw.user.info." + info.user_id.to_str();

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -3228,12 +3228,12 @@ int MotrStore::forward_request_to_master(const DoutPrefixProvider *dpp, User* us
 
 std::string MotrStore::zone_unique_id(uint64_t unique_num)
 {
-  return "";
+  return motr->zone_unique_id(unique_num);
 }
 
 std::string MotrStore::zone_unique_trans_id(const uint64_t unique_num)
 {
-  return "";
+  return motr->zone_unique_trans_id(unique_num);
 }
 
 int MotrStore::cluster_stat(RGWClusterStat& stats)
@@ -3846,6 +3846,10 @@ void *newMotrStore(CephContext *cct)
     if (rc != 0) {
       ldout(cct, 0) << "ERROR: m0_ufid_init() failed: " << rc << dendl;
       goto out;
+    }
+    RGWMotr* motr = new RGWMotr();
+    if (motr) {
+      store->setMotr(motr);
     }
 
     // Create global indices if not yet.

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -27,6 +27,7 @@ extern "C" {
 
 #include "rgw_sal.h"
 #include "rgw_rados.h"
+#include "rgw_motr.h"
 #include "rgw_notify.h"
 #include "rgw_oidc_provider.h"
 #include "rgw_role.h"
@@ -877,6 +878,7 @@ class MotrStore : public Store {
     MotrMetaCache* obj_meta_cache;
     MotrMetaCache* user_cache;
     MotrMetaCache* bucket_inst_cache;
+    RGWMotr *motr =nullptr;
 
   public:
     CephContext *cctx;
@@ -931,7 +933,8 @@ class MotrStore : public Store {
     virtual void get_ratelimit(RGWRateLimitInfo& bucket_ratelimit, RGWRateLimitInfo& user_ratelimit, RGWRateLimitInfo& anon_ratelimit) override;
     virtual void get_quota(RGWQuotaInfo& bucket_quota, RGWQuotaInfo& user_quota) override;
     virtual int set_buckets_enabled(const DoutPrefixProvider *dpp, std::vector<rgw_bucket>& buckets, bool enabled) override;
-    virtual uint64_t get_new_req_id() override { return 0; }
+    virtual uint64_t get_new_req_id() override { return motr->get_new_req_id();}
+    RGWServices* svc() { return &motr->svc; }
     virtual int get_sync_policy_handler(const DoutPrefixProvider *dpp,
         std::optional<rgw_zone_id> zone,
         std::optional<rgw_bucket> bucket,
@@ -954,7 +957,7 @@ class MotrStore : public Store {
     virtual int meta_remove(const DoutPrefixProvider *dpp, std::string& metadata_key, optional_yield y) override;
 
     virtual const RGWSyncModuleInstanceRef& get_sync_module() { return sync_module; }
-    virtual std::string get_host_id() { return ""; }
+    virtual std::string get_host_id() { return motr->get_host_id();}
 
     virtual std::unique_ptr<LuaScriptManager> get_lua_script_manager() override;
     virtual std::unique_ptr<RGWRole> get_role(std::string name,
@@ -1029,6 +1032,8 @@ class MotrStore : public Store {
     MotrMetaCache* get_obj_meta_cache() {return obj_meta_cache;}
     MotrMetaCache* get_user_cache() {return user_cache;}
     MotrMetaCache* get_bucket_inst_cache() {return bucket_inst_cache;}
+    void setMotr(RGWMotr * st) { motr = st; }
+    RGWMotr* getMotr(void) { return motr; }
 };
 
 struct obj_time_weight {

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -936,6 +936,7 @@ class MotrStore : public Store {
     virtual int set_buckets_enabled(const DoutPrefixProvider *dpp, std::vector<rgw_bucket>& buckets, bool enabled) override;
     virtual uint64_t get_new_req_id() override { return motr->get_new_req_id();}
     RGWServices* svc() { return &motr->svc; }
+    RGWCtl* ctl(){return &motr->ctl;}
     virtual int get_sync_policy_handler(const DoutPrefixProvider *dpp,
         std::optional<rgw_zone_id> zone,
         std::optional<rgw_bucket> bucket,

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -207,6 +207,7 @@ class MotrUser : public User {
     struct m0_idx      idx;
 
   public:
+    std::set<std::string> access_key_tracker;
     MotrUser(MotrStore *_st, const rgw_user& _u) : User(_u), store(_st) { }
     MotrUser(MotrStore *_st, const RGWUserInfo& _i) : User(_i), store(_st) { }
     MotrUser(MotrStore *_st) : store(_st) { }
@@ -1026,6 +1027,7 @@ class MotrStore : public Store {
                           std::string key_str, bufferlist &bl, bool update=true);
     int check_n_create_global_indices();
     int store_access_key(const DoutPrefixProvider *dpp, optional_yield y, MotrAccessKey access_key);
+    int delete_access_key(const DoutPrefixProvider *dpp, optional_yield y, std::string access_key);
     int store_email_info(const DoutPrefixProvider *dpp, optional_yield y, MotrEmailInfo& email_info);
 
     int init_metadata_cache(const DoutPrefixProvider *dpp, CephContext *cct);


### PR DESCRIPTION
**Problem** :The response of a rest API request for user info (with an invalid access-key) does not contain Host-id and Request-id. But in the plane ceph setup, the response contains both Host-id and Request-id.

**Root Cause**: Host-id & Request-id generation is part of RGWServices and RGWServices are not accessible from MotrStore,

**Solution** : By making RGWServices available in MotrStore, we can fetch HostId and RequestId from RGWServices .
For achieving this, implement a class RGWMotr (similar to RGWRados) which contain reference to RGWServices ,
and MotrStore can have a reference to RGWMotr.

**Jira Associated** : https://jts.seagate.com/browse/CORTX-29158
                                https://jts.seagate.com/browse/CORTX-28931
<!--
  -

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
