### PR TITLE
rgw_sal_motr: [CORTX-31087] Support delimiter parameter for multipart uploads.

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1065,7 +1065,7 @@ int MotrBucket::list_multiparts(const DoutPrefixProvider *dpp,
       "motr.rgw.bucket." + tenant_bkt_name + ".multiparts";
   key_vec[0].clear();
   key_vec[0].assign(marker.begin(), marker.end());
-  rc = store->next_query_by_name(bucket_multipart_iname, key_vec, val_vec);
+  rc = store->next_query_by_name(bucket_multipart_iname, key_vec, val_vec, prefix, delim);
   if (rc < 0) {
     ldpp_dout(dpp, 0) << "ERROR: NEXT query failed. " << rc << dendl;
     return rc;
@@ -1077,9 +1077,11 @@ int MotrBucket::list_multiparts(const DoutPrefixProvider *dpp,
   int ocount = 0;
   rgw_obj_key last_obj_key;
   *is_truncated = false;
-  for (const auto& bl: val_vec) {
+
+   for (auto& bl : val_vec) {
+    
     if (bl.length() == 0)
-      break;
+      continue;
 
     if((marker != "") && (ocount == 0))
     {

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1082,7 +1082,7 @@ int MotrBucket::list_multiparts(const DoutPrefixProvider *dpp,
   rgw_obj_key last_obj_key;
   *is_truncated = false;
 
-   for (auto& bl : val_vec) {
+  for (const auto& bl: val_vec) {
     
     if (bl.length() == 0)
       continue;


### PR DESCRIPTION
Problem :
Delimiter parameter not supported in multipart uploads.
For example the below query wont filter out multiparts begining
with test
aws s3api list-multipart-uploads --bucket multiparttable --delimiter test --endpoint-url http://127.0.0.1:8000


Solution :
Passed delimiter parameter to query api of motr.
changed the loop for evaluation of results.

Signed-off-by: Deepak Mahale <deepak.mahale@seagate.com>

<details>
<summary>Testing Done</summary>

> [root@ssc-vm-g4-rhev4-0344 build]#  aws s3api list-multipart-uploads --bucket multiparttable --endpoint-url http://127.0.0.1:8000
> {
>     "Uploads": [
>         {
>             "UploadId": "2~zo4vCNd1kt5gWqbL9XYdIgGmOYuLcKK",
>             "Key": "deep",
>             "Initiated": "2022-05-10T10:53:05.624Z",
>             "StorageClass": "STANDARD",
>             "Owner": {
>                 "DisplayName": "",
>                 "ID": ""
>             },
>             "Initiator": {
>                 "ID": "",
>                 "DisplayName": ""
>             }
>         },
>         {
>             "UploadId": "2~kEBS8BPJO1ad_vNq3Lb5ZkIfVnCwrJz",
>             "Key": "deepak",
>             "Initiated": "2022-05-10T10:53:05.624Z",
>             "StorageClass": "STANDARD",
>             "Owner": {
>                 "DisplayName": "",
>                 "ID": ""
>             },
>             "Initiator": {
>                 "ID": "",
>                 "DisplayName": ""
>             }
>         },
>         {
>             "UploadId": "2~uz7pbejnmz8uTlFQs12E4LBItO1x8QA",
>             "Key": "test1",
>             "Initiated": "2022-05-10T10:53:05.624Z",
>             "StorageClass": "STANDARD",
>             "Owner": {
>                 "DisplayName": "",
>                 "ID": ""
>             },
>             "Initiator": {
>                 "ID": "",
>                 "DisplayName": ""
>             }
>         },
>         {
>             "UploadId": "2~Wo1rXY09s_Bk2o5omJtfOC85QFkfHc7",
>             "Key": "test2",
>             "Initiated": "2022-05-10T10:53:05.624Z",
>             "StorageClass": "STANDARD",
>             "Owner": {
>                 "DisplayName": "",
>                 "ID": ""
>             },
>             "Initiator": {
>                 "ID": "",
>                 "DisplayName": ""
>             }
>         },
>         {
>             "UploadId": "2~TJAtrN6ZG11NkYBqe7yRhSFDyrBAHR1",
>             "Key": "test3",
>             "Initiated": "2022-05-10T10:53:05.624Z",
>             "StorageClass": "STANDARD",
>             "Owner": {
>                 "DisplayName": "",
>                 "ID": ""
>             },
>             "Initiator": {
>                 "ID": "",
>                 "DisplayName": ""
>             }
>         },
>         {
>             "UploadId": "2~Xcfa4k2BUD0QRxZznHVB3ukQDDLVWGm",
>             "Key": "test4",
>             "Initiated": "2022-05-10T10:53:05.624Z",
>             "StorageClass": "STANDARD",
>             "Owner": {
>                 "DisplayName": "",
>                 "ID": ""
>             },
>             "Initiator": {
>                 "ID": "",
>                 "DisplayName": ""
>             }
>         }
>     ]
> }
> [root@ssc-vm-g4-rhev4-0344 build]#  aws s3api list-multipart-uploads --bucket multiparttable --delimiter ak --prefix deep --endpoint-url http://127.0.0.1:8000
> {
>     "Uploads": [
>         {
>             "UploadId": "2~zo4vCNd1kt5gWqbL9XYdIgGmOYuLcKK",
>             "Key": "deep",
>             "Initiated": "2022-05-10T10:53:14.329Z",
>             "StorageClass": "STANDARD",
>             "Owner": {
>                 "DisplayName": "",
>                 "ID": ""
>             },
>             "Initiator": {
>                 "ID": "",
>                 "DisplayName": ""
>             }
>         }
>     ]
> }
> [root@ssc-vm-g4-rhev4-0344 build]#  aws s3api list-multipart-uploads --bucket multiparttable --delimiter test --endpoint-url http://127.0.0.1:8000
> {
>     "Uploads": [
>         {
>             "UploadId": "2~zo4vCNd1kt5gWqbL9XYdIgGmOYuLcKK",
>             "Key": "deep",
>             "Initiated": "2022-05-10T10:53:22.502Z",
>             "StorageClass": "STANDARD",
>             "Owner": {
>                 "DisplayName": "",
>                 "ID": ""
>             },
>             "Initiator": {
>                 "ID": "",
>                 "DisplayName": ""
>             }
>         },
>         {
>             "UploadId": "2~kEBS8BPJO1ad_vNq3Lb5ZkIfVnCwrJz",
>             "Key": "deepak",
>             "Initiated": "2022-05-10T10:53:22.502Z",
>             "StorageClass": "STANDARD",
>             "Owner": {
>                 "DisplayName": "",
>                 "ID": ""
>             },
>             "Initiator": {
>                 "ID": "",
>                 "DisplayName": ""
>             }
>         }
>     ]
> }
> [root@ssc-vm-g4-rhev4-0344 build]#  aws s3api list-multipart-uploads --bucket multiparttable --delimiter d --endpoint-url http://127.0.0.1:8000
> {
>     "Uploads": [
>         {
>             "UploadId": "2~uz7pbejnmz8uTlFQs12E4LBItO1x8QA",
>             "Key": "test1",
>             "Initiated": "2022-05-10T10:53:35.432Z",
>             "StorageClass": "STANDARD",
>             "Owner": {
>                 "DisplayName": "",
>                 "ID": ""
>             },
>             "Initiator": {
>                 "ID": "",
>                 "DisplayName": ""
>             }
>         },
>         {
>             "UploadId": "2~Wo1rXY09s_Bk2o5omJtfOC85QFkfHc7",
>             "Key": "test2",
>             "Initiated": "2022-05-10T10:53:35.432Z",
>             "StorageClass": "STANDARD",
>             "Owner": {
>                 "DisplayName": "",
>                 "ID": ""
>             },
>             "Initiator": {
>                 "ID": "",
>                 "DisplayName": ""
>             }
>         },
>         {
>             "UploadId": "2~TJAtrN6ZG11NkYBqe7yRhSFDyrBAHR1",
>             "Key": "test3",
>             "Initiated": "2022-05-10T10:53:35.432Z",
>             "StorageClass": "STANDARD",
>             "Owner": {
>                 "DisplayName": "",
>                 "ID": ""
>             },
>             "Initiator": {
>                 "ID": "",
>                 "DisplayName": ""
>             }
>         },
>         {
>             "UploadId": "2~Xcfa4k2BUD0QRxZznHVB3ukQDDLVWGm",
>             "Key": "test4",
>             "Initiated": "2022-05-10T10:53:35.432Z",
>             "StorageClass": "STANDARD",
>             "Owner": {
>                 "DisplayName": "",
>                 "ID": ""
>             },
>             "Initiator": {
>                 "ID": "",
>                 "DisplayName": ""
>             }
>         }
>     ]
> }

</details>



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
