### PR TITLE
rgw_sal_motr: [CORTX-29019] Instrument RGW with ADDB probes

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -3308,6 +3308,13 @@ options:
   default: false
   services:
   - rgw
+- name: motr_addb_enabled
+  type: bool
+  level: advanced
+  desc: Set to true when Motr client ADDB is needed
+  default: false
+  services:
+  - rgw
 - name: rgw_luarocks_location
   type: str
   level: advanced

--- a/src/rgw/motr/addb/README.md
+++ b/src/rgw/motr/addb/README.md
@@ -1,0 +1,17 @@
+ADDB is Motr sub-system, which provides convenient way for system events logging. ADDB is integrated and used by rgw_sal_motr.cc, while other RGW related code is not affected. Using ADDB allows to map S3 requests to subsequent Motr calls, that can be used for analysis and debugging purposes.
+rgw_sal_motr.cc is instumented with ADDB() calls, which add entries into so-called ADDB storage object (ADDB stob). Entries are added in binary format and can be parsed to human-readable format by invoking `m0addb2dump` utility and RGW ADDB plugin, that allows to map binary entries to corresponding layer ID and parameters.
+`m0addb2utility` can found after standard installation of cortx-motr rpm, and RGW ADDB plugin (rgw_addb_plugin.so) is installed during cortx-rgw-integration rpm installation to /opt/seagate/cortx/rgw/bin path.
+RGW ADDB plugin can be compiled manually:
+```
+# git clone https://github.com/Seagate/cortx-rgw-integration
+# cd cortx-rgw-integration
+# cd src/addb_plugin
+# make plugin
+```
+
+Standard usage of RGW ADDB assumes its automatic conversion using PerfLine utility (Seagte CORTX utility for automatic performance runs).
+ADDB stob can be converted manually by execution of the following command:
+`# m0addb2dump -f -p /opt/seagate/cortx/rgw/bin/rgw_addb_plugin.so -- addb_12345/o/100000000000000:2 > dumpr_1.txt`
+
+cortx-motr repo: https://github.com/Seagate/cortx-motr
+cortx-rgw-integration repo: https://github.com/Seagate/cortx-rgw-integration

--- a/src/rgw/motr/addb/rgw_addb.h
+++ b/src/rgw/motr/addb/rgw_addb.h
@@ -1,0 +1,60 @@
+/*
+ * Ceph - scalable distributed file system
+ *
+ * RGW ADDB macro for ADDB probes.
+ *
+ * Copyright (C) 2022 Seagate Technology LLC and/or its Affiliates
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#pragma once
+
+#ifndef __RGW_ADDB_H__
+#define __RGW_ADDB_H__
+
+#include <addb2/addb2_internal.h>
+
+#define ADDB(_addb_id, ...)                                      \
+  do {                                                           \
+    uint64_t addb_params__[] = {__VA_ARGS__};                    \
+    constexpr auto addb_params_size__ =                          \
+      sizeof addb_params__ / sizeof addb_params__[0];            \
+    m0_addb2_add(_addb_id, addb_params_size__, addb_params__);   \
+  } while (false)
+
+enum RGWAddbId {
+  RGW_ADDB_RANGE_START = M0_ADDB2__EXT_RANGE_1,
+  RGW_ADDB_MEASUREMENT_ID = RGW_ADDB_RANGE_START,
+  RGW_ADDB_REQUEST_ID,
+  RGW_ADDB_REQUEST_OPCODE_ID,
+  RGW_ADDB_REQUEST_TO_MOTR_ID,
+  RGW_ADDB_LAST_REQUEST_ID = RGW_ADDB_REQUEST_TO_MOTR_ID,
+  RGW_ADDB_RANGE_END = RGW_ADDB_LAST_REQUEST_ID
+};
+
+enum RGWAddbPhaseCode {
+  RGW_ADDB_PHASE_START,
+  RGW_ADDB_PHASE_ERROR,
+  RGW_ADDB_PHASE_DONE,
+};
+
+enum RGWAddbFuncName {
+  RGW_ADDB_FUNC_CREATE_MOBJ,
+  RGW_ADDB_FUNC_OPEN_MOBJ,
+  RGW_ADDB_FUNC_DELETE_MOBJ,
+  RGW_ADDB_FUNC_WRITE_MOBJ,
+  RGW_ADDB_FUNC_READ_MOBJ,
+  RGW_ADDB_FUNC_WRITE,
+  RGW_ADDB_FUNC_GET_NEW_REQ_ID,
+  RGW_ADDB_FUNC_DO_IDX_OP,
+  RGW_ADDB_FUNC_DO_IDX_NEXT_OP,
+  RGW_ADDB_FUNC_DELETE_IDX_BY_NAME,
+  RGW_ADDB_FUNC_CREATE_IDX_BY_NAME,
+};
+
+#endif

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -728,6 +728,8 @@ class MotrAtomicWriter : public Writer {
   struct m0_bufvec attr;
   struct m0_indexvec ext;
 
+  uint64_t req_id;
+
   public:
   MotrAtomicWriter(const DoutPrefixProvider *dpp,
           optional_yield y,


### PR DESCRIPTION
Problem: RGW SAL Motr code and incoming RGW requests shall be
instrumented with ADDB probes to reconstruct io-path in scope of
debugging and performance-related work.

Solution: Basic Motr SAL operations (open/write/read/close/delete_obj
and do_idx_op) are instumented with ADDB probes. Handled three types of
operations: S3 Put, S3 Get and S3 Delete multiple objects.

ADDB is Motr sub-system designed for collecting system information
for further analysis. ADDB stands for Analytic and Diagnostic Data-Base.
ADDB probes, added into RGW code, are saved into binary file during RGW
execution and can be converted into human-readable format for
post-execution analysis. Typical ADDB record contains timestamp,
sub-system id (Motr client, CAS, RPC, ...) and passed parameters.

Signed-off-by: Maxim Malezhin <maxim.malezhin@seagate.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
