### PR TITLE
rgw_sal_motr: [CORTX-29962] Optimise object storage size

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -62,6 +62,11 @@ static std::string motr_global_indices[] = {
   RGW_IAM_MOTR_EMAIL_KEY
 };
 
+static unsigned roundup(unsigned x, unsigned by)
+{
+  return ((x - 1) / by + 1) * by;
+}
+
 void MotrMetaCache::invalid(const DoutPrefixProvider *dpp,
                            const string& name)
 {
@@ -1873,7 +1878,7 @@ void MotrObject::close_mobj()
 int MotrObject::write_mobj(const DoutPrefixProvider *dpp, bufferlist&& in_buffer, uint64_t offset)
 {
   int rc;
-  unsigned bs, left;
+  int64_t bs, left;
   struct m0_op *op;
   char *start, *p;
   struct m0_bufvec buf;
@@ -1932,9 +1937,16 @@ int MotrObject::write_mobj(const DoutPrefixProvider *dpp, bufferlist&& in_buffer
     if (left < bs)
       bs = this->get_optimal_bs(left);
     if (left < bs) {
+      // This is the last I/O.
+      // Pad to allign with unit size (and not the group size) and 
+      // set M0_ENF_NO_RMW flag to force no RMW
+      mobj->ob_entity.en_flags |= M0_ENF_NO_RMW;
+      uint64_t lid = M0_OBJ_LAYOUT_ID(meta.layout_id);
+      unsigned unit_sz = m0_obj_layout_id_to_unit_size(lid);
+
+      bs = roundup(left, unit_sz);
       ldpp_dout(dpp, 20) <<__func__<< " Padding [" << (bs - left) << "] bytes" << dendl;
       data.append_zero(bs - left);
-      left = bs;
       p = data.c_str();
     }
     buf.ov_buf[0] = p;
@@ -2322,11 +2334,6 @@ int MotrObject::read_multipart_obj(const DoutPrefixProvider* dpp,
   return 0;
 }
 
-static unsigned roundup(unsigned x, unsigned by)
-{
-  return ((x - 1) / by + 1) * by;
-}
-
 unsigned MotrObject::get_optimal_bs(unsigned len)
 {
   struct m0_pool_version *pver;
@@ -2397,7 +2404,7 @@ unsigned MotrAtomicWriter::populate_bvec(unsigned len, bufferlist::iterator &bi)
 int MotrAtomicWriter::write()
 {
   int rc;
-  unsigned bs, left;
+  int64_t bs, left;
   struct m0_op *op;
   bufferlist::iterator bi;
 
@@ -2428,7 +2435,16 @@ int MotrAtomicWriter::write()
     if (left < bs)
       bs = obj.get_optimal_bs(left);
     if (left < bs) {
-      acc_data.append_zero(bs - left);
+      // Pad to allign with unit size (and not the group size) and 
+      // set M0_ENF_NO_RMW flag to force no RMW
+      obj.mobj->ob_entity.en_flags |= M0_ENF_NO_RMW;
+      uint64_t lid = M0_OBJ_LAYOUT_ID(obj.meta.layout_id);
+      unsigned unit_sz = m0_obj_layout_id_to_unit_size(lid);
+
+      unsigned left_alligned_unit_sz = roundup(left, unit_sz);
+      ldpp_dout(dpp, 20) <<__func__<< " Padding [" << (left_alligned_unit_sz - left) << "] bytes" << dendl;
+      acc_data.append_zero(left_alligned_unit_sz - left);
+      bs = left_alligned_unit_sz;
       auto off = bi.get_off();
       bufferlist tmp;
       acc_data.splice(off, bs, &tmp);


### PR DESCRIPTION
Problem:
Object's size on backend Motr storage shows more space than expected in a given
storage configuration. This was due to padding done to align data to the group size.

Resolution:
The padding done to the last IO in data alignment can be minimized further by aligning data to
the unit size boundary, instead of group size. The unit size aligned padding
requires the use of RMW flag from Motr backend storage to indicate no RMW
operation  when number of units available are less than the group size.

Signed-off-by: Dattaprasad Govekar <dattaprasad.govekar@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
