### PR TITLE
rgw:[CORTX-29341] GET IAM user is not working as expected with multiple tenant

### DIFF
--- a/src/rgw/rgw_rest_user.cc
+++ b/src/rgw/rgw_rest_user.cc
@@ -68,9 +68,11 @@ void RGWOp_User_Info::execute(optional_yield y)
   std::string uid_str, access_key_str;
   bool fetch_stats;
   bool sync_stats;
+  std::string tenant_name;
 
   RESTArgs::get_string(s, "uid", uid_str, &uid_str);
   RESTArgs::get_string(s, "access-key", access_key_str, &access_key_str);
+  RESTArgs::get_string(s, "tenant", tenant_name, &tenant_name);
 
   // if uid was not supplied in rest argument, error out now, otherwise we'll
   // end up initializing anonymous user, for which keys.init will eventually
@@ -85,6 +87,10 @@ void RGWOp_User_Info::execute(optional_yield y)
   RESTArgs::get_bool(s, "stats", false, &fetch_stats);
 
   RESTArgs::get_bool(s, "sync", false, &sync_stats);
+
+  if (!tenant_name.empty()) {
+    uid.tenant = tenant_name;
+  }
 
   op_state.set_user_id(uid);
   op_state.set_access_key(access_key_str);

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -335,7 +335,7 @@ int MotrUser::load_user_from_idx(const DoutPrefixProvider *dpp,
   struct MotrUserInfo muinfo;
   bufferlist bl;
   ldpp_dout(dpp, 20) << "info.user_id.id = "  << info.user_id.id << dendl;
-  if (store->get_user_cache()->get(dpp, info.user_id.id, bl)) {
+  if (store->get_user_cache()->get(dpp, info.user_id.to_str(), bl)) {
     // Cache misses
     int rc = store->do_idx_op_by_name(RGW_MOTR_USERS_IDX_NAME,
                                       M0_IC_GET, info.user_id.to_str(), bl);
@@ -344,7 +344,7 @@ int MotrUser::load_user_from_idx(const DoutPrefixProvider *dpp,
         return rc;
 
     // Put into cache.
-    store->get_user_cache()->put(dpp, info.user_id.id, bl);
+    store->get_user_cache()->put(dpp, info.user_id.to_str(), bl);
   }
 
   bufferlist& blr = bl;
@@ -484,7 +484,7 @@ int MotrUser::store_user(const DoutPrefixProvider* dpp,
   }
 
   // Put the user info into cache.
-  rc = store->get_user_cache()->put(dpp, info.user_id.id, bl);
+  rc = store->get_user_cache()->put(dpp, info.user_id.to_str(), bl);
 
 out:
   return rc;


### PR DESCRIPTION
Problem :The user info command not fetching the user info
from right tenant

Root Cause: Putting the user info in to user_cache with
incorrect key & tenant name is not being populated while fetching.

Solution : added fix for pushing in to user_cache with correct key
& make sure tenant name populated correctly during the execution
of user info command.

Signed-off-by: sanalpk <sanal.kaarthikeyan@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
