### PR TITLE
rgw_sal_motr: [CORTX-29534] Fix rgw server crash due to lib Motr assert

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -3737,7 +3737,7 @@ out:
 
 int MotrStore::delete_motr_idx_by_name(string iname)
 {
-  struct m0_idx idx;
+  struct m0_idx idx = {};
   struct m0_uint128 idx_id;
   struct m0_op *op = nullptr;
 
@@ -3809,7 +3809,7 @@ void MotrStore::index_name_to_motr_fid(string iname, struct m0_uint128 *id)
 int MotrStore::do_idx_op_by_name(string idx_name, enum m0_idx_opcode opcode,
                                  string key_str, bufferlist &bl, bool update)
 {
-  struct m0_idx idx;
+  struct m0_idx idx = {};
   vector<uint8_t> key(key_str.begin(), key_str.end());
   vector<uint8_t> val;
   struct m0_uint128 idx_id;


### PR DESCRIPTION
Problem:
Due to invalid/junk values of pv id and layout type in some index operations (due to uninitialized variable of type struct m0_idx), lib Motr raises assert, causing rgw server to crash. 

Resolution:
The fix initializes "struct m0_idx idx", so that pv id and layout type are set to 0 during lib Motr index operations.

Signed-off-by: Dattaprasad Govekar <dattaprasad.govekar@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
