### PR TITLE
rgw_usage:CORTX-30360: Added Storage Stats as part of usage API to get capacity used by a user.

### DIFF
--- a/src/rgw/rgw_usage.cc
+++ b/src/rgw/rgw_usage.cc
@@ -145,6 +145,41 @@ int RGWUsage::show(const DoutPrefixProvider *dpp, rgw::sal::Store* store,
 
     formatter->close_section(); // summary
   }
+  
+  // Added storage stats for a user as part of this API
+  // New section StorageStats added as part of usage
+  // Steps - 1. Update user stats for the user
+  //         2. Read those stats and add in StorageStats section
+  ret = rgw_user_sync_all_stats(dpp, store, user, null_yield);
+
+  if (ret < 0) {
+      return ret;
+  }
+
+  constexpr bool omit_utilized_stats = false;
+  RGWStorageStats stats(omit_utilized_stats);
+  ceph::real_time last_stats_sync;
+  ceph::real_time last_stats_update;
+
+  ret = user->read_stats(dpp, null_yield, &stats, &last_stats_sync, &last_stats_update);
+
+  if (ret < 0) {
+      return ret;
+  }
+
+  formatter->open_array_section("StorageStats");
+  encode_json("size", stats.size, formatter);
+  encode_json("size_actual", stats.size_rounded, formatter);
+  encode_json("size_kb", rgw_rounded_kb(stats.size), formatter);
+  encode_json("size_kb_actual", rgw_rounded_kb(stats.size_rounded), formatter);
+  encode_json("num_objects", stats.num_objects, formatter);
+  utime_t last_sync_ut(last_stats_sync);
+  encode_json("last_stats_sync", last_sync_ut, formatter);
+  utime_t last_update_ut(last_stats_update);
+  encode_json("last_stats_update", last_update_ut, formatter);
+
+  flusher.flush();
+  formatter->close_section(); // CapacityUsed
 
   formatter->close_section(); // usage
   flusher.flush();


### PR DESCRIPTION
Problem : Storage stats for a user was not there as part of usage API.
Solution : Updated stats for a user and added those fields as part of usage API.
Signed-off-by: Diwakar92 <diwakar.kumar@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
