### PR TITLE
rgw_sal_motr: [CORTX-29664] optimise head-object s3api handling

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1447,21 +1447,7 @@ int MotrObject::MotrReadOp::prepare(optional_yield y, const DoutPrefixProvider* 
       return -ERR_NOT_MODIFIED;
     }
   }
-
-  // Skip opening an empty object.
-  if(source->get_obj_size() == 0)
-    return 0;
-
-  // Open the object here.
-  if (source->category == RGWObjCategory::MultiMeta) {
-    ldpp_dout(dpp, 20) <<__func__<< ": open obj parts..." << dendl;
-    rc = source->get_part_objs(dpp, this->part_objs)? :
-         source->open_part_objs(dpp, this->part_objs);
-    return rc;
-  } else {
-    ldpp_dout(dpp, 20) <<__func__<< ": open object..." << dendl;
-    return source->open_mobj(dpp);
-  }
+  return 0;
 }
 
 int MotrObject::MotrReadOp::read(int64_t off, int64_t end, bufferlist& bl, optional_yield y, const DoutPrefixProvider* dpp)
@@ -1482,11 +1468,25 @@ int MotrObject::MotrReadOp::iterate(const DoutPrefixProvider* dpp, int64_t off, 
 {
   int rc;
 
-  if (source->category == RGWObjCategory::MultiMeta)
+  if (source->category == RGWObjCategory::MultiMeta) {
+    ldpp_dout(dpp, 20) <<__func__<< ": open obj parts..." << dendl;
+    rc = source->get_part_objs(dpp, this->part_objs)? :
+         source->open_part_objs(dpp, this->part_objs);
+    if (rc < 0) {
+      ldpp_dout(dpp, 10) << "ERROR: failed to open motr object: rc=" << rc << dendl;
+      return rc;
+    }
     rc = source->read_multipart_obj(dpp, off, end, cb, part_objs);
-  else
+  }
+  else {
+    ldpp_dout(dpp, 20) <<__func__<< ": open object..." << dendl;
+    rc = source->open_mobj(dpp);
+    if (rc < 0) {
+      ldpp_dout(dpp, 10) << "ERROR: failed to open motr object: rc=" << rc << dendl;
+      return rc;
+    }
     rc = source->read_mobj(dpp, off, end, cb);
-
+  }
   return rc;
 }
 


### PR DESCRIPTION
Ticket: https://jts.seagate.com/browse/CORTX-29664

Problem Description:

- For a head object s3api, there is no need to open an object since only metadata and no body is returned.
for more info on head object, s3api refer : https://docs.aws.amazon.com/cli/latest/reference/s3api/head-object.html
- while doing a head object s3API call, the object was getting opened in MotrObject::MotrReadOp::prepare() which was not needed at all.
- also, we were not closing the object which might result in a memory leak.

Problem Solution:

- The solution is to open the object in MotrObject::MotrReadOp::iterate() instead of prepare().(we don't come until iterate in head-object s3api call)
- This won't call open_mobj() unnecessarily during head-object s3api call.
   
Signed-off-by: Pranav Diliprao Pawar <pranav.pawar@seagate.com>

## Testing Done
<details><summary> Test 1: </summary>

>[root@ssc-vm-rhev4-2217 build]# aws s3api head-object --bucket test --key 100mb --endpoint-url http://localhost:8000                                                                                       
{
    "AcceptRanges": "bytes",
    "LastModified": "Mon, 04 Apr 2022 04:31:13 GMT",
    "ContentLength": 104857600,
    "ETag": "\"3f2084ae7783f66c382a320427cec487-2\"",
    "ContentType": "binary/octet-stream",
    "Metadata": {}
}


#### Logs:
```
2022-04-03T23:17:19.411-0600 7fe5a37ab700  2 req 0 0.013000053s s3:get_obj recalculating target
2022-04-03T23:17:19.411-0600 7fe5a37ab700  2 req 0 0.013000053s s3:get_obj reading permissions
2022-04-03T23:17:19.411-0600 7fe5a37ab700  0 req 0 0.013000053s s3:get_obj WARNING: couldn't find acl header for object, generating default
2022-04-03T23:17:19.411-0600 7fe5a37ab700 20 bucket's user:  mgwuser
2022-04-03T23:17:19.411-0600 7fe5a37ab700 20 req 0 0.013000053s s3:get_obj load user: user id =   mgwuser
2022-04-03T23:17:19.411-0600 7fe5a37ab700 20 req 0 0.013000053s s3:get_obj info.user_id.id = mgwuser
2022-04-03T23:17:19.411-0600 7fe5a37ab700  0 req 0 0.013000053s s3:get_obj Cache miss: name = mgwuser, rc = -2
2022-04-03T23:17:19.411-0600 7fe5a37ab700 20 id = 0xceecd44036b5ece5:0xb8a34aa7d56c156a
2022-04-03T23:17:19.411-0600 7fe5a37ab700 20 converted id = 0x7800000036b5ece5:0xb8a34aa7d56c156a
2022-04-03T23:17:19.411-0600 7fe5a37ab700 20 do_idx_op_by_name: do_idx_op_by_name(): op=GET idx=motr.rgw.users key=mgwuser
2022-04-03T23:17:19.413-0600 7fe5a37ab700 20 req 0 0.015000062s s3:get_obj do_idx_op_by_name() = 0
2022-04-03T23:17:19.413-0600 7fe5a37ab700  0 req 0 0.015000062s s3:get_obj Put into cache: name = mgwuser
2022-04-03T23:17:19.413-0600 7fe5a37ab700  2 req 0 0.015000062s s3:get_obj init op
2022-04-03T23:17:19.413-0600 7fe5a37ab700 20 bucket's user:  mgwuser
2022-04-03T23:17:19.413-0600 7fe5a37ab700  2 req 0 0.015000062s s3:get_obj verifying op mask
2022-04-03T23:17:19.413-0600 7fe5a37ab700 20 req 0 0.015000062s s3:get_obj required_mask= 1 user.op_mask=7
2022-04-03T23:17:19.413-0600 7fe5a37ab700  2 req 0 0.015000062s s3:get_obj verifying op permissions
2022-04-03T23:17:19.413-0600 7fe5a37ab700 20 req 0 0.015000062s s3:get_obj -- Getting permissions begin with perm_mask=49
2022-04-03T23:17:19.413-0600 7fe5a37ab700  5 req 0 0.015000062s s3:get_obj Searching permissions for identity=rgw::auth::SysReqApplier -> rgw::auth::LocalApplier(acct_user=mgwuser, acct_name=mgwuser, subuser=, perm_mask=15, is_admin=0) mask=49
2022-04-03T23:17:19.413-0600 7fe5a37ab700  5 req 0 0.015000062s s3:get_obj Searching permissions for uid=mgwuser
2022-04-03T23:17:19.413-0600 7fe5a37ab700  5 req 0 0.015000062s s3:get_obj Found permission: 15
2022-04-03T23:17:19.413-0600 7fe5a37ab700  5 req 0 0.015000062s s3:get_obj Searching permissions for group=1 mask=49
2022-04-03T23:17:19.413-0600 7fe5a37ab700  5 req 0 0.015000062s s3:get_obj Permissions for group not found
2022-04-03T23:17:19.413-0600 7fe5a37ab700  5 req 0 0.015000062s s3:get_obj Searching permissions for group=2 mask=49
2022-04-03T23:17:19.413-0600 7fe5a37ab700  5 req 0 0.015000062s s3:get_obj Permissions for group not found
2022-04-03T23:17:19.413-0600 7fe5a37ab700  5 req 0 0.015000062s s3:get_obj -- Getting permissions done for identity=rgw::auth::SysReqApplier -> rgw::auth::LocalApplier(acct_user=mgwuser, acct_name=mgwuser, subuser=, perm_mask=15, is_admin=0), owner=mgwuser, perm=1
2022-04-03T23:17:19.413-0600 7fe5a37ab700 10 req 0 0.015000062s s3:get_obj  identity=rgw::auth::SysReqApplier -> rgw::auth::LocalApplier(acct_user=mgwuser, acct_name=mgwuser, subuser=, perm_mask=15, is_admin=0) requested perm (type)=1, policy perm=1, user_perm_mask=15, acl perm=1
2022-04-03T23:17:19.413-0600 7fe5a37ab700  2 req 0 0.015000062s s3:get_obj verifying op params
2022-04-03T23:17:19.413-0600 7fe5a37ab700  2 req 0 0.015000062s s3:get_obj pre-executing
2022-04-03T23:17:19.413-0600 7fe5a37ab700  2 req 0 0.015000062s s3:get_obj check rate limiting
2022-04-03T23:17:19.413-0600 7fe5a37ab700  2 req 0 0.015000062s s3:get_obj executing
2022-04-03T23:17:19.413-0600 7fe5a37ab700 20 req 0 0.015000062s s3:get_obj prepare: bucket=test
2022-04-03T23:17:19.414-0600 7fe5a37ab700  0 req 0 0.016000066s s3:get_obj Cache miss: name = 100mb, rc = -2
2022-04-03T23:17:19.414-0600 7fe5a37ab700 20 req 0 0.016000066s s3:get_obj get_bucket_dir_ent: non-versioned bucket!
2022-04-03T23:17:19.414-0600 7fe5a37ab700 20 id = 0xb20c8d422223b6af:0x46090892e8797763
2022-04-03T23:17:19.414-0600 7fe5a37ab700 20 converted id = 0x780000002223b6af:0x46090892e8797763
2022-04-03T23:17:19.414-0600 7fe5a37ab700 20 do_idx_op_by_name: do_idx_op_by_name(): op=GET idx=motr.rgw.bucket.index.test key=100mb
2022-04-03T23:17:19.416-0600 7fe5a37ab700  0 req 0 0.018000074s s3:get_obj Put into cache: name = 100mb
2022-04-03T23:17:19.416-0600 7fe5a37ab700 20 req 0 0.018000074s s3:get_obj get_bucket_dir_ent: lid=0x0
2022-04-03T23:17:19.416-0600 7fe5a37ab700 20 req 0 0.018000074s s3:get_obj prepare: object's etag: 3f2084ae7783f66c382a320427cec487-2
2022-04-03T23:17:19.416-0600 7fe5a37ab700 15 req 0 0.018000074s Encryption mode:
2022-04-03T23:17:19.416-0600 7fe5a37ab700  2 req 0 0.018000074s s3:get_obj completing
2022-04-03T23:17:19.416-0600 7fe5a37ab700  2 req 0 0.018000074s s3:get_obj op status=0
2022-04-03T23:17:19.416-0600 7fe5a37ab700  2 req 0 0.018000074s s3:get_obj http status=200
2022-04-03T23:17:19.416-0600 7fe5a37ab700  1 ====== req done req=0x7fe5c2eba780 op status=0 http_status=200 latency=0.018000074s ======
2022-04-03T23:17:19.417-0600 7fe5a37ab700  1 beast: 0x7fe5c2eba780: ::1 - mgwuser [03/Apr/2022:23:17:19.397 -0600] "HEAD /test/100mb HTTP/1.1" 200 0 - "aws-cli/1.22.71 Python/3.6.8 Linux/4.18.0-305.3.1.el8_4.x86_64 botocore/1.24.16" - latency=0.018000074s

```
</details>

<details><summary> Test 2: </summary>

>[root@ssc-vm-rhev4-2217 build]# aws s3api head-object --bucket test --key 0kb --endpoint-url http://localhost:8000
{
    "AcceptRanges": "bytes",
    "LastModified": "Mon, 04 Apr 2022 03:56:03 GMT",
    "ContentLength": 0,
    "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
    "ContentType": "binary/octet-stream",
    "Metadata": {}
}


#### Logs:
```
2022-04-03T23:27:30.437-0600 7fe59cf9e700  2 req 0 0.011000044s s3:get_obj recalculating target
2022-04-03T23:27:30.437-0600 7fe59cf9e700  2 req 0 0.011000044s s3:get_obj reading permissions
2022-04-03T23:27:30.437-0600 7fe59cf9e700  0 req 0 0.011000044s s3:get_obj WARNING: couldn't find acl header for object, generating default
2022-04-03T23:27:30.437-0600 7fe59cf9e700 20 bucket's user:  mgwuser
2022-04-03T23:27:30.437-0600 7fe59cf9e700 20 req 0 0.011000044s s3:get_obj load user: user id =   mgwuser
2022-04-03T23:27:30.437-0600 7fe59cf9e700 20 req 0 0.011000044s s3:get_obj info.user_id.id = mgwuser
2022-04-03T23:27:30.437-0600 7fe59cf9e700  0 req 0 0.011000044s s3:get_obj Cache miss: name = mgwuser, rc = -2
2022-04-03T23:27:30.437-0600 7fe59cf9e700 20 id = 0xceecd44036b5ece5:0xb8a34aa7d56c156a
2022-04-03T23:27:30.437-0600 7fe59cf9e700 20 converted id = 0x7800000036b5ece5:0xb8a34aa7d56c156a
2022-04-03T23:27:30.437-0600 7fe59cf9e700 20 do_idx_op_by_name: do_idx_op_by_name(): op=GET idx=motr.rgw.users key=mgwuser
2022-04-03T23:27:30.439-0600 7fe59cf9e700 20 req 0 0.013000052s s3:get_obj do_idx_op_by_name() = 0
2022-04-03T23:27:30.439-0600 7fe59cf9e700  0 req 0 0.013000052s s3:get_obj Put into cache: name = mgwuser
2022-04-03T23:27:30.439-0600 7fe59cf9e700  2 req 0 0.013000052s s3:get_obj init op
2022-04-03T23:27:30.439-0600 7fe59cf9e700 20 bucket's user:  mgwuser
2022-04-03T23:27:30.439-0600 7fe59cf9e700  2 req 0 0.013000052s s3:get_obj verifying op mask
2022-04-03T23:27:30.439-0600 7fe59cf9e700 20 req 0 0.013000052s s3:get_obj required_mask= 1 user.op_mask=7
2022-04-03T23:27:30.439-0600 7fe59cf9e700  2 req 0 0.013000052s s3:get_obj verifying op permissions
2022-04-03T23:27:30.439-0600 7fe59cf9e700 20 req 0 0.013000052s s3:get_obj -- Getting permissions begin with perm_mask=49
2022-04-03T23:27:30.439-0600 7fe59cf9e700  5 req 0 0.013000052s s3:get_obj Searching permissions for identity=rgw::auth::SysReqApplier -> rgw::auth::LocalApplier(acct_user=mgwuser, acct_name=mgwuser, subuser=, perm_mask=15, is_admin=0) mask=49
2022-04-03T23:27:30.439-0600 7fe59cf9e700  5 req 0 0.013000052s s3:get_obj Searching permissions for uid=mgwuser
2022-04-03T23:27:30.439-0600 7fe59cf9e700  5 req 0 0.013000052s s3:get_obj Found permission: 15
2022-04-03T23:27:30.439-0600 7fe59cf9e700  5 req 0 0.013000052s s3:get_obj Searching permissions for group=1 mask=49
2022-04-03T23:27:30.439-0600 7fe59cf9e700  5 req 0 0.013000052s s3:get_obj Permissions for group not found
2022-04-03T23:27:30.439-0600 7fe59cf9e700  5 req 0 0.013000052s s3:get_obj Searching permissions for group=2 mask=49
2022-04-03T23:27:30.439-0600 7fe59cf9e700  5 req 0 0.013000052s s3:get_obj Permissions for group not found
2022-04-03T23:27:30.439-0600 7fe59cf9e700  5 req 0 0.013000052s s3:get_obj -- Getting permissions done for identity=rgw::auth::SysReqApplier -> rgw::auth::LocalApplier(acct_user=mgwuser, acct_name=mgwuser, subuser=, perm_mask=15, is_admin=0), owner=mgwuser, perm=1
2022-04-03T23:27:30.439-0600 7fe59cf9e700 10 req 0 0.013000052s s3:get_obj  identity=rgw::auth::SysReqApplier -> rgw::auth::LocalApplier(acct_user=mgwuser, acct_name=mgwuser, subuser=, perm_mask=15, is_admin=0) requested perm (type)=1, policy perm=1, user_perm_mask=15, acl perm=1
2022-04-03T23:27:30.439-0600 7fe59cf9e700  2 req 0 0.013000052s s3:get_obj verifying op params
2022-04-03T23:27:30.439-0600 7fe59cf9e700  2 req 0 0.013000052s s3:get_obj pre-executing
2022-04-03T23:27:30.439-0600 7fe59cf9e700  2 req 0 0.013000052s s3:get_obj check rate limiting
2022-04-03T23:27:30.439-0600 7fe59cf9e700  2 req 0 0.013000052s s3:get_obj executing
2022-04-03T23:27:30.439-0600 7fe59cf9e700 20 req 0 0.013000052s s3:get_obj prepare: bucket=test
2022-04-03T23:27:30.439-0600 7fe59cf9e700  0 req 0 0.013000052s s3:get_obj Cache miss: name = 0kb, rc = -2
2022-04-03T23:27:30.439-0600 7fe59cf9e700 20 req 0 0.013000052s s3:get_obj get_bucket_dir_ent: non-versioned bucket!
2022-04-03T23:27:30.439-0600 7fe59cf9e700 20 id = 0xb20c8d422223b6af:0x46090892e8797763
2022-04-03T23:27:30.439-0600 7fe59cf9e700 20 converted id = 0x780000002223b6af:0x46090892e8797763
2022-04-03T23:27:30.439-0600 7fe59cf9e700 20 do_idx_op_by_name: do_idx_op_by_name(): op=GET idx=motr.rgw.bucket.index.test key=0kb
2022-04-03T23:27:30.442-0600 7fe59cf9e700  0 req 0 0.016000064s s3:get_obj Put into cache: name = 0kb
2022-04-03T23:27:30.442-0600 7fe59cf9e700 20 req 0 0.016000064s s3:get_obj get_bucket_dir_ent: lid=0x0
2022-04-03T23:27:30.442-0600 7fe59cf9e700 20 req 0 0.016000064s s3:get_obj prepare: object's etag: d41d8cd98f00b204e9800998ecf8427e
2022-04-03T23:27:30.442-0600 7fe59cf9e700 15 req 0 0.016000064s Encryption mode:
2022-04-03T23:27:30.442-0600 7fe59cf9e700  2 req 0 0.016000064s s3:get_obj completing
2022-04-03T23:27:30.442-0600 7fe59cf9e700  2 req 0 0.016000064s s3:get_obj op status=0
2022-04-03T23:27:30.442-0600 7fe59cf9e700  2 req 0 0.016000064s s3:get_obj http status=200
2022-04-03T23:27:30.442-0600 7fe59cf9e700  1 ====== req done req=0x7fe5c2eba780 op status=0 http_status=200 latency=0.016000064s ======
2022-04-03T23:27:30.442-0600 7fe59cf9e700  1 beast: 0x7fe5c2eba780: ::1 - mgwuser [03/Apr/2022:23:27:30.425 -0600] "HEAD /test/0kb HTTP/1.1" 200 0 - "aws-cli/1.22.71 Python/3.6.8 Linux/4.18.0-305.3.1.el8_4.x86_64 botocore/1.24.16" - latency=0.016000064s

```
</details>

<details><summary> Test 3: </summary>

>[root@ssc-vm-rhev4-2217 build]# aws s3api head-object --bucket test --key 1gb --endpoint-url http://localhost:8000
{
    "AcceptRanges": "bytes",
    "LastModified": "Mon, 04 Apr 2022 03:58:38 GMT",
    "ContentLength": 1048576000,
    "ETag": "\"e5c834fbdaa6bfd8eac5eb9404eefdd4\"",
    "ContentType": "binary/octet-stream",
    "Metadata": {}
}



#### Logs:
```
2022-04-03T23:27:30.437-0600 7fe59cf9e700  2 req 0 0.011000044s s3:get_obj recalculating target
2022-04-03T23:27:30.437-0600 7fe59cf9e700  2 req 0 0.011000044s s3:get_obj reading permissions
2022-04-03T23:27:30.437-0600 7fe59cf9e700  0 req 0 0.011000044s s3:get_obj WARNING: couldn't find acl header for object, generating default
2022-04-03T23:27:30.437-0600 7fe59cf9e700 20 bucket's user:  mgwuser
2022-04-03T23:27:30.437-0600 7fe59cf9e700 20 req 0 0.011000044s s3:get_obj load user: user id =   mgwuser
2022-04-03T23:27:30.437-0600 7fe59cf9e700 20 req 0 0.011000044s s3:get_obj info.user_id.id = mgwuser
2022-04-03T23:27:30.437-0600 7fe59cf9e700  0 req 0 0.011000044s s3:get_obj Cache miss: name = mgwuser, rc = -2
2022-04-03T23:27:30.437-0600 7fe59cf9e700 20 id = 0xceecd44036b5ece5:0xb8a34aa7d56c156a
2022-04-03T23:27:30.437-0600 7fe59cf9e700 20 converted id = 0x7800000036b5ece5:0xb8a34aa7d56c156a
2022-04-03T23:27:30.437-0600 7fe59cf9e700 20 do_idx_op_by_name: do_idx_op_by_name(): op=GET idx=motr.rgw.users key=mgwuser
2022-04-03T23:27:30.439-0600 7fe59cf9e700 20 req 0 0.013000052s s3:get_obj do_idx_op_by_name() = 0
2022-04-03T23:27:30.439-0600 7fe59cf9e700  0 req 0 0.013000052s s3:get_obj Put into cache: name = mgwuser
2022-04-03T23:27:30.439-0600 7fe59cf9e700  2 req 0 0.013000052s s3:get_obj init op
2022-04-03T23:27:30.439-0600 7fe59cf9e700 20 bucket's user:  mgwuser
2022-04-03T23:27:30.439-0600 7fe59cf9e700  2 req 0 0.013000052s s3:get_obj verifying op mask
2022-04-03T23:27:30.439-0600 7fe59cf9e700 20 req 0 0.013000052s s3:get_obj required_mask= 1 user.op_mask=7
2022-04-03T23:27:30.439-0600 7fe59cf9e700  2 req 0 0.013000052s s3:get_obj verifying op permissions
2022-04-03T23:27:30.439-0600 7fe59cf9e700 20 req 0 0.013000052s s3:get_obj -- Getting permissions begin with perm_mask=49
2022-04-03T23:27:30.439-0600 7fe59cf9e700  5 req 0 0.013000052s s3:get_obj Searching permissions for identity=rgw::auth::SysReqApplier -> rgw::auth::LocalApplier(acct_user=mgwuser, acct_name=mgwuser, subuser=, perm_mask=15, is_admin=0) mask=49
2022-04-03T23:27:30.439-0600 7fe59cf9e700  5 req 0 0.013000052s s3:get_obj Searching permissions for uid=mgwuser
2022-04-03T23:27:30.439-0600 7fe59cf9e700  5 req 0 0.013000052s s3:get_obj Found permission: 15
2022-04-03T23:27:30.439-0600 7fe59cf9e700  5 req 0 0.013000052s s3:get_obj Searching permissions for group=1 mask=49
2022-04-03T23:27:30.439-0600 7fe59cf9e700  5 req 0 0.013000052s s3:get_obj Permissions for group not found
2022-04-03T23:27:30.439-0600 7fe59cf9e700  5 req 0 0.013000052s s3:get_obj Searching permissions for group=2 mask=49
2022-04-03T23:27:30.439-0600 7fe59cf9e700  5 req 0 0.013000052s s3:get_obj Permissions for group not found
2022-04-03T23:27:30.439-0600 7fe59cf9e700  5 req 0 0.013000052s s3:get_obj -- Getting permissions done for identity=rgw::auth::SysReqApplier -> rgw::auth::LocalApplier(acct_user=mgwuser, acct_name=mgwuser, subuser=, perm_mask=15, is_admin=0), owner=mgwuser, perm=1
2022-04-03T23:27:30.439-0600 7fe59cf9e700 10 req 0 0.013000052s s3:get_obj  identity=rgw::auth::SysReqApplier -> rgw::auth::LocalApplier(acct_user=mgwuser, acct_name=mgwuser, subuser=, perm_mask=15, is_admin=0) requested perm (type)=1, policy perm=1, user_perm_mask=15, acl perm=1
2022-04-03T23:27:30.439-0600 7fe59cf9e700  2 req 0 0.013000052s s3:get_obj verifying op params
2022-04-03T23:27:30.439-0600 7fe59cf9e700  2 req 0 0.013000052s s3:get_obj pre-executing
2022-04-03T23:27:30.439-0600 7fe59cf9e700  2 req 0 0.013000052s s3:get_obj check rate limiting
2022-04-03T23:27:30.439-0600 7fe59cf9e700  2 req 0 0.013000052s s3:get_obj executing
2022-04-03T23:27:30.439-0600 7fe59cf9e700 20 req 0 0.013000052s s3:get_obj prepare: bucket=test
2022-04-03T23:27:30.439-0600 7fe59cf9e700  0 req 0 0.013000052s s3:get_obj Cache miss: name = 0kb, rc = -2
2022-04-03T23:27:30.439-0600 7fe59cf9e700 20 req 0 0.013000052s s3:get_obj get_bucket_dir_ent: non-versioned bucket!
2022-04-03T23:27:30.439-0600 7fe59cf9e700 20 id = 0xb20c8d422223b6af:0x46090892e8797763
2022-04-03T23:27:30.439-0600 7fe59cf9e700 20 converted id = 0x780000002223b6af:0x46090892e8797763
2022-04-03T23:27:30.439-0600 7fe59cf9e700 20 do_idx_op_by_name: do_idx_op_by_name(): op=GET idx=motr.rgw.bucket.index.test key=0kb
2022-04-03T23:27:30.442-0600 7fe59cf9e700  0 req 0 0.016000064s s3:get_obj Put into cache: name = 0kb
2022-04-03T23:27:30.442-0600 7fe59cf9e700 20 req 0 0.016000064s s3:get_obj get_bucket_dir_ent: lid=0x0
2022-04-03T23:27:30.442-0600 7fe59cf9e700 20 req 0 0.016000064s s3:get_obj prepare: object's etag: d41d8cd98f00b204e9800998ecf8427e
2022-04-03T23:27:30.442-0600 7fe59cf9e700 15 req 0 0.016000064s Encryption mode:
2022-04-03T23:27:30.442-0600 7fe59cf9e700  2 req 0 0.016000064s s3:get_obj completing
2022-04-03T23:27:30.442-0600 7fe59cf9e700  2 req 0 0.016000064s s3:get_obj op status=0
2022-04-03T23:27:30.442-0600 7fe59cf9e700  2 req 0 0.016000064s s3:get_obj http status=200
2022-04-03T23:27:30.442-0600 7fe59cf9e700  1 ====== req done req=0x7fe5c2eba780 op status=0 http_status=200 latency=0.016000064s ======
2022-04-03T23:27:30.442-0600 7fe59cf9e700  1 beast: 0x7fe5c2eba780: ::1 - mgwuser [03/Apr/2022:23:27:30.425 -0600] "HEAD /test/0kb HTTP/1.1" 200 0 - "aws-cli/1.22.71 Python/3.6.8 Linux/4.18.0-305.3.1.el8_4.x86_64 botocore/1.24.16" - latency=0.016000064s


```
</details>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
