### PR TITLE
rgw: [CORTX-30811]exclude src/pybind from repository scan

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,14 +1,12 @@
 {
   "scanSettings": {
-    "configMode": "AUTO",
-	"configExternalURL": "",
-	"projectToken": ""
+    "configMode": "LOCAL"
   },
   "checkRunSettings": {
     "displayMode": "diff",
     "vulnerableCheckRunConclusionLevel": "failure"
   },
   "issueSettings": {
-    "minSeverityLevel": "LOW"
+    "minSeverityLevel": "NONE"
   }
 }

--- a/whitesource.config
+++ b/whitesource.config
@@ -24,6 +24,9 @@ updateInventory=true
 #Exclude file extensions or specific directories by adding **/*.<extension> or **/<excluded_dir>/**
 excludes=**/src/pybind/**
 
+npm.ignoreDirectoryPatterns=**/cortx-rgw/src/pybind/**/*.json
+npm.resolveDependencies=true
+
 case.sensitive.glob=false
 followSymbolicLinks=true
 

--- a/whitesource.config
+++ b/whitesource.config
@@ -1,0 +1,32 @@
+###############################################################
+# WhiteSource configuration file
+###############################################################
+# GENERAL SCAN MODE: Files and Package Managers
+###############################################################
+# Organization vitals
+###############################################################
+
+# Change the below URL to your WhiteSource server.
+# Use the 'WhiteSource Server URL' which can be retrieved
+# from your 'Profile' page on the 'Server URLs' panel.
+# Then, add the '/agent' path to it.
+wss.url=https://saas.whitesourcesoftware.com/agent
+
+############
+# Policies #
+############
+checkPolicies=false
+forceCheckAllDependencies=false
+forceUpdate=false
+forceUpdate.failBuildOnPolicyViolation=false
+updateInventory=true
+
+#Exclude file extensions or specific directories by adding **/*.<extension> or **/<excluded_dir>/**
+excludes=**/src/pybind/**
+
+case.sensitive.glob=false
+followSymbolicLinks=true
+
+# Linux package manager settings
+################################
+scanPackageManager=false


### PR DESCRIPTION
Regarding github.com/cortx-rgw repository.

Whitesource scans are enabled on this repository.

Test result uncovered many vulnerabilities from the files in src/pybind folder.

After discussion with development team , it is found that contents in src/pybind are not part of cortx deliverables.

So creating this bug to exclude src/pybind folder from whitesource scanning.

This will result in whitesource not reporting any vulnerabilities for the files under src/pybind folder

JIRA ticket -> https://jts.seagate.com/browse/CORTX-30811

Signed-off-by: Swanand S Gadre <swanand.s.gadre@seagate.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [X] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>