### PR TITLE
rgw_sal_motr: [CORTX-27628] Support Multipart Complete API in RGW

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -6385,6 +6385,9 @@ void RGWCompleteMultipart::execute(optional_yield y)
     ldpp_dout(this, 0) << "ERROR: upload complete failed ret=" << op_ret << dendl;
     return;
   }
+  // Set the calculated etag used in the send response
+  rgw::sal::Attrs &attrs = target_obj->get_attrs();
+  etag = attrs[RGW_ATTR_ETAG].to_str();
 
   // remove the upload meta object ; the meta object is not versioned
   // when the bucket is, as that would add an unneeded delete marker

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1572,27 +1572,34 @@ int MotrObject::MotrDeleteOp::delete_obj(const DoutPrefixProvider* dpp, optional
   // Delete from the cache first.
   source->store->get_obj_meta_cache()->remove(dpp, source->get_key().to_str());
 
-  // Delete the object's entry from the bucket index.
+  if (ent.meta.size == 0) {
+    ldpp_dout(dpp, 20) << __func__ << ": Object size is 0, not deleting motr object." << dendl;
+  } else {
+    // Remove the motr object.
+    if (source->get_bucket()->get_info().versioning_status() == BUCKET_VERSIONED ||
+        source->get_bucket()->get_info().versioning_status() == BUCKET_VERSIONS_SUSPENDED) {
+          // TODO - Object Versioning feature
+          // If Bucket is versioned or versioning suspended, handle object deletion here.
+          // Presently, do nothing.
+          return 0;
+        } else {
+          if (source->category == RGWObjCategory::MultiMeta)
+            rc = source->delete_part_objs(dpp);
+          else
+            rc = source->delete_mobj(dpp);
+          if (rc < 0) {
+            ldpp_dout(dpp, 0) << "Failed to delete the object from Motr. " << dendl;
+            return rc;
+          }
+        }
+  }
+  // Finally, delete the object's entry from the bucket index.
   bufferlist bl;
   string bucket_index_iname = "motr.rgw.bucket.index." + tenant_bkt_name;
   rc = source->store->do_idx_op_by_name(bucket_index_iname,
                                             M0_IC_DEL, source->get_key().to_str(), bl);
   if (rc < 0) {
     ldpp_dout(dpp, 0) << "Failed to del object's entry from bucket index. " << dendl;
-    return rc;
-  }
-
-  if (ent.meta.size == 0) {
-    ldpp_dout(dpp, 0) << __func__ << ": Object size is 0, not deleting motr object." << dendl;
-    return 0;
-  }
-  // Remove the motr objects.
-  if (source->category == RGWObjCategory::MultiMeta)
-    rc = source->delete_part_objs(dpp);
-  else
-    rc = source->delete_mobj(dpp);
-  if (rc < 0) {
-    ldpp_dout(dpp, 0) << "Failed to delete the object from Motr. " << dendl;
     return rc;
   }
 
@@ -2784,6 +2791,8 @@ int MotrMultipartUpload::list_parts(const DoutPrefixProvider *dpp, CephContext *
   int last_num = 0;
   int part_cnt = 0;
   ldpp_dout(dpp, 20) << __func__ << ": marker = " << marker << dendl;
+  parts.clear();
+
   for (const auto& bl: val_vec) {
     if (bl.length() == 0)
       break;
@@ -2850,7 +2859,7 @@ int MotrMultipartUpload::complete(const DoutPrefixProvider *dpp,
   int marker = 0;
   uint64_t min_part_size = cct->_conf->rgw_multipart_min_part_size;
   auto etags_iter = part_etags.begin();
-  rgw::sal::Attrs attrs = target_obj->get_attrs();
+  rgw::sal::Attrs &attrs = target_obj->get_attrs();
 
   do {
     ldpp_dout(dpp, 20) << "MotrMultipartUpload::complete(): list_parts()" << dendl;
@@ -2996,8 +3005,9 @@ int MotrMultipartUpload::complete(const DoutPrefixProvider *dpp,
   rc = this->store->do_idx_op_by_name(bucket_multipart_iname,
                                       M0_IC_GET, meta_obj->get_key().to_str(), bl);
   ldpp_dout(dpp, 20) << "MotrMultipartUpload::complete(): read entry from bucket multipart index rc=" << rc << dendl;
-  if (rc < 0)
-    return rc;
+  if (rc < 0) {
+    return rc == -ENOENT ? -ERR_NO_SUCH_UPLOAD : rc;
+  }
   rgw_bucket_dir_entry ent;
   bufferlist& blr = bl;
   auto ent_iter = blr.cbegin();
@@ -3005,7 +3015,7 @@ int MotrMultipartUpload::complete(const DoutPrefixProvider *dpp,
 
   // Update the dir entry and insert it to the bucket index so
   // the object will be seen when listing the bucket.
-  bufferlist update_bl;
+  bufferlist update_bl, old_check_bl;
   target_obj->get_key().get_index_key(&ent.key);  // Change to offical name :)
   ent.meta.size = off;
   ent.meta.accounted_size = accounted_size;
@@ -3021,6 +3031,40 @@ int MotrMultipartUpload::complete(const DoutPrefixProvider *dpp,
   string bucket_index_iname = "motr.rgw.bucket.index." + tenant_bkt_name;
   ldpp_dout(dpp, 20) << "MotrMultipartUpload::complete(): target_obj name=" << target_obj->get_name()
                                   << " target_obj oid=" << target_obj->get_oid() << dendl;
+
+  std::string obj_type = "simple object";
+  MotrObject::Meta old_meta;
+  rgw_bucket_dir_entry old_ent;
+
+  // Before updating bucket index with entry for new object, check if
+  // old object exists. Perform M0_IC_GET operation on bucket index.
+  rc = store->do_idx_op_by_name(bucket_index_iname, M0_IC_GET,
+                                target_obj->get_name(), old_check_bl);
+  if (rc == 0 && old_check_bl.length() > 0) {
+    auto ent_iter = old_check_bl.cbegin();
+    old_ent.decode(ent_iter);
+    rgw::sal::Attrs dummy;
+    decode(dummy, ent_iter);
+    old_meta.decode(ent_iter);
+    std::unique_ptr<rgw::sal::Object> old_obj = target_obj->get_bucket()->get_object(rgw_obj_key(target_obj->get_name()));
+    rgw::sal::MotrObject *old_mobj = static_cast<rgw::sal::MotrObject *>(old_obj.get());
+    if (old_ent.meta.category == RGWObjCategory::MultiMeta) {
+      obj_type = "multipart object";
+      old_mobj->set_category(RGWObjCategory::MultiMeta);
+    }
+    ldpp_dout(dpp, 20) << "MotrMultipartUpload::complete(): Old " << obj_type << " exists" << dendl;
+    // Delete old object
+    rc = old_mobj->delete_object(dpp, obj_ctx, y, true);
+    if (rc == 0) {
+      ldpp_dout(dpp, 20) << "MotrMultipartUpload::complete(): Old " << obj_type << " ["
+          << old_mobj->get_name() <<  "] deleted succesfully" << dendl;
+    } else {
+      ldpp_dout(dpp, 20) << "MotrMultipartUpload::complete(): Failed to delete old " << obj_type << " ["
+          << old_mobj->get_name() <<  "]. Error = " << rc << dendl;
+      return rc;
+    }
+  }
+
   rc = store->do_idx_op_by_name(bucket_index_iname, M0_IC_PUT,
                                 target_obj->get_name(), update_bl);
   if (rc < 0)

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1582,16 +1582,16 @@ int MotrObject::MotrDeleteOp::delete_obj(const DoutPrefixProvider* dpp, optional
           // If Bucket is versioned or versioning suspended, handle object deletion here.
           // Presently, do nothing.
           return 0;
-        } else {
-          if (source->category == RGWObjCategory::MultiMeta)
-            rc = source->delete_part_objs(dpp);
-          else
-            rc = source->delete_mobj(dpp);
-          if (rc < 0) {
-            ldpp_dout(dpp, 0) << "Failed to delete the object from Motr. " << dendl;
-            return rc;
-          }
-        }
+    } else {
+      if (source->category == RGWObjCategory::MultiMeta)
+        rc = source->delete_part_objs(dpp);
+      else
+        rc = source->delete_mobj(dpp);
+      if (rc < 0) {
+        ldpp_dout(dpp, 0) << "Failed to delete the object from Motr. " << dendl;
+        return rc;
+      }
+    }
   }
   // Finally, delete the object's entry from the bucket index.
   bufferlist bl;
@@ -3059,7 +3059,7 @@ int MotrMultipartUpload::complete(const DoutPrefixProvider *dpp,
       ldpp_dout(dpp, 20) << "MotrMultipartUpload::complete(): Old " << obj_type << " ["
           << old_mobj->get_name() <<  "] deleted succesfully" << dendl;
     } else {
-      ldpp_dout(dpp, 20) << "MotrMultipartUpload::complete(): Failed to delete old " << obj_type << " ["
+      ldpp_dout(dpp, 0) << "MotrMultipartUpload::complete(): Failed to delete old " << obj_type << " ["
           << old_mobj->get_name() <<  "]. Error = " << rc << dendl;
       return rc;
     }


### PR DESCRIPTION
Handle deletion of old object during object overwrite situation, while executing Complete multipart API.

Signed-off-by: Dattaprasad Govekar <dattaprasad.govekar@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
