### PR TITLE
rgw_rest_bucket: [CORTX-31085] Support `max-size` attr for SetBucketQuota

### DIFF
--- a/src/rgw/rgw_rest_bucket.cc
+++ b/src/rgw/rgw_rest_bucket.cc
@@ -293,9 +293,12 @@ void RGWOp_Set_Bucket_Quota::execute(optional_yield y)
     RGWQuotaInfo *old_quota = &bucket->get_info().quota;
     int64_t old_max_size_kb = rgw_rounded_kb(old_quota->max_size);
     int64_t max_size_kb;
+    bool has_max_size_kb = false;
     RESTArgs::get_int64(s, "max-objects", old_quota->max_objects, &quota.max_objects);
-    RESTArgs::get_int64(s, "max-size-kb", old_max_size_kb, &max_size_kb);
-    quota.max_size = max_size_kb * 1024;
+    RESTArgs::get_int64(s, "max-size", old_quota->max_size, &quota.max_size);
+    RESTArgs::get_int64(s, "max-size-kb", old_max_size_kb, &max_size_kb, &has_max_size_kb);
+    if (has_max_size_kb)
+      quota.max_size = max_size_kb * 1024;
     RESTArgs::get_bool(s, "enabled", old_quota->enabled, &quota.enabled);
   }
 


### PR DESCRIPTION
`max-size` attr is not supported for SetBucketQuota as that of SetUserQuota.
Adding support for the attribute, keeping the `max-size-kb` as dominating in case
both are mentioned.

```bash
Wed, 4 May 2022 08:57:08 GMT
/admin/bucket
PUT http://ssc-vm-g4-rhev4-0318.colo.seagate.com:8000/admin/bucket?quota&bucket=mybkt&uid=mgwuser&max-size=990927 HTTP/1.1
Auth: AWS NB71GXG3O7MMBELODQOO:dCokdTJdD2C55V58gjndOmUGC20=
HTTP/1.1 200 OK

Response Content is:
```

```bash
Wed, 4 May 2022 08:57:27 GMT
/admin/bucket
GET http://ssc-vm-g4-rhev4-0318.colo.seagate.com:8000/admin/bucket?stats&bucket=mybkt&uid=mgwuser HTTP/1.1
Auth: AWS NB71GXG3O7MMBELODQOO:2A7il8HXIwz+WgV7aBJ4rDKTefY=
HTTP/1.1 200 OK

Response Content is: [{"bucket":"mybkt","num_shards":1,"tenant":"","zonegroup":"0956b174-fe14-4f97-8b50-bb7ec5e1cf62","placement_rule":"default","explicit_placement":{"data_pool":"","data_extra_pool":"","index_pool":""},"id":"","marker":"","index_type":"Normal","owner":"mgwuser","ver":"","master_ver":"","mtime":"0.000000","creation_time":"0.000000","max_marker":"","usage":{},
"bucket_quota":{"enabled":true,"check_on_raw":false,"max_size":990927,"max_size_kb":968,"max_objects":27}}]
```

Signed-off-by: Sumedh A. Kulkarni <sumedh.a.kulkarni@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
