### PR TITLE
rgw_sal_motr: [CORTX-27629] Fix for page-size parameter in list multiparts upload api

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1024,9 +1024,13 @@ int MotrBucket::list_multiparts(const DoutPrefixProvider *dpp,
       map<string, bool> *common_prefixes,
       bool *is_truncated)
 {
-  int rc;
-  vector<string> key_vec(max_uploads);
-  vector<bufferlist> val_vec(max_uploads);
+  int rc = 0;
+  if( max_uploads <= 0 )
+	return rc;
+  int upl = max_uploads;
+  upl++;
+  vector<string> key_vec(upl);
+  vector<bufferlist> val_vec(upl);
   string tenant_bkt_name = get_bucket_name(this->get_tenant(), this->get_name());
 
   string bucket_multipart_iname =
@@ -1049,6 +1053,11 @@ int MotrBucket::list_multiparts(const DoutPrefixProvider *dpp,
     if (bl.length() == 0)
       break;
 
+    if((marker != "") && (ocount == 0))
+    {
+        ocount++;
+        continue;
+    }
     rgw_bucket_dir_entry ent;
     auto iter = bl.cbegin();
     ent.decode(iter);
@@ -1065,7 +1074,7 @@ int MotrBucket::list_multiparts(const DoutPrefixProvider *dpp,
     uploads.push_back(this->get_multipart_upload(key.name));
     last_obj_key = key;
     ocount++;
-    if (ocount == max_uploads) {
+    if (ocount == upl) {
       *is_truncated = true;
       break;
     }


### PR DESCRIPTION
rgw_sal_motr: [CORTX-27629] Fix for page-size parameter in list multiparts upload api
Signed-off-by: dharmendra-jyani <dharmendra.jyani@seagate.com>

**Problem** - 
1)List multipart api parameter page-size was not working as expected, for page-size 0 and less then 0 rgw was crashing
2) For page size 1, it was giving error. And for greater than page-size 1 , it was listing duplicates upload id on console.

**Solution**  Added a check for page size less then equal to 0, so that we can return 0 from starting of function. 
For page size 1 and more than 1 added a condition such that if marker is not empty then we have to skip that upload id to copy to vector to avoid duplicates as that id is already being present in result vector.

> **1) For page size 0**
[root@ssc-vm-g4-rhev4-0761 build]# aws s3api list-multipart-uploads --bucket testbucket3 --page-size 0
[root@ssc-vm-g4-rhev4-0761 build]#

> **2) For page size 1**
[root@ssc-vm-g4-rhev4-0761 build]# aws s3api list-multipart-uploads --bucket testbucket3 --page-size 1
{
    "Uploads": [
        {
            "UploadId": "2~8F9N1XH4VJpg_uyom9j01kdepYv3BGk",
            "Key": "multipart/01",
            "Initiated": "2022-04-13T09:53:07.363Z",
            "StorageClass": "STANDARD",
            "Owner": {
                "DisplayName": "",
                "ID": ""
            },
            "Initiator": {
                "ID": "",
                "DisplayName": ""
            }
        },
        {
            "UploadId": "2~LBobqJftoTaQZRgSiWcy6ZRYMekMmT6",
            "Key": "multipart/01",
            "Initiated": "2022-04-13T09:53:07.363Z",
            "StorageClass": "STANDARD",
            "Owner": {
                "DisplayName": "",
                "ID": ""
            },
            "Initiator": {
                "ID": "",
                "DisplayName": ""
            }
        },
        {
            "UploadId": "2~JcHHzsjktSxGEKxXK0CGuqlps04rHuF",
            "Key": "multipart/02",
            "Initiated": "2022-04-13T09:53:07.383Z",
            "StorageClass": "STANDARD",
            "Owner": {
                "DisplayName": "",
                "ID": ""
            },
            "Initiator": {
                "ID": "",
                "DisplayName": ""
            }
        },
        {
            "UploadId": "2~KURmpCfuStRvtJeb6-uH60uhEGtHOoT",
            "Key": "multipart/02",
            "Initiated": "2022-04-13T09:53:07.449Z",
            "StorageClass": "STANDARD",
            "Owner": {
                "DisplayName": "",
                "ID": ""
            },
            "Initiator": {
                "ID": "",
                "DisplayName": ""
            }
        }
    ]
}

**3) For page size 2**
[root@ssc-vm-g4-rhev4-0761 build]# aws s3api list-multipart-uploads --bucket testbucket3 --page-size 2
{
    "Uploads": [
        {
            "UploadId": "2~8F9N1XH4VJpg_uyom9j01kdepYv3BGk",
            "Key": "multipart/01",
            "Initiated": "2022-04-13T09:53:07.363Z",
            "StorageClass": "STANDARD",
            "Owner": {
                "DisplayName": "",
                "ID": ""
            },
            "Initiator": {
                "ID": "",
                "DisplayName": ""
            }
        },
        {
            "UploadId": "2~LBobqJftoTaQZRgSiWcy6ZRYMekMmT6",
            "Key": "multipart/01",
            "Initiated": "2022-04-13T09:53:07.363Z",
            "StorageClass": "STANDARD",
            "Owner": {
                "DisplayName": "",
                "ID": ""
            },
            "Initiator": {
                "ID": "",
                "DisplayName": ""
            }
        },
        {
            "UploadId": "2~JcHHzsjktSxGEKxXK0CGuqlps04rHuF",
            "Key": "multipart/02",
            "Initiated": "2022-04-13T09:53:07.383Z",
            "StorageClass": "STANDARD",
            "Owner": {
                "DisplayName": "",
                "ID": ""
            },
            "Initiator": {
                "ID": "",
                "DisplayName": ""
            }
        },
        {
            "UploadId": "2~KURmpCfuStRvtJeb6-uH60uhEGtHOoT",
            "Key": "multipart/02",
            "Initiated": "2022-04-13T09:53:07.449Z",
            "StorageClass": "STANDARD",
            "Owner": {
                "DisplayName": "",
                "ID": ""
            },
            "Initiator": {
                "ID": "",
                "DisplayName": ""
            }
        }
    ]
}






## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

