### PR TITLE
rgw_sal_motr:[CORTX-29171] Fixed byte range issue in get object api

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1851,12 +1851,12 @@ int MotrObject::read_mobj(const DoutPrefixProvider* dpp, int64_t off, int64_t en
   struct m0_indexvec ext;
 
   start = off;
-  off = 0;
   // make end pointer exclusive:
   // it's easier to work with it this way
   end++;
   ldpp_dout(dpp, 20) << "MotrObject::read_mobj(): off=" << off <<
                        " end=" << end << dendl;
+  off = 0;
   // As `off` may not be parity group size aligned, even using optimal
   // buffer block size, simply reading data from offset `off` could come
   // across parity group boundary. And Motr only allows page-size aligned
@@ -1896,9 +1896,10 @@ int MotrObject::read_mobj(const DoutPrefixProvider* dpp, int64_t off, int64_t en
     left -= actual;
     // Read from Motr.
     op = nullptr;
-    if( start > (block_start_off + bs))
+    if( start >= ( block_start_off + bs )) 
     {
 	block_start_off += bs;
+	ldpp_dout(dpp, 70) << "MotrObject::read_mobj(): block_start_off=" << block_start_off <<dendl;
 	continue;
     }
     if( bloff != 0 )


### PR DESCRIPTION
Signed-off-by: dharmendra-jyani <dharmendra.jyani@seagate.com>

## Problem Statement
If we are giving byte range from 0 to any random number then get object is working, but if we are giving the range from non zero value then get object api is not working. Giving error "No Such Key"

## Fix
![BS-image](https://user-images.githubusercontent.com/91260838/158534755-a076eecf-db69-4107-bc12-f432852978b3.png)

In normal get object API, motr reads in block size, here in diagram suppose our object is being divided into 6 blocks, motr will start reading from 0th offset and reads block by block and pass it to the client.
Now take an example of byte range:-
Suppose the starting offset is present in block 1 and end offset is present in block4.  We have to to send the data from particular offset,  first we have to read the whole block and once we get the whole block from the motr we will pass the data from particular offset to the client.

## Parent Story
https://jts.seagate.com/browse/CORTX-29171

## Testing Done

1.   [root@ssc-vm-g4-rhev4-0761 ~]# aws s3api get-object --bucket testbucket3 --key anaconda  --range bytes=1-2 anac2
{
    "AcceptRanges": "bytes",
    "LastModified": "Fri, 18 Feb 2022 13:01:50 GMT",
    "ContentLength": 2,
    "ETag": "\"9f907f83a6a8658212e21cb147e91841\"",
    "ContentRange": "bytes 1-2/2058",
    "ContentType": "binary/octet-stream",
    "Metadata": {}
}

2. [root@ssc-vm-g4-rhev4-0761 ~]# aws s3api get-object --bucket testbucket3 --key anaconda  --range bytes=2-28 anac2
{
    "AcceptRanges": "bytes",
    "LastModified": "Fri, 18 Feb 2022 13:01:50 GMT",
    "ContentLength": 27,
    "ETag": "\"9f907f83a6a8658212e21cb147e91841\"",
    "ContentRange": "bytes 2-28/2058",
    "ContentType": "binary/octet-stream",
    "Metadata": {}
}
3. [root@ssc-vm-g4-rhev4-0761 ~]# aws s3api get-object --bucket testbucket3 --key anaconda  --range bytes=125-2451 anac2
{
    "AcceptRanges": "bytes",
    "LastModified": "Fri, 18 Feb 2022 13:01:50 GMT",
    "ContentLength": 1933,
    "ETag": "\"9f907f83a6a8658212e21cb147e91841\"",
    "ContentRange": "bytes 125-2057/2058",
    "ContentType": "binary/octet-stream",
    "Metadata": {}
}




## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests


