### PR TITLE
rgw_sal_motr: [CORTX-31066] Fix multipart object download

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1919,25 +1919,42 @@ int MotrObject::write_mobj(const DoutPrefixProvider *dpp, bufferlist&& in_buffer
     return 0;
 
   processed_bytes += left;
+  int64_t available_data = 0;
+  if (io_ctxt.accumulated_buffer_list.size() > 0) {
+    // We are in data accumulation mode
+    available_data = io_ctxt.total_bufer_sz;
+  }
 
   bs = this->get_optimal_bs(left);
   ldpp_dout(dpp, 20) <<__func__<< ": left=" << left << " bs=" << bs << dendl;
-  if (left < bs) {
+  if ((left + available_data) < bs) {
     // Determine if there are any further chunks/bytes from socket to be processed
     int64_t remaining_bytes = expected_obj_size - processed_bytes;
     if (remaining_bytes > 0) {
+      if (io_ctxt.accumulated_buffer_list.size() == 0) {
+        // Save offset
+        io_ctxt.start_offset = offset;
+      }
       // Append current buffer to the list of accumulated buffers
       ldpp_dout(dpp, 20) <<__func__<< " More data (" <<  remaining_bytes << " bytes) in-flight. Accumulating buffer..." << dendl;
       io_ctxt.accumulated_buffer_list.push_back(std::move(data));
-      if (io_ctxt.start_offset == 0)
-        io_ctxt.start_offset = offset;
       io_ctxt.total_bufer_sz += left;
       return 0;
     } else {
-      // Append last buffer
+      // This is last IO. Check if we have previously accumulated buffers.
+      // If not, simply use in_buffer/data
+      if (io_ctxt.accumulated_buffer_list.size() > 0) {
+        // Append last buffer
+        io_ctxt.accumulated_buffer_list.push_back(std::move(data));
+        io_ctxt.total_bufer_sz += left;
+      }
+    }
+  } else if ((left + available_data) == bs)  {
+    // Ready to write data to Motr. Add it to accumulated buffer
+    if (io_ctxt.accumulated_buffer_list.size() > 0) {
       io_ctxt.accumulated_buffer_list.push_back(std::move(data));
       io_ctxt.total_bufer_sz += left;
-    }
+    } // else, simply use in_buffer
   }
 
   rc = m0_bufvec_empty_alloc(&buf, 1) ?:
@@ -1974,7 +1991,7 @@ int MotrObject::write_mobj(const DoutPrefixProvider *dpp, bufferlist&& in_buffer
       unsigned unit_sz = m0_obj_layout_id_to_unit_size(lid);
 
       bs = roundup(left, unit_sz);
-      ldpp_dout(dpp, 20) <<__func__<< " Padding [" << (bs - left) << "] bytes" << dendl;
+      ldpp_dout(dpp, 20) <<__func__<< " left ="<< left << ",bs=" << bs << ", Padding [" << (bs - left) << "] bytes" << dendl;
       data.append_zero(bs - left);
       p = data.c_str();
     }
@@ -1984,6 +2001,7 @@ int MotrObject::write_mobj(const DoutPrefixProvider *dpp, bufferlist&& in_buffer
     ext.iv_vec.v_count[0] = bs;
     attr.ov_vec.v_count[0] = 0;
 
+    ldpp_dout(dpp, 20) <<__func__<< "Write buffer bytes=[" << bs << "], at offset=[" << offset << "]" << dendl;
     op = nullptr;
     rc = m0_obj_op(this->mobj, M0_OC_WRITE, &ext, &buf, &attr, 0, 0, &op);
     if (rc != 0)
@@ -2001,6 +2019,9 @@ out:
   m0_indexvec_free(&ext);
   m0_bufvec_free(&attr);
   m0_bufvec_free2(&buf);
+  // Reset io_ctxt state
+  io_ctxt.start_offset = 0;
+  io_ctxt.total_bufer_sz = 0;
   return rc;
 }
 


### PR DESCRIPTION
Problem:
The download of multipart object fails when the part size is not
multiple of 4MB.
Due to logical issue in code, during object write, the last IO chunk is written to
the already written offset; thereby causing less object size. 
When such object is read, it tries to read more data than available, 
causing Motr to return -ENOENT.

Solution:
Fixed logical issue in code so that last IO write is done in the correct
offset/region of object space.

Signed-off-by: Dattaprasad Govekar <dattaprasad.govekar@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
