### PR TITLE
rgw_sal_motr: [CORTX-29411] Fix ListParts API for non-consecutive parts

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -2699,7 +2699,6 @@ int MotrMultipartUpload::list_parts(const DoutPrefixProvider *dpp, CephContext *
 
   int last_num = 0;
   int part_cnt = 0;
-  uint32_t expected_next = 0;
   ldpp_dout(dpp, 20) << __func__ << ": marker = " << marker << dendl;
   for (const auto& bl: val_vec) {
     if (bl.length() == 0)
@@ -2718,12 +2717,6 @@ int MotrMultipartUpload::list_parts(const DoutPrefixProvider *dpp, CephContext *
     ldpp_dout(dpp, 20) << __func__ << ": meta:oid=[" << meta.oid.u_hi << "," << meta.oid.u_lo
                                               << "], meta:pvid=[" << meta.pver.f_container << "," << meta.pver.f_key
                                               << "], meta:layout id=" << meta.layout_id << dendl;
-
-    if (!expected_next)
-      expected_next = info.num + 1;
-    else if (expected_next && info.num != expected_next)
-      return -EINVAL;
-    else expected_next = info.num + 1;
 
     if ((int)info.num > marker) {
       last_num = info.num;


### PR DESCRIPTION
**Bug:** https://jts.seagate.com/browse/CORTX-29411

**Problem & RCA:** 
* In ListParts API we are validating for `curr_part_number == prev_part_number + 1`.
* If we have uploaded parts 1 and 10000, then the List Part API errors out as the part numbers are not consecutive.
This is not an expected behaviour.

**Solution:** 
* `expected_next` part number is used in Rados to differentiate between sorted and unsorted keys. If the keys are not consecutive then the gateway does not support sorted_omap. 
* Motr KVS on the other hand has all the keys sorted and there is no effect of non-consecutive keys on reading them.
* so there seems no need to keep track of the `expected_next` variable
* Removing the code related to `expected_next` variable.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
