### PR TITLE
rgw_sal_motr: [CORTX-29221] Fix corner/negative cases in Multipart ListParts API

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -2675,7 +2675,10 @@ int MotrMultipartUpload::list_parts(const DoutPrefixProvider *dpp, CephContext *
 				     int *next_marker, bool *truncated,
 				     bool assume_unsorted)
 {
-  int rc;
+  int rc = 0;
+  if (num_parts <= 0 or marker < 0)
+    return rc;
+
   vector<string> key_vec(num_parts);
   vector<bufferlist> val_vec(num_parts);
 


### PR DESCRIPTION
# Change Summary

Problem:
When Multipart ListParts API is invoked using aws s3api command with invalid values for parameters like, max-items, page-size, max-parts, inconsistent results are displayed to the end user. The issue is parameter validation (check for -ve and zero value was not in place).

Resolution:
Added code to handle negative and zero values to the parameters in "aws s3api list-parts" command line.  This should avoid RGW application crash.

## Parent Story
_[CORTX-29221](https://jts.seagate.com/browse/CORTX-29221):_
_Multipart Part Listing API negative/corner cases handling_

## Sub Tasks covered in this PR
NA

## Exclusions in Implementation :
NA.

## Implementation/Current Flow :
Added code to handle 0 and -ve value checking of parameters in aws s3api list-parts command.

## Testing Done : 

<details>
  <summary> **Case 1 : Invoke aws s3api list-parts with max-parts 0 and negative values** </summary>
The response is consistent with S3 standard, with basic information in response and no parts details. No RGW application crash is seen.
</details>

<details>
  <summary> **Case 2 : Invoke aws s3api list-parts with page-size 0 and negative values** </summary>
The response is consistent with S3 standard, with basic information in response and no parts details. No RGW application crash is seen.
</details>

<details>
  <summary> **Case 3 : Invoke aws s3api list-parts with max-items 0 and negative values** </summary>
The response is consistent with S3 standard, with basic information in response when max-items is 0. When max-items is -ve, the response shows first (1000 - (negative numerical value)) parts and their details. No RGW application crash is seen.
</details>

<details>
  <summary> **Case 4 : Invoke aws s3api list-parts with max-parts value as 1001/1002 values, when there are total 1004 parts available** </summary>
The response shows details of first 1000 parts only.
</details>


Signed-off-by: Dattaprasad Govekar <dattaprasad.govekar@seagate.com>

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
