### PR TITLE
rgw_sal_motr: [CORTX-29655] Fix bytecount for multipart object sizes

### DIFF
--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -487,6 +487,20 @@ class MotrOIDCProvider : public RGWOIDCProvider {
   }
 };
 
+// Used to accumulate remaining write IO chunks of multipart write,
+// in order to make Motr write IO aligned with the parity group size.
+// E.g., for part obj of size of 5.5MB (i.e. object lid=0xb), when the 
+// chunk size is 4MB, MotrObject::write_mobj() will collect each 4MB chunk
+// until the end of data from client. So, in this case, two chunks of 4MB
+// and 1.5MB will be added to 'AccumulateIOCtxt::accumulated_buffer_list'.
+// When both the chucks are read completely, Motr write IO is performed.
+struct AccumulateIOCtxt{
+  // Accumulate buffer from socket until we have data of optimal block size 
+  std::vector<bufferlist> accumulated_buffer_list;
+  uint64_t start_offset = 0;
+  uint64_t total_bufer_sz = 0;
+};
+
 class MotrObject : public Object {
   private:
     MotrStore *store;
@@ -503,6 +517,11 @@ class MotrObject : public Object {
     uint64_t part_off;
     uint64_t part_size;
     uint64_t part_num;
+    // Object size as available from Content-Length header
+    uint64_t expected_obj_size = 0;
+    // Total Number of bytes processed so far
+    uint64_t processed_bytes = 0;
+    struct AccumulateIOCtxt io_ctxt = {};
 
   public:
 
@@ -673,6 +692,7 @@ class MotrObject : public Object {
     void set_category(RGWObjCategory _category) {category = _category;}
     int get_bucket_dir_ent(const DoutPrefixProvider *dpp, rgw_bucket_dir_entry& ent);
     int update_version_entries(const DoutPrefixProvider *dpp);
+    uint64_t get_processed_bytes() { return processed_bytes; }
 };
 
 // A placeholder locking class for multipart upload.
@@ -748,6 +768,8 @@ protected:
   const std::string part_num_str;
   std::unique_ptr<MotrObject> part_obj;
   uint64_t actual_part_size = 0;
+  // Part object size available from Content-Length header
+  uint64_t expected_part_size = 0;
 
 public:
   MotrMultipartWriter(const DoutPrefixProvider *dpp,
@@ -760,6 +782,11 @@ public:
 				  Writer(dpp, y), store(_store), head_obj(std::move(_head_obj)),
 				  part_num(_part_num), part_num_str(part_num_str)
   {
+    struct req_state *s = static_cast<struct req_state *>(obj_ctx.get_private());
+    if (s) {
+      // Save the part's size available from Content-Length header
+      expected_part_size = s->content_length;
+    }
   }
   ~MotrMultipartWriter() = default;
 


### PR DESCRIPTION
**Problem**:

    1. Incorrect object part layout id
During Motr part object creation, rgw_max_chunk_size (default=4MB in ./rgw.yaml.in) is passed to compute object layout id(lid), and not the actual object part's size. The actual part size is available from Content-Length header. Due to this, incorrect lid is set on the created part object.

    2. Additional data is seen added to object storage due to padding. 
This increases the bytecount of some objects in storage.

**Resolution**:
 For (1):
 Determine the part object size using Content-Length header value. Pass the same during part object creation using Motr.

 For (2): 
Apply padding only to the last IO chunk read from the client. For  intermediate chunks, accumulate them in an internal list,  until complete data is read from the client. Then convert this list of buffers into single buffer to make Motr write IO aligned
to optimal block/group size. This way, unwanted padding to intermediate chunks is avoided. The padding would be done only in the last write IO. Later (in another code change), minimal padding would be done to align the data to object's unit size boundary (and not to the group size boundary) and would make use of rmw flag to inform libMotr about the same.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
