### PR TITLE
rgw_sal_motr: [CORTX-29526] fix memleaks in MotrZone

### DIFF
--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -435,7 +435,13 @@ class MotrZone : public Zone {
       info.storage_classes = sc;
       zone_params->placement_pools["default"] = info;
     }
-    ~MotrZone() = default;
+    ~MotrZone() {
+      delete current_period;
+      delete zone_params;
+      delete zone_public_config;
+      delete zonegroup;
+      delete realm;
+    };
 
     virtual const RGWZoneGroup& get_zonegroup() override;
     virtual int get_zonegroup(const std::string& id, RGWZoneGroup& zonegroup) override;


### PR DESCRIPTION
## Problem Statment
There are many memory leaks reported in rgw server by valgrind. It points to the memory allcations done in MotrZone class, that is not released in the destructor.

```
==3606169== 176 bytes in 1 blocks are indirectly lost in loss record 27 of 53
==3606169==    at 0x4C36B6F: operator new[](unsigned long) (vg_replace_malloc.c:640)
==3606169==    by 0x552719C: allocate (new_allocator.h:111)
==3606169==    by 0x552719C: allocate (alloc_traits.h:436)
==3606169==    by 0x552719C: _M_get_node (stl_tree.h:588)
==3606169==    by 0x552719C: _M_create_node<const std::piecewise_construct_t&, std::tuple<const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&>, std::tuple<> >
 (stl_tree.h:642)
==3606169==    by 0x552719C: std::_Rb_tree_iterator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::
allocator<char> > const, RGWZoneStorageClass> > std::_Rb_tree<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, RGWZoneStorageClass>, std::_Select1st<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, RGWZoneStorageClass> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, RGWZoneStorageClass> > >::_M_emplace_hint_unique<std::piecewise_construct_t const&, std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>, std::tuple<> >(std::_Rb_tree_const_iterator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, RGWZoneStorageClass> >, std::piecewise_construct_t const&, std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>&&, std::tuple<>&&) (stl_tree.h:2421)
==3606169==    by 0x55272EE: std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, RGWZoneStorageClass, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, RGWZoneStorageClass> > >::operator[](std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (stl_map.h:499)
==3606169==    by 0x5A0BF1A: RGWZoneStorageClasses (rgw_zone.h:194)
==3606169==    by 0x5A0BF1A: RGWZonePlacementInfo (rgw_zone.h:279)
==3606169==    by 0x5A0BF1A: pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&, 0> (tuple:1668)
==3606169==    by 0x5A0BF1A: pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&> (tuple:1657)
==3606169==    by 0x5A0BF1A: construct<std::pair<const std::__cxx11::basic_string<char>, RGWZonePlacementInfo>, const std::piecewise_construct_t&, std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&>, std::tuple<> > (new_allocator.h:136)
==3606169==    by 0x5A0BF1A: construct<std::pair<const std::__cxx11::basic_string<char>, RGWZonePlacementInfo>, const std::piecewise_construct_t&, std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&>, std::tuple<> > (alloc_traits.h:475)
==3606169==    by 0x5A0BF1A: _M_construct_node<const std::piecewise_construct_t&, std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&>, std::tuple<> > (stl_tree.h:626)
==3606169==    by 0x5A0BF1A: _M_create_node<const std::piecewise_construct_t&, std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&>, std::tuple<> > (stl_tree.h:643)
==3606169==    by 0x5A0BF1A: std::_Rb_tree_iterator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, RGWZonePlacementInfo> > std::_Rb_tree<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, RGWZonePlacementInfo>, std::_Select1st<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, RGWZonePlacementInfo> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, RGWZonePlacementInfo> > >::_M_emplace_hint_unique<std::piecewise_construct_t const&, std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&>, std::tuple<> >(std::_Rb_tree_const_iterator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, RGWZonePlacementInfo> >, std::piecewise_construct_t const&, std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&>&&, std::tuple<>&&) (stl_tree.h:2421)
==3606169==    by 0x5AE6F00: operator[] (stl_map.h:518)
==3606169==    by 0x5AE6F00: rgw::sal::MotrZone::MotrZone(rgw::sal::MotrStore*) (rgw_sal_motr.h:436)
==3606169==    by 0x5ADBA3D: MotrStore (rgw_sal_motr.h:890)
==3606169==    by 0x5ADBA3D: newMotrStore (rgw_sal_motr.cc:3921)
==3606169==    by 0x5964212: StoreManager::init_storage_provider(DoutPrefixProvider const*, ceph::common::CephContext*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, bool, bool, bool, bool, bool, bool) (rgw_sal.cc:115)
==3606169==    by 0x549E549: get_storage (rgw_sal.h:1456)
==3606169==    by 0x549E549: radosgw_Main(int, char const**) (rgw_main.cc:370)
==3606169==    by 0x182A71: main (radosgw.cc:12)
```

## Solution
Release the memory in the destructor of MotrZone class.



Signed-off-by: saurabh jain <saurabh.jain2@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
