### PR TITLE
rgw: [CORTX-28931] HostId/RequestId generation for sal layer

### DIFF
--- a/src/rgw/rgw_rest_user.cc
+++ b/src/rgw/rgw_rest_user.cc
@@ -68,9 +68,11 @@ void RGWOp_User_Info::execute(optional_yield y)
   std::string uid_str, access_key_str;
   bool fetch_stats;
   bool sync_stats;
+  std::string tenant_name;
 
   RESTArgs::get_string(s, "uid", uid_str, &uid_str);
   RESTArgs::get_string(s, "access-key", access_key_str, &access_key_str);
+  RESTArgs::get_string(s, "tenant", tenant_name, &tenant_name);
 
   // if uid was not supplied in rest argument, error out now, otherwise we'll
   // end up initializing anonymous user, for which keys.init will eventually
@@ -85,6 +87,10 @@ void RGWOp_User_Info::execute(optional_yield y)
   RESTArgs::get_bool(s, "stats", false, &fetch_stats);
 
   RESTArgs::get_bool(s, "sync", false, &sync_stats);
+
+  if (!tenant_name.empty()) {
+    uid.tenant = tenant_name;
+  }
 
   op_state.set_user_id(uid);
   op_state.set_access_key(access_key_str);

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -3894,6 +3894,8 @@ void *newMotrStore(CephContext *cct)
     const auto& admin_proc_ep  = g_conf().get_val<std::string>("motr_admin_endpoint");
     const auto& admin_proc_fid = g_conf().get_val<std::string>("motr_admin_fid");
     const int init_flags = cct->get_init_flags();
+    store->mc_utils.instance_id = proc_fid;
+    store->mc_utils.proc_ep = proc_ep;
     ldout(cct, 0) << "INFO: motr my endpoint: " << proc_ep << dendl;
     ldout(cct, 0) << "INFO: motr ha endpoint: " << ha_ep << dendl;
     ldout(cct, 0) << "INFO: motr my fid:      " << proc_fid << dendl;

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -198,7 +198,36 @@ class MotrNotification : public Notification {
     virtual int publish_commit(const DoutPrefixProvider* dpp, uint64_t size,
 			       const ceph::real_time& mtime, const std::string& etag, const std::string& version) override { return 0; }
 };
+struct MotrCommonUtils {
+  std::string zone_name;
+  std::string zone_group;
+  std::string instance_id;
+  std::string proc_ep;
+  MotrCommonUtils()
+  {
+    zone_name = "default";
+    zone_group = "default";
+    instance_id = "default";
+    proc_ep = "0.0.0.0";
+  }
+  std::string gen_host_id()
+  {
+    std::size_t pos = proc_ep.find("@");
+    std::string ipaddr = proc_ep.substr (9,pos-9);
+    return ipaddr +":"+instance_id;
+  }
+  std::string gen_trans_id(uint64_t unique_num)
+  {
+    char buf[41]; /* 2 + 21 + 1 + 16 (timestamp can consume up to 16) + 1 */
+    time_t timestamp = time(NULL);
 
+    snprintf(buf, sizeof(buf), "tx%021llx-%016llx",
+              (unsigned long long)unique_num,
+             (unsigned long long)timestamp);
+    return std::string(buf);
+
+  }
+};
 class MotrUser : public User {
   private:
     MotrStore         *store;
@@ -886,7 +915,7 @@ class MotrStore : public Store {
     struct m0_realm     uber_realm;
     struct m0_config    conf = {};
     struct m0_idx_dix_config dix_conf = {};
-
+    struct MotrCommonUtils mc_utils;
     MotrStore(CephContext *c): zone(this), cctx(c) {}
     ~MotrStore() {
       delete obj_meta_cache;
@@ -955,7 +984,9 @@ class MotrStore : public Store {
     virtual int meta_remove(const DoutPrefixProvider *dpp, std::string& metadata_key, optional_yield y) override;
 
     virtual const RGWSyncModuleInstanceRef& get_sync_module() { return sync_module; }
-    virtual std::string get_host_id() { return ""; }
+    virtual std::string get_host_id() {
+      return mc_utils.gen_host_id();
+    }
 
     virtual std::unique_ptr<LuaScriptManager> get_lua_script_manager() override;
     virtual std::unique_ptr<RGWRole> get_role(std::string name,


### PR DESCRIPTION
**Problem** : HostId/RequestId is not present in the invalid response

Root Cause: HostId/RequestId generation is part of RGWService, 
which is not present in the MotrStore

**Solution** : added logic to generate HostId/RequestId
As per the implementation HostId is a combination of host ip
and motr fid.
RequestId is a combination of a unique number & time stamp.

Newly generated HostId/RequestId in the response looks like below
Response Content is: {"Code":"InvalidAccessKeyId",
"**RequestId":"tx0000000000000fffffffe-0000000062348871**",
"**HostId":"192.168.53.171:0x7200000000000001:0x29**"}

**Jira Assosiated** :https://jts.seagate.com/browse/CORTX-28931

Signed-off-by: sanalpk <sanal.kaarthikeyan@seagate.com>






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
