### PR TITLE
rgw_sal_motr: [CORTX-30790] Fix for max-uploads and prefix parameter in list multipart upload api

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1028,7 +1028,8 @@ int MotrBucket::list_multiparts(const DoutPrefixProvider *dpp,
   if( max_uploads <= 0 )
 	return rc;
   int upl = max_uploads;
-  upl++;
+  if( marker != "" )
+	upl++;
   vector<string> key_vec(upl);
   vector<bufferlist> val_vec(upl);
   string tenant_bkt_name = get_bucket_name(this->get_tenant(), this->get_name());
@@ -1062,15 +1063,15 @@ int MotrBucket::list_multiparts(const DoutPrefixProvider *dpp,
     auto iter = bl.cbegin();
     ent.decode(iter);
 
+    rgw_obj_key key(ent.key);
     if (prefix.size() &&
-        (0 != ent.key.name.compare(0, prefix.size(), prefix))) {
+        (0 != key.name.compare(0, prefix.size(), prefix))) {
       ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__ <<
         ": skippping \"" << ent.key <<
         "\" because doesn't match prefix" << dendl;
       continue;
     }
 
-    rgw_obj_key key(ent.key);
     uploads.push_back(this->get_multipart_upload(key.name));
     last_obj_key = key;
     ocount++;


### PR DESCRIPTION
Signed-off-by: dharmendra-jyani <dharmendra.jyani@seagate.com>

**Problem:-** list-multipart-upload api parameter max-upload and prefix are not working as expected.
**Fix:**- One condition was not added for max-uploads parameter, because of that it was listing one more upload, added the condition such that it should list according to the given input. 
For prefix parameter we were comparing the wrong data source in code, so changed with correct data source so that can list all the parameters according to the prefix.

**Test results**
1)
[root@ssc-vm-g4-rhev4-0761 ~]# aws s3api list-multipart-uploads --bucket testbucket3  --prefix "ab"
{
    "Uploads": [
        {
            "UploadId": "2~FEM8fSC_H7llkOMiTVTG8ru-Sxq0WHn",
            "Key": "ab",
            "Initiated": "2022-05-02T05:35:38.426Z",
            "StorageClass": "STANDARD",
            "Owner": {
                "DisplayName": "",
                "ID": ""
            },
            "Initiator": {
                "ID": "",
                "DisplayName": ""
            }
        }
    ]
}

2) [root@ssc-vm-g4-rhev4-0761 ~]# aws s3api list-multipart-uploads --bucket testbucket3  --prefix "a/b"
{
    "Uploads": [
        {
            "UploadId": "2~wb4CmMRIzzKSjguoJ3dprgBP5KoErye",
            "Key": "a/ba/c",
            "Initiated": "2022-05-02T05:36:36.141Z",
            "StorageClass": "STANDARD",
            "Owner": {
                "DisplayName": "",
                "ID": ""
            },
            "Initiator": {
                "ID": "",
                "DisplayName": ""
            }
        }
    ]
}

**For max-uploads**
[root@ssc-vm-g4-rhev4-0761 ~]# aws s3api list-multipart-uploads --bucket testbucket3  --max-uploads 2
{
    "Bucket": "testbucket3",
    "NextKeyMarker": "a/aa",
    "NextUploadIdMarker": "2~bDELniBceCbLdnsJsJJjXVs9fEKYma9",
    "MaxUploads": 2,
    "IsTruncated": true,
    "Uploads": [
        {
            "UploadId": "2~WyGOSkVJSeQziBMZOS2xpeL2SfBEPdK",
            "Key": "a",
            "Initiated": "2022-05-02T05:37:12.463Z",
            "StorageClass": "STANDARD",
            "Owner": {
                "DisplayName": "",
                "ID": ""
            },
            "Initiator": {
                "ID": "",
                "DisplayName": ""
            }
        },
        {
            "UploadId": "2~bDELniBceCbLdnsJsJJjXVs9fEKYma9",
            "Key": "a/aa",
            "Initiated": "2022-05-02T05:37:12.463Z",
            "StorageClass": "STANDARD",
            "Owner": {
                "DisplayName": "",
                "ID": ""
            },
            "Initiator": {
                "ID": "",
                "DisplayName": ""
            }
        }
    ]
}


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

