### PR TITLE
rgw: [CORTX-28064] Enable store specific implementation for user list

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -8166,52 +8166,42 @@ next:
     if (opt_cmd == OPT::USER_LIST) {
       metadata_key = "user";
     }
-    void *handle;
-    int max = 1000;
-    int ret = store->meta_list_keys_init(dpp(), metadata_key, marker, &handle);
-    if (ret < 0) {
-      cerr << "ERROR: can't get key: " << cpp_strerror(-ret) << std::endl;
-      return -ret;
-    }
 
-    bool truncated;
+    bool truncated = false;
+    void *handle;
     uint64_t count = 0;
+    std::list<std::string> users;
 
     if (max_entries_specified) {
       formatter->open_object_section("result");
+      truncated = true;
     }
     formatter->open_array_section("keys");
-
-    uint64_t left;
-    do {
-      list<string> keys;
-      left = (max_entries_specified ? max_entries - count : max);
-      ret = store->meta_list_keys_next(dpp(), handle, left, keys, &truncated);
-      if (ret < 0 && ret != -ENOENT) {
-        cerr << "ERROR: lists_keys_next(): " << cpp_strerror(-ret) << std::endl;
-        return -ret;
-      } if (ret != -ENOENT) {
-	for (list<string>::iterator iter = keys.begin(); iter != keys.end(); ++iter) {
-	  formatter->dump_string("key", *iter);
-          ++count;
-	}
-	formatter->flush(cout);
+    
+    int ret = store->list_user(dpp(), metadata_key, marker, max_entries, handle, users);
+     if (ret < 0) {
+      cerr << "ERROR: can't get key: " << cpp_strerror(-ret) << std::endl;
+      return -ret;
+    }
+    if (ret != -ENOENT) {
+      for (list<string>::iterator iter = users.begin(); iter != users.end(); ++iter){
+        formatter->dump_string("key", *iter);
+        ++count;
       }
-    } while (truncated && left > 0);
-
+      formatter->flush(cout);
+    }
     formatter->close_section();
 
     if (max_entries_specified) {
       encode_json("truncated", truncated, formatter.get());
       encode_json("count", count, formatter.get());
       if (truncated) {
-        encode_json("marker", store->meta_get_marker(handle), formatter.get());
+        if(handle)
+          encode_json("marker", store->meta_get_marker(handle), formatter.get());
       }
       formatter->close_section();
     }
     formatter->flush(cout);
-
-    store->meta_list_keys_complete(handle);
   }
 
   if (opt_cmd == OPT::MDLOG_LIST) {

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -350,6 +350,10 @@ class Store {
     virtual std::string meta_get_marker(void* handle) = 0;
     /** Remove a specific metadata key */
     virtual int meta_remove(const DoutPrefixProvider* dpp, std::string& metadata_key, optional_yield y) = 0;
+    /** Get list of users */
+    virtual int list_user(const DoutPrefixProvider* dpp, const std::string& metadata_key,
+                        const std::string& marker, int max_entries, void *&handle,
+                        std::list<std::string>& users) = 0;
     /** Get an instance of the Sync module for bucket sync */
     virtual const RGWSyncModuleInstanceRef& get_sync_module() = 0;
     /** Get the ID of the current host */

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -351,9 +351,9 @@ class Store {
     /** Remove a specific metadata key */
     virtual int meta_remove(const DoutPrefixProvider* dpp, std::string& metadata_key, optional_yield y) = 0;
     /** Get list of users */
-    virtual int list_user(const DoutPrefixProvider* dpp, const std::string& metadata_key,
-                        const std::string& marker, int max_entries, void *&handle,
-                        std::list<std::string>& users) = 0;
+    virtual int list_users(const DoutPrefixProvider* dpp, const std::string& metadata_key,
+                        std::string& marker, int max_entries, void *&handle,
+                        bool* truncated, std::list<std::string>& users) = 0;
     /** Get an instance of the Sync module for bucket sync */
     virtual const RGWSyncModuleInstanceRef& get_sync_module() = 0;
     /** Get the ID of the current host */

--- a/src/rgw/rgw_sal_dbstore.cc
+++ b/src/rgw/rgw_sal_dbstore.cc
@@ -1891,9 +1891,9 @@ namespace rgw::sal {
   {
     return 0;
   }
-  int DBStore::list_user(const DoutPrefixProvider* dpp, const std::string& metadata_key,
-                        const std::string& marker, int max_entries, void *&handle,
-                        std::list<std::string>& users)
+  int DBStore::list_users(const DoutPrefixProvider* dpp, const std::string& metadata_key,
+                        std::string& marker, int max_entries, void *&handle,
+                        bool* truncated, std::list<std::string>& users)
   {
     return 0;
   }

--- a/src/rgw/rgw_sal_dbstore.cc
+++ b/src/rgw/rgw_sal_dbstore.cc
@@ -1891,6 +1891,12 @@ namespace rgw::sal {
   {
     return 0;
   }
+  int DBStore::list_user(const DoutPrefixProvider* dpp, const std::string& metadata_key,
+                        const std::string& marker, int max_entries, void *&handle,
+                        std::list<std::string>& users)
+  {
+    return 0;
+  }
 
   int DBStore::initialize(CephContext *_cct, const DoutPrefixProvider *_dpp) {
     int ret = 0;

--- a/src/rgw/rgw_sal_dbstore.h
+++ b/src/rgw/rgw_sal_dbstore.h
@@ -694,7 +694,9 @@ public:
       virtual const char* get_name() const override {
         return "dbstore";
       }
-
+      virtual int list_user(const DoutPrefixProvider* dpp, const std::string& metadata_key,
+                        const std::string& marker, int max_entries, void *&handle,
+                        std::list<std::string>& users) override;
       virtual std::unique_ptr<User> get_user(const rgw_user& u) override;
       virtual int get_user_by_access_key(const DoutPrefixProvider *dpp, const std::string& key, optional_yield y, std::unique_ptr<User>* user) override;
       virtual int get_user_by_email(const DoutPrefixProvider *dpp, const std::string& email, optional_yield y, std::unique_ptr<User>* user) override;

--- a/src/rgw/rgw_sal_dbstore.h
+++ b/src/rgw/rgw_sal_dbstore.h
@@ -694,9 +694,10 @@ public:
       virtual const char* get_name() const override {
         return "dbstore";
       }
-      virtual int list_user(const DoutPrefixProvider* dpp, const std::string& metadata_key,
-                        const std::string& marker, int max_entries, void *&handle,
-                        std::list<std::string>& users) override;
+
+      virtual int list_users(const DoutPrefixProvider* dpp, const std::string& metadata_key,
+                        std::string& marker, int max_entries, void *&handle,
+                        bool* truncated, std::list<std::string>& users) override;
       virtual std::unique_ptr<User> get_user(const rgw_user& u) override;
       virtual int get_user_by_access_key(const DoutPrefixProvider *dpp, const std::string& key, optional_yield y, std::unique_ptr<User>* user) override;
       virtual int get_user_by_email(const DoutPrefixProvider *dpp, const std::string& email, optional_yield y, std::unique_ptr<User>* user) override;

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -3489,6 +3489,12 @@ int MotrStore::meta_remove(const DoutPrefixProvider *dpp, string& metadata_key, 
 {
   return 0;
 }
+int MotrStore::list_user(const DoutPrefixProvider* dpp, const std::string& metadata_key,
+                        const std::string& marker, int max_entries, void *&handle,
+                        std::list<std::string>& users)
+{
+    return 0;
+}
 
 int MotrStore::open_idx(struct m0_uint128 *id, bool create, struct m0_idx *idx)
 {

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -3489,9 +3489,9 @@ int MotrStore::meta_remove(const DoutPrefixProvider *dpp, string& metadata_key, 
 {
   return 0;
 }
-int MotrStore::list_user(const DoutPrefixProvider* dpp, const std::string& metadata_key,
-                        const std::string& marker, int max_entries, void *&handle,
-                        std::list<std::string>& users)
+int MotrStore::list_users(const DoutPrefixProvider* dpp, const std::string& metadata_key,
+                        std::string& marker, int max_entries, void *&handle,
+                        bool* truncated, std::list<std::string>& users)
 {
     return 0;
 }

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -903,9 +903,10 @@ class MotrStore : public Store {
     virtual const char* get_name() const override {
       return "motr";
     }
-    virtual int list_user(const DoutPrefixProvider* dpp, const std::string& metadata_key,
-                        const std::string& marker, int max_entries, void *&handle,
-                        std::list<std::string>& users) override;
+
+    virtual int list_users(const DoutPrefixProvider* dpp, const std::string& metadata_key,
+                        std::string& marker, int max_entries, void *&handle,
+                        bool* truncated, std::list<std::string>& users) override;
     virtual std::unique_ptr<User> get_user(const rgw_user& u) override;
     virtual std::string get_cluster_id(const DoutPrefixProvider* dpp,  optional_yield y) override;
     virtual int get_user_by_access_key(const DoutPrefixProvider *dpp, const std::string& key, optional_yield y, std::unique_ptr<User>* user) override;

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -903,7 +903,9 @@ class MotrStore : public Store {
     virtual const char* get_name() const override {
       return "motr";
     }
-
+    virtual int list_user(const DoutPrefixProvider* dpp, const std::string& metadata_key,
+                        const std::string& marker, int max_entries, void *&handle,
+                        std::list<std::string>& users) override;
     virtual std::unique_ptr<User> get_user(const rgw_user& u) override;
     virtual std::string get_cluster_id(const DoutPrefixProvider* dpp,  optional_yield y) override;
     virtual int get_user_by_access_key(const DoutPrefixProvider *dpp, const std::string& key, optional_yield y, std::unique_ptr<User>* user) override;

--- a/src/rgw/rgw_sal_rados.cc
+++ b/src/rgw/rgw_sal_rados.cc
@@ -1300,30 +1300,34 @@ int RadosStore::meta_remove(const DoutPrefixProvider* dpp, std::string& metadata
   return ctl()->meta.mgr->remove(metadata_key, y, dpp);
 }
 
-int RadosStore::list_user(const DoutPrefixProvider *dpp, const std::string& metadata_key,
-                        const std::string& marker, int max_entries, void *&handle,
-                        std::list<std::string>& users)
+int RadosStore::list_users(const DoutPrefixProvider *dpp, const std::string& metadata_key,
+                        std::string& marker, int max_entries, void *&handle,
+                        bool* truncated, std::list<std::string>& users)
 {
   int max = 1000;
   uint64_t left;
   uint64_t count = 0;
-  bool truncated = (max_entries!= -1 ? true : false);
 
+  if (max_entries > max) {
+      max_entries = max;
+  }
   int ret = meta_list_keys_init(dpp, metadata_key, marker, &handle);
   if (ret < 0){
-    return -ret;
+    return ret;
   }
   do {
-    left = ((max_entries!= -1) ? max_entries - count : max);
-    ret = meta_list_keys_next(dpp, handle, left, users, &truncated);
+    std::list<std::string> keys;
+    left = ((max_entries > 0) ? max_entries - count : max);
+    ret = meta_list_keys_next(dpp, handle, left, keys, truncated);
     if (ret < 0 && ret != -ENOENT) {
-      return -ret;
+      return ret;
     }
-    count += users.size();
-  } while (truncated && left > 0);
+    count += keys.size();
+    users.splice(users.end(), keys);
+  } while (*truncated && left > 0);
 
+  marker = meta_get_marker(handle);
   meta_list_keys_complete(handle);
-  
   return ret;
 }
 

--- a/src/rgw/rgw_sal_rados.h
+++ b/src/rgw/rgw_sal_rados.h
@@ -433,9 +433,9 @@ class RadosStore : public Store {
     virtual int meta_list_keys_next(const DoutPrefixProvider *dpp, void* handle, int max, std::list<std::string>& keys, bool* truncated) override;
     virtual void meta_list_keys_complete(void* handle) override;
     virtual std::string meta_get_marker(void* handle) override;
-    virtual int list_user(const DoutPrefixProvider* dpp, const std::string& metadata_key,
-                          const std::string& marker, int max_entries, void *&handle,
-                          std::list<std::string>& users) override;
+    virtual int list_users(const DoutPrefixProvider* dpp, const std::string& metadata_key,
+                          std::string& marker, int max_entries, void *&handle,
+                          bool* truncated, std::list<std::string>& users) override;
     virtual int meta_remove(const DoutPrefixProvider* dpp, std::string& metadata_key, optional_yield y) override;
     virtual const RGWSyncModuleInstanceRef& get_sync_module() { return rados->get_sync_module(); }
     virtual std::string get_host_id() { return rados->host_id; }

--- a/src/rgw/rgw_sal_rados.h
+++ b/src/rgw/rgw_sal_rados.h
@@ -433,6 +433,9 @@ class RadosStore : public Store {
     virtual int meta_list_keys_next(const DoutPrefixProvider *dpp, void* handle, int max, std::list<std::string>& keys, bool* truncated) override;
     virtual void meta_list_keys_complete(void* handle) override;
     virtual std::string meta_get_marker(void* handle) override;
+    virtual int list_user(const DoutPrefixProvider* dpp, const std::string& metadata_key,
+                          const std::string& marker, int max_entries, void *&handle,
+                          std::list<std::string>& users) override;
     virtual int meta_remove(const DoutPrefixProvider* dpp, std::string& metadata_key, optional_yield y) override;
     virtual const RGWSyncModuleInstanceRef& get_sync_module() { return rados->get_sync_module(); }
     virtual std::string get_host_id() { return rados->host_id; }


### PR DESCRIPTION
## Parent Ticket
[CORTX-28064](https://jts.seagate.com/browse/CORTX-28064)

## Problem Description
Function for user list api are called directly from `rgw_admin.cc` (in case of CLI) and from `rgw_user.cc` (in case of REST API). These functions are closely integrated with rados which makes implementation of user list complex for other stores.

## Solution
Move function calls for user list to backend store. 

## Implementation
A new function `list_users()` is introduced in backend store which will call the `meta_list_keys_init()`, `meta_list_keys_next()` and `meta_list_keys_complete()` functions for rados as backend. 
Other stores can independently implement `list_users()` function without following implementation of above 3 functions. 

Signed-off-by: Jeet Jain <jeet.jain@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Output

### All users

<details>

<summary>CLI</summary>
<pre>
$ bin/radosgw-admin user list
2022-03-31T23:22:51.011-0600 7f00b63175c0 -1 WARNING: all dangerous and experimental features are enabled.
2022-03-31T23:22:51.023-0600 7f00b63175c0 -1 WARNING: all dangerous and experimental features are enabled.
2022-03-31T23:22:51.024-0600 7f00b63175c0 -1 WARNING: all dangerous and experimental features are enabled.
2022-03-31T23:22:51.024-0600 7f00b63175c0  1 RGW CONF BACKEND STORE = rados
2022-03-31T23:22:51.024-0600 7f00b63175c0  1 RGW BACKEND STORE = rados
{
    "keys": [
        "abcde",
        "abcd",
        "mgwtestuser123",
        "pqr$abcd890dd",
        "mgwtestuser",
        "test",
        "abc",
        "abcd890d",
        "abcd890",
        "rgwadmintest",
        "testid",
        "pqrs$abcd890dd",
        "abcdefg"
    ],
    "truncated": "false",
    "count": 13
}
</pre>
</details>
<details>
<summary>REST API</summary>
<pre>
Fri, 1 Apr 2022 05:25:54 GMT
/admin/user
Auth: AWS 0EW8CCHKO0E8S5LTPMYD:I5sBbBYYGQJJ8sN9aB0BgomWH0o=
HTTP/1.1 200 OK

Response: {"keys":["abcde","abcd","mgwtestuser123","pqr$abcd890dd","mgwtestuser","test","abc","abcd890d","abcd890","rgwadmintest","testid","pqrs$abcd890dd","abcdefg"],"truncated":false,"count":13}
</pre>
</details>

### First n users

<details>
<summary>CLI</summary>
<pre>
$ bin/radosgw-admin user list --max-entries 5
2022-03-31T23:23:11.603-0600 7f35186f25c0 -1 WARNING: all dangerous and experimental features are enabled.
2022-03-31T23:23:11.620-0600 7f35186f25c0 -1 WARNING: all dangerous and experimental features are enabled.
2022-03-31T23:23:11.621-0600 7f35186f25c0 -1 WARNING: all dangerous and experimental features are enabled.
2022-03-31T23:23:11.621-0600 7f35186f25c0 1 RGW CONF BACKEND STORE = rados
2022-03-31T23:23:11.621-0600 7f35186f25c0 1 RGW BACKEND STORE = rados
{
  "keys": [
    "abcde",
    "abcd",
    "mgwtestuser123",
    "pqr$abcd890dd",
    "mgwtestuser"
  ],
  "truncated": "true",
  "count": 5,
  "marker": "7:6a87b59a:users.uid::test:head"
}
</pre>
</details>

<details>
<summary>REST API</summary>
<pre>
Fri, 1 Apr 2022 05:35:44 GMT
/admin/user
Auth: AWS 0EW8CCHKO0E8S5LTPMYD:amVAvZta273k8vTL2rHH0yldoyg=
HTTP/1.1 200 OK

Response: {"keys":["abcde","abcd","mgwtestuser123","pqr$abcd890dd","mgwtestuser"],"truncated":true,"count":5,"marker":"7:6a87b59a:users.uid::test:head"}
</pre>
</details>
<hr>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
