### PR TITLE
rgw_sal_motr: [CORTX-30178] Fix for listing object versions in lexicographical order

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1034,6 +1034,19 @@ int MotrBucket::list(const DoutPrefixProvider *dpp, ListParams& params, int max,
     }
   }
 
+  // Sort the object versions
+  vector<rgw_bucket_dir_entry>::iterator iter;
+
+  for (iter = results.objs.begin(); iter != results.objs.end(); ++iter) {
+    std::sort(results.objs.begin(), results.objs.end(), [](const rgw_bucket_dir_entry& res1, const rgw_bucket_dir_entry& res2)
+    {
+      if (res1.key.name == res2.key.name)
+        return res1.meta.mtime > res2.meta.mtime;
+      else
+        return res1.key.name < res2.key.name;
+    });
+  }
+
   return 0;
 }
 

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1034,18 +1034,16 @@ int MotrBucket::list(const DoutPrefixProvider *dpp, ListParams& params, int max,
     }
   }
 
-  // Sort the object versions
+  // Sort by object versions
   vector<rgw_bucket_dir_entry>::iterator iter;
 
-  for (iter = results.objs.begin(); iter != results.objs.end(); ++iter) {
-    std::sort(results.objs.begin(), results.objs.end(), [](const rgw_bucket_dir_entry& res1, const rgw_bucket_dir_entry& res2)
-    {
-      if (res1.key.name == res2.key.name)
-        return res1.meta.mtime > res2.meta.mtime;
-      else
-        return res1.key.name < res2.key.name;
-    });
-  }
+  std::sort(results.objs.begin(), results.objs.end(), [](const rgw_bucket_dir_entry& res1, const rgw_bucket_dir_entry& res2)
+  {
+    if (res1.key.name == res2.key.name)
+      return res1.meta.mtime > res2.meta.mtime;
+    else
+      return res1.key.name < res2.key.name;
+  });
 
   return 0;
 }


### PR DESCRIPTION
Problem description:
* Object versions listed in random order in List Object Versions API

Solution:
* Sort the object versions based on last_modified_time of objects in MotrBucket::list() method.

Signed-off-by: Priyanka Salunke <priyanka.s.salunke@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
