### PR TITLE
rgw_sal_motr: [CORTX-29112] Fix list-parts api for parallel multipart uploads.

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -2622,9 +2622,19 @@ int MotrMultipartUpload::delete_parts(const DoutPrefixProvider *dpp)
   } while (truncated);
 
   // Delete object part index.
-  std::string oid = mp_obj.get_key();
   string tenant_bkt_name = get_bucket_name(bucket->get_tenant(), bucket->get_name());
-  string obj_part_iname = "motr.rgw.object." + tenant_bkt_name + "." + oid + ".parts";
+  string upload_id = get_upload_id();
+  
+  if (upload_id.length() == 0){
+    rc = store->get_upload_id(tenant_bkt_name, mp_obj.get_key(), upload_id);
+    if (rc < 0) {
+      ldpp_dout(dpp, 0) << "ERROR: get_upload_id failed. " << rc << dendl;
+      return rc;
+    }
+  }
+
+  string obj_part_iname = "motr.rgw.object." + tenant_bkt_name + "." + mp_obj.get_key() + 
+                          "." + upload_id + ".parts";
   return store->delete_motr_idx_by_name(obj_part_iname);
 }
 
@@ -2669,16 +2679,19 @@ std::unique_ptr<rgw::sal::Object> MotrMultipartUpload::get_meta_obj()
 struct motr_multipart_upload_info
 {
   rgw_placement_rule dest_placement;
+  string upload_id;
 
   void encode(bufferlist& bl) const {
     ENCODE_START(1, 1, bl);
     encode(dest_placement, bl);
+    encode(upload_id, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(bufferlist::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(dest_placement, bl);
+    decode(upload_id, bl);
     DECODE_FINISH(bl);
   }
 };
@@ -2711,6 +2724,7 @@ int MotrMultipartUpload::init(const DoutPrefixProvider *dpp, optional_yield y,
 
     motr_multipart_upload_info upload_info;
     upload_info.dest_placement = dest_placement;
+    upload_info.upload_id = upload_id;
     bufferlist mpbl;
     encode(upload_info, mpbl);
 
@@ -2739,10 +2753,12 @@ int MotrMultipartUpload::init(const DoutPrefixProvider *dpp, optional_yield y,
   if (rc < 0)
     return rc;
   string tenant_bkt_name = get_bucket_name(bucket->get_tenant(), bucket->get_name());
+  //This is multipart init, you will always have upload id here.
+  string upload_id = get_upload_id();
 
   // Create object part index.
-  // TODO: add bucket as part of the name.
-  string obj_part_iname = "motr.rgw.object." + tenant_bkt_name + "." + oid + ".parts";
+  string obj_part_iname = "motr.rgw.object." + tenant_bkt_name + "." + mp_obj.get_key() +
+                          "." + upload_id + ".parts";
   ldpp_dout(dpp, 20) << "MotrMultipartUpload::init(): object part index=" << obj_part_iname << dendl;
   rc = store->create_motr_idx_by_name(obj_part_iname);
   if (rc == -EEXIST)
@@ -2766,9 +2782,19 @@ int MotrMultipartUpload::list_parts(const DoutPrefixProvider *dpp, CephContext *
   vector<string> key_vec(num_parts);
   vector<bufferlist> val_vec(num_parts);
 
-  std::string oid = mp_obj.get_key();
   string tenant_bkt_name = get_bucket_name(bucket->get_tenant(), bucket->get_name());
-  string obj_part_iname = "motr.rgw.object." + tenant_bkt_name + "." + oid + ".parts";
+  string upload_id = get_upload_id();
+
+  if(upload_id.length() == 0){
+    rc = store->get_upload_id(tenant_bkt_name, this->get_key(), upload_id);
+    if (rc < 0) {
+      ldpp_dout(dpp, 0) << "ERROR: get_upload_id failed. " << rc << dendl;
+      return rc;
+    }
+  }
+
+  string obj_part_iname = "motr.rgw.object." + tenant_bkt_name + "." + mp_obj.get_key() + 
+                          "." + upload_id + ".parts";
   ldpp_dout(dpp, 20) << __func__ << ": object part index = " << obj_part_iname << dendl;
   key_vec[0].clear();
   key_vec[0] = "part.";
@@ -3018,6 +3044,7 @@ int MotrMultipartUpload::complete(const DoutPrefixProvider *dpp,
   MotrObject::Meta meta_dummy;
   meta_dummy.encode(update_bl);
 
+
   string bucket_index_iname = "motr.rgw.bucket.index." + tenant_bkt_name;
   ldpp_dout(dpp, 20) << "MotrMultipartUpload::complete(): target_obj name=" << target_obj->get_name()
                                   << " target_obj oid=" << target_obj->get_oid() << dendl;
@@ -3182,8 +3209,12 @@ int MotrMultipartWriter::complete(size_t accounted_size, const std::string& etag
   snprintf(buf, sizeof(buf), "%08d", (int)part_num);
   p.append(buf);
   string tenant_bkt_name = get_bucket_name(head_obj->get_bucket()->get_tenant(), head_obj->get_bucket()->get_name());
+  
+  //This is a MultipartComplete operation so this should always have valid upload id.
+  string upload_id_str = upload_id;
+
   string obj_part_iname = "motr.rgw.object." + tenant_bkt_name + "." +
-	                  head_obj->get_key().to_str() + ".parts";
+	                  head_obj->get_key().to_str() + "." + upload_id_str + ".parts";
   ldpp_dout(dpp, 20) << "MotrMultipartWriter::complete(): object part index = " << obj_part_iname << dendl;
   rc = store->do_idx_op_by_name(obj_part_iname, M0_IC_PUT, p, bl);
   if (rc < 0) {
@@ -3191,6 +3222,36 @@ int MotrMultipartWriter::complete(size_t accounted_size, const std::string& etag
   }
 
   return 0;
+}
+
+int MotrStore::get_upload_id(string tenant_bkt_name, string key_name, string& upload_id){
+  int rc = 0;
+  bufferlist bl;
+
+  string index_name = "motr.rgw.bucket.index." + tenant_bkt_name;
+
+  rc = this->do_idx_op_by_name(index_name,
+                              M0_IC_GET, key_name, bl);
+  if (rc < 0) {
+    //ldpp_dout(cctx, 0) << "ERROR: NEXT query failed. " << rc << dendl;
+    return rc;
+  }
+
+  rgw_bucket_dir_entry ent;
+  bufferlist& blr = bl;
+  auto ent_iter = blr.cbegin();
+  ent.decode(ent_iter);
+
+  motr_multipart_upload_info upload_info;
+  bufferlist mpbl;
+  mpbl.append(ent.meta.user_data.c_str(), ent.meta.user_data.size());
+  auto mpbl_iter = mpbl.cbegin();
+  upload_info.decode(mpbl_iter);
+
+  upload_id.clear();
+  upload_id.append(upload_info.upload_id);
+
+  return rc;
 }
 
 std::unique_ptr<RGWRole> MotrStore::get_role(std::string name,

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -770,6 +770,7 @@ protected:
   uint64_t actual_part_size = 0;
   // Part object size available from Content-Length header
   uint64_t expected_part_size = 0;
+  const std::string upload_id;
 
 public:
   MotrMultipartWriter(const DoutPrefixProvider *dpp,
@@ -780,7 +781,7 @@ public:
 		       const rgw_placement_rule *ptail_placement_rule,
 		       uint64_t _part_num, const std::string& part_num_str) :
 				  Writer(dpp, y), store(_store), head_obj(std::move(_head_obj)),
-				  part_num(_part_num), part_num_str(part_num_str)
+				  part_num(_part_num), part_num_str(part_num_str), upload_id(upload->get_upload_id())
   {
     struct req_state *s = static_cast<struct req_state *>(obj_ctx.get_private());
     if (s) {
@@ -865,7 +866,8 @@ class MotrMultipartUpload : public MultipartUpload {
 public:
   MotrMultipartUpload(MotrStore* _store, Bucket* _bucket, const std::string& oid,
                       std::optional<std::string> upload_id, ACLOwner _owner, ceph::real_time _mtime) :
-       MultipartUpload(_bucket), store(_store), mp_obj(oid, upload_id), owner(_owner), mtime(_mtime) {}
+       MultipartUpload(_bucket), store(_store), mp_obj(oid, upload_id), owner(_owner), mtime(_mtime) {
+       }
   virtual ~MotrMultipartUpload() = default;
 
   virtual const std::string& get_meta() const { return mp_obj.get_meta(); }
@@ -1010,6 +1012,7 @@ class MotrStore : public Store {
     virtual int get_oidc_providers(const DoutPrefixProvider *dpp,
         const std::string& tenant,
         std::vector<std::unique_ptr<RGWOIDCProvider>>& providers) override;
+    int get_upload_id(std::string tenant_bkt_name, std::string key_name, std::string& upload_id);
     virtual std::unique_ptr<Writer> get_append_writer(const DoutPrefixProvider *dpp,
         optional_yield y,
         std::unique_ptr<rgw::sal::Object> _head_obj,


### PR DESCRIPTION
Problem :

Current Multipart uploads had part details in an index named
"motr.rgw.object." + tenant_bkt_name + "." + oid + "." +  ".parts".
Due to this behavior 2 Multipart uploads for same object would
share same table and list each others parts, and may lead to corrupted data

Solution :

Changed the current implementation by appending upload_id
to the index name. This creates seperate index table for
each upload id where all parts related to that upload id
would be present.

<details>
<summary>Testing</summary>

> [root@ssc-vm-g4-rhev4-0344 build]# aws s3api create-multipart-upload --bucket testbucket1 --key dmultipartup2 --endpoint-url http://127.0.0.1:8000
> {
>     "Bucket": "testbucket1",
>     "Key": "dmultipartup2",
>     "UploadId": "2~ZsW30EjwvJb0jgTNvffovl6FCeUGBL6"
> }
> [root@ssc-vm-g4-rhev4-0344 build]# aws s3api upload-part --bucket testbucket1 --key dmultipartup2 --part-number 1 --body 5.8mfile --upload-id "2~ZsW30EjwvJb0jgTNvffovl6FCeUGBL6" --endpoint-url http://127.0.0.1:8000
> {
>     "ETag": "\"e172cb0ac71b925da96ccdc004998730\""
> }
> [root@ssc-vm-g4-rhev4-0344 build]# aws s3api create-multipart-upload --bucket testbucket1 --key dmultipartup2 --endpoint-url http://127.0.0.1:8000                      {
>     "Bucket": "testbucket1",
>     "Key": "dmultipartup2",
>     "UploadId": "2~4kiQkHgUcVUV-ATbASZbHEmSlHrN4Es"
> }
> [root@ssc-vm-g4-rhev4-0344 build]# aws s3api upload-part --bucket testbucket1 --key dmultipartup2 --part-number 1 --body 5.8mfile --upload-id "2~4kiQkHgUcVUV-ATbASZbHEmSlHrN4Es" --endpoint-url http://127.0.0.1:8000
> {
>     "ETag": "\"e172cb0ac71b925da96ccdc004998730\""
> }
> [root@ssc-vm-g4-rhev4-0344 build]# aws s3api upload-part --bucket testbucket1 --key dmultipartup2 --part-number 2 --body 5.8mfile --upload-id "2~4kiQkHgUcVUV-ATbASZbHEmSlHrN4Es" --endpoint-url http://127.0.0.1:8000
> {
>     "ETag": "\"e172cb0ac71b925da96ccdc004998730\""
> }
> [root@ssc-vm-g4-rhev4-0344 build]# aws s3api list-parts --bucket testbucket1 --key dmultipartup2 --upload-id "2~4kiQkHgUcVUV-ATbASZbHEmSlHrN4Es" --endpoint-url http://127.0.0.1:8000
> {
>     "Parts": [
>         {
>             "PartNumber": 1,
>             "LastModified": "2022-04-26T08:45:16.485Z",
>             "ETag": "\"e172cb0ac71b925da96ccdc004998730\"",
>             "Size": 6062080
>         },
>         {
>             "PartNumber": 2,
>             "LastModified": "2022-04-26T08:45:29.305Z",
>             "ETag": "\"e172cb0ac71b925da96ccdc004998730\"",
>             "Size": 6062080
>         }
>     ],
>     "Initiator": null,
>     "Owner": {
>         "DisplayName": "",
>         "ID": ""
>     },
>     "StorageClass": "STANDARD"
> }
> [root@ssc-vm-g4-rhev4-0344 build]# aws s3api list-parts --bucket testbucket1 --key dmultipartup2 --upload-id "2~ZsW30EjwvJb0jgTNvffovl6FCeUGBL6" --endpoint-url http://127.0.0.1:8000
> {
>     "Parts": [
>         {
>             "PartNumber": 1,
>             "LastModified": "2022-04-26T08:44:45.039Z",
>             "ETag": "\"e172cb0ac71b925da96ccdc004998730\"",
>             "Size": 6062080
>         }
>     ],
>     "Initiator": null,
>     "Owner": {
>         "DisplayName": "",
>         "ID": ""
>     },
>     "StorageClass": "STANDARD"
> }
> [root@ssc-vm-g4-rhev4-0344 build]# aws s3api complete-multipart-upload --bucket testbuc^Ct1 --key dmultipartup1 --multipart-upload file://mpustruct --upload-id "2~LI3QszkyxpNV4KImi1rYfrxEgWS3fMH" --endpoint-url http://127.0.0.1:8000
> [root@ssc-vm-g4-rhev4-0344 build]# vim mpustruct1
> [root@ssc-vm-g4-rhev4-0344 build]# aws s3api complete-multipart-upload --bucket testbucket1 --key dmultipartup2 --multipart-upload file://mpustruct1 --upload-id "2~ZsW30EjwvJb0jgTNvffovl6FCeUGBL6" --endpoint-url http://127.0.0.1:8000
> {
>     "Location": "http://127.0.0.1:8000/testbucket1/dmultipartup2",
>     "Bucket": "testbucket1",
>     "Key": "dmultipartup2",
>     "ETag": ""
> }
> [root@ssc-vm-g4-rhev4-0344 build]# aws s3 ls s3://testbucket1 --endpoint-url http://127.0.0.1:8000                                                                      2022-04-22 01:36:25   12124160 dmultipartup1
> 2022-04-26 02:47:28    6062080 dmultipartup2
> [root@ssc-vm-g4-rhev4-0344 build]# aws s3api complete-multipart-upload --bucket testbucket1 --key dmultipartup2 --multipart-upload file://mpustruct --upload-id "2~4kiQkHgUcVUV-ATbASZbHEmSlHrN4Es" --endpoint-url http://127.0.0.1:8000
> {
>     "Location": "http://127.0.0.1:8000/testbucket1/dmultipartup2",
>     "Bucket": "testbucket1",
>     "Key": "dmultipartup2",
>     "ETag": ""
> }
> [root@ssc-vm-g4-rhev4-0344 build]# aws s3 ls s3://testbucket1 --endpoint-url http://127.0.0.1:8000                                                                      2022-04-22 01:36:25   12124160 dmultipartup1
> 2022-04-26 02:51:39   12124160 dmultipartup2
> [root@ssc-vm-g4-rhev4-0344 build]# aws s3api delete-object --bucket testbucket1 --key dmultipartup2 --endpoint-url http://127.0.0.1:8000
> [root@ssc-vm-g4-rhev4-0344 build]# aws s3 ls s3://testbucket1 --endpoint-url http://127.0.0.1:8000
> 2022-04-22 01:36:25   12124160 dmultipartup1

</details>

Signed-off-by: Deepak Mahale <deepak.mahale@seagate.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
