### PR TITLE
rgw: [CORTX-28931] HostId/RequestId generation for sal motr [DRAFT]

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -3368,7 +3368,9 @@ std::string MotrStore::zone_unique_id(uint64_t unique_num)
 
 std::string MotrStore::zone_unique_trans_id(const uint64_t unique_num)
 {
-  return "";
+  static uint64_t num = 0xffffffff;
+  num = num -1;
+  return mc_utils.gen_trans_id(num);
 }
 
 int MotrStore::cluster_stat(RGWClusterStat& stats)
@@ -3938,6 +3940,8 @@ void *newMotrStore(CephContext *cct)
     const auto& admin_proc_ep  = g_conf().get_val<std::string>("motr_admin_endpoint");
     const auto& admin_proc_fid = g_conf().get_val<std::string>("motr_admin_fid");
     const int init_flags = cct->get_init_flags();
+    store->mc_utils.instance_id = proc_fid;
+    store->mc_utils.proc_ep = proc_ep;
     ldout(cct, 0) << "INFO: motr my endpoint: " << proc_ep << dendl;
     ldout(cct, 0) << "INFO: motr ha endpoint: " << ha_ep << dendl;
     ldout(cct, 0) << "INFO: motr my fid:      " << proc_fid << dendl;


### PR DESCRIPTION
**Problem** : HostId/RequestId is not present in the invalid response

**Root Cause**: HostId/RequestId generation is part of RGWService,
which is not present in the MotrStore

**Solution** : added logic to generate HostId/RequestId
As per the implementation HostId is a combination of host ip
and motr fid.
RequestId is a combination of a unique number & time stamp.

Newly generated HostId/RequestId in the response looks like below
Response Content is: {"Code":"InvalidAccessKeyId",
"RequestId":"tx0000000000000fffffffe-0000000062348871",
"HostId":"192.168.53.171:0x7200000000000001:0x29"}

**Jira Assosiated** :https://jts.seagate.com/browse/CORTX-28931
**Reference** : https://seagate-systems.atlassian.net/wiki/spaces/PRIVATECOR/pages/942342290/HostId+RequestId+generation+for+Invalid+Responses

Signed-off-by: sanalpk [sanal.kaarthikeyan@seagate.com](mailto:sanal.kaarthikeyan@seagate.com)


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
