### PR TITLE
rgw_sal_motr : [CORTX-27638] : Fix for Head and Get object with version-id parameter

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -2105,7 +2105,7 @@ int MotrObject::get_bucket_dir_ent(const DoutPrefixProvider *dpp, rgw_bucket_dir
       rc = this->store->do_idx_op_by_name(bucket_index_iname,
                           M0_IC_GET, this->get_key().to_str(), bl);
       if(rc < 0) {
-        ldpp_dout(dpp, 0) << __func__ << "ERROR: failed to get object's entry from bucket index: rc="
+        ldpp_dout(dpp, 0) << __func__ << " ERROR: do_idx_op_by_name failed to get object's entry: rc="
                           << rc << dendl;
         return rc;
       }

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -2089,13 +2089,13 @@ int MotrObject::get_bucket_dir_ent(const DoutPrefixProvider *dpp, rgw_bucket_dir
   if (this->get_bucket()->get_info().versioning_status() == BUCKET_VERSIONED ||
       this->get_bucket()->get_info().versioning_status() == BUCKET_SUSPENDED) {
 
-    rgw_bucket_dir_entry ent_to_check;
+    //rgw_bucket_dir_entry ent_to_check;
 
     // Check entry in the cache
     if (this->store->get_obj_meta_cache()->get(dpp, this->get_name(), bl) == 0) {
         iter = bl.cbegin();
-        ent_to_check.decode(iter);
-        ent = ent_to_check;
+        ent.decode(iter);
+        //ent = ent_to_check;
         rc = 0;
         goto out;
     }
@@ -2109,40 +2109,40 @@ int MotrObject::get_bucket_dir_ent(const DoutPrefixProvider *dpp, rgw_bucket_dir
                           M0_IC_GET, this->get_key().to_str(), bl);
       if(rc<0)
         return rc;
-      else
-      {
-        iter = bl.cbegin();
-        ent_to_check.decode(iter);
-        ent = ent_to_check;
-        rc = 0;
-        // Put into the cache
-        this->store->get_obj_meta_cache()->put(dpp, this->get_name(), bl);
-        goto out;
-      }
+
+      iter = bl.cbegin();
+      ent.decode(iter);
+      //ent = ent_to_check;
+      rc = 0;
+      // Put into the cache
+      this->store->get_obj_meta_cache()->put(dpp, this->get_name(), bl);
+      goto out;
+
     }
     else
     {  // Version-id instance is empty
        // Cache miss.
         keys[0] = this->get_name();
-        rc = store->next_query_by_name(bucket_index_iname, keys, vals);
+
+        rc = store->next_query_by_name(bucket_index_iname, keys, vals, this->get_name());
         if (rc < 0) {
           ldpp_dout(dpp, 0) << __func__ << "ERROR: NEXT query failed. " << rc << dendl;
           return rc;
         }
 
         rc = -ENOENT;
-  
+
         for (const auto& bl: vals) {
           if (bl.length() == 0)
             break;
 
           iter = bl.cbegin();
-          ent_to_check.decode(iter);
+          ent.decode(iter);
 
           // check the current object version
-          if (ent_to_check.is_current()) {
+          if (ent.is_current()) {
             ldpp_dout(dpp, 20) <<__func__<< ": found current version!" << dendl;
-            ent = ent_to_check;
+            //ent = ent_to_check;
             rc = 0;
             this->store->get_obj_meta_cache()->put(dpp, this->get_name(), bl);
             break;


### PR DESCRIPTION
Problem description:
- Head object and Get object with version-id attribute is giving latest version contents always in the response. 

Solution:
- Adding the conditions in the `get_bucket_dir_entry()` method to get the object contents of specific version.

During testing, some cache issues are observed in the head & get object API with specific version id. The Jira is created and added the observed cache issues there. - https://jts.seagate.com/browse/CORTX-31109. This code is tested with `rgw cache enabled = false` parameter. 

Head and Get object with null version-id cases will be covered in another PR - https://github.com/Seagate/cortx-rgw/pull/200

Signed-off-by: Priyanka Salunke <priyanka.s.salunke@seagate.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
