### PR TITLE
rgw_sal_motr: [CORTX-30344]PutBucketTagging: Sets tags for a bucket

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -726,7 +726,7 @@ int MotrBucket::put_info(const DoutPrefixProvider *dpp, bool exclusive, ceph::re
 
   // Insert bucket instance using bucket's marker (string).
   int rc = store->do_idx_op_by_name(RGW_MOTR_BUCKET_INST_IDX_NAME,
-                                  M0_IC_PUT, tenant_bkt_name, bl, !exclusive);
+                                  M0_IC_PUT, tenant_bkt_name, bl, exclusive);
   if (rc == 0)
     store->get_bucket_inst_cache()->put(dpp, tenant_bkt_name, bl);
 


### PR DESCRIPTION
Problem:
PutBucketTagging API didn't work with motr as backend. It throws BucketAlreadyExists error while trying to set tags for a bucket

Resolution:
Slight modifications has been done in sal_motr code to enable the API.
Based on exclusive(boolean), it sets flags as M0_OIF_OVERWRITE which resolves BucketAlreadyExists error
```
M0_OIF_OVERWRITE -->For M0_IC_PUT operation, instructs it to silently overwrite existing record with the same key, if any
```

Results:
```
[root@ssc-vm-g2-rhev4-3138 ~]# aws --endpoint=$endpoint s3api put-bucket-tagging --bucket test-buckets --tagging '{"TagSet":[{ "Key": "team", "Value": "c5-solvers" }]}'
[root@ssc-vm-g2-rhev4-3138 ~]# aws --endpoint=$endpoint s3api get-bucket-tagging --bucket test-buckets                                {
    "TagSet": [
        {
            "Key": "team",
            "Value": "c5-solvers"
        }
    ]
}
```

Signed-off-by: Selvakumar <selva.k.nambi@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
