### PR TITLE
rgw_sal_motr: [CORTX-31196]PutBucketTagging: Call put_info() with false to update the attributes

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -275,7 +275,7 @@ int MotrUser::create_bucket(const DoutPrefixProvider* dpp,
     // Create a new bucket: (1) Add a key/value pair in the
     // bucket instance index. (2) Create a new bucket index.
     MotrBucket* mbucket = static_cast<MotrBucket*>(bucket.get());
-    ret = mbucket->put_info(dpp, y, ceph::real_time())? :
+    ret = mbucket->put_info(dpp, true, ceph::real_time())? :
           mbucket->create_bucket_index() ? :
           mbucket->create_multipart_indices();
     if (ret < 0)
@@ -721,9 +721,6 @@ int MotrBucket::put_info(const DoutPrefixProvider *dpp, bool exclusive, ceph::re
   bufferlist bl;
   struct MotrBucketInfo mbinfo;
   string tenant_bkt_name = get_bucket_name(info.bucket.tenant, info.bucket.name);
-  
-  // Set exclusive to false for put bucket tags
-  exclusive = (attrs.find(RGW_ATTR_TAGS) == attrs.end());
 
   ldpp_dout(dpp, 20) << "put_info(): bucket_id=" << info.bucket.bucket_id << dendl;
   mbinfo.info = info;
@@ -901,7 +898,8 @@ int MotrBucket::merge_and_store_attrs(const DoutPrefixProvider *dpp, Attrs& new_
   for (auto& it : new_attrs)
     attrs[it.first] = it.second;
 
-  return put_info(dpp, y, ceph::real_time());
+  // Call put_info with false to update the attributes
+  return put_info(dpp, false, ceph::real_time());
 }
 
 int MotrBucket::try_refresh_info(const DoutPrefixProvider *dpp, ceph::real_time *pmtime)

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -900,8 +900,8 @@ int MotrBucket::merge_and_store_attrs(const DoutPrefixProvider *dpp, Attrs& new_
   for (auto& it : new_attrs)
     attrs[it.first] = it.second;
 
-  // "put_info" is meant to update existing metadata, by
-  // explicitly passing false. Passing "yield" was incorrect
+  // "put_info" second bool argument is meant to update existing metadata,
+  // which is not needed here. So explicitly passing false.
   return put_info(dpp, false, ceph::real_time());
 }
 

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -275,6 +275,9 @@ int MotrUser::create_bucket(const DoutPrefixProvider* dpp,
     // Create a new bucket: (1) Add a key/value pair in the
     // bucket instance index. (2) Create a new bucket index.
     MotrBucket* mbucket = static_cast<MotrBucket*>(bucket.get());
+	
+	// "put_info" accepts boolean value mentioning whether to create new or update existing. 
+    // "yield" is not a boolean flag, hence explicitly passing true to create a new record.
     ret = mbucket->put_info(dpp, true, ceph::real_time())? :
           mbucket->create_bucket_index() ? :
           mbucket->create_multipart_indices();
@@ -898,7 +901,8 @@ int MotrBucket::merge_and_store_attrs(const DoutPrefixProvider *dpp, Attrs& new_
   for (auto& it : new_attrs)
     attrs[it.first] = it.second;
 
-  // Call put_info with false to update the attributes
+  // "merge_and_store_attrs" is meant to updating existing metadata, 
+  // hence explicitly passing false. Passing "yield" was incorrect
   return put_info(dpp, false, ceph::real_time());
 }
 

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -721,6 +721,9 @@ int MotrBucket::put_info(const DoutPrefixProvider *dpp, bool exclusive, ceph::re
   bufferlist bl;
   struct MotrBucketInfo mbinfo;
   string tenant_bkt_name = get_bucket_name(info.bucket.tenant, info.bucket.name);
+  
+  // Set exclusive to false for put bucket tags
+  exclusive = (attrs.find(RGW_ATTR_TAGS) == attrs.end());
 
   ldpp_dout(dpp, 20) << "put_info(): bucket_id=" << info.bucket.bucket_id << dendl;
   mbinfo.info = info;
@@ -731,7 +734,7 @@ int MotrBucket::put_info(const DoutPrefixProvider *dpp, bool exclusive, ceph::re
 
   // Insert bucket instance using bucket's marker (string).
   int rc = store->do_idx_op_by_name(RGW_MOTR_BUCKET_INST_IDX_NAME,
-                                  M0_IC_PUT, tenant_bkt_name, bl, exclusive);
+                                  M0_IC_PUT, tenant_bkt_name, bl, !exclusive);
   if (rc == 0)
     store->get_bucket_inst_cache()->put(dpp, tenant_bkt_name, bl);
 

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -275,9 +275,8 @@ int MotrUser::create_bucket(const DoutPrefixProvider* dpp,
     // Create a new bucket: (1) Add a key/value pair in the
     // bucket instance index. (2) Create a new bucket index.
     MotrBucket* mbucket = static_cast<MotrBucket*>(bucket.get());
-	
-	// "put_info" accepts boolean value mentioning whether to create new or update existing. 
-    // "yield" is not a boolean flag, hence explicitly passing true to create a new record.
+    // "put_info" accepts boolean value mentioning whether to create new or update existing. 
+    // "yield" is not a boolean flag hence explicitly passing true to create a new record.
     ret = mbucket->put_info(dpp, true, ceph::real_time())? :
           mbucket->create_bucket_index() ? :
           mbucket->create_multipart_indices();
@@ -901,8 +900,8 @@ int MotrBucket::merge_and_store_attrs(const DoutPrefixProvider *dpp, Attrs& new_
   for (auto& it : new_attrs)
     attrs[it.first] = it.second;
 
-  // "merge_and_store_attrs" is meant to updating existing metadata, 
-  // hence explicitly passing false. Passing "yield" was incorrect
+  // "put_info" is meant to update existing metadata, by
+  // explicitly passing false. Passing "yield" was incorrect
   return put_info(dpp, false, ceph::real_time());
 }
 


### PR DESCRIPTION
Signed-off-by: Selvakumar <selva.k.nambi@seagate.com>

Problem:
Enabled PutBucketTagging API by removing negation in exclusive flag(#172 ). PutBucketVersioning API is affected due to this change. 

1. CreateBucket initially calls put_info() where exclusive=true, hence update=False.
2. PutBucketTagging calls put_info() where exclusive=false to make update=True. If PutBucketTagging is called with exclusive=True, it will try to CreateBucket again as mentioned in step 1

Resolution:
By setting exclusive to false in put_info() function updates the attributes and  resolves the issue

Results:
```
[root@ssc-vm-rhev4-2587 build]# aws --endpoint=$endpoint_url s3api put-bucket-versioning --bucket test-buckets --versioning-configura Status=Suspended
[root@ssc-vm-rhev4-2587 build]# aws --endpoint=$endpoint_url s3api get-bucket-versioning --bucket test-buckets
{
    "Status": "Suspended",
    "MFADelete": "Disabled"
}
[root@ssc-vm-rhev4-2587 build]# aws --endpoint=$endpoint_url s3api put-bucket-versioning --bucket test-buckets --versioning-configura Status=Enabled
[root@ssc-vm-rhev4-2587 build]# aws --endpoint=$endpoint_url s3api get-bucket-versioning --bucket test-buckets                       {
    "Status": "Enabled",
    "MFADelete": "Disabled"
}
[root@ssc-vm-rhev4-2587 build]#
[root@ssc-vm-rhev4-2587 build]#
[root@ssc-vm-rhev4-2587 build]#
[root@ssc-vm-rhev4-2587 build]#
[root@ssc-vm-rhev4-2587 build]# aws --endpoint=$endpoint_url s3api put-bucket-tagging --bucket test-buckets --tagging '{"TagSet":[{ ": "team", "Value": "c5-solvers12345" }]}'
[root@ssc-vm-rhev4-2587 build]# aws --endpoint=$endpoint_url s3api get-bucket-tagging --bucket test-buckets                          {
    "TagSet": [
        {
            "Key": "team",
            "Value": "c5-solvers12345"
        }
    ]
}
```

```
[root@ssc-vm-rhev4-2587 build]# bin/radosgw-admin quota set --uid mgwuser --bucket test-buckets --max-size 1024                      2022-05-10T05:21:19.222-0600 7fcb064db5c0 -1 WARNING: all dangerous and experimental features are enabled.
2022-05-10T05:21:19.263-0600 7fcb064db5c0 -1 WARNING: all dangerous and experimental features are enabled.
2022-05-10T05:21:19.265-0600 7fcb064db5c0 -1 WARNING: all dangerous and experimental features are enabled.
2022-05-10T05:21:19.265-0600 7fcb064db5c0  1 RGW CONF BACKEND STORE = motr
2022-05-10T05:21:19.265-0600 7fcb064db5c0  1 RGW BACKEND STORE = motr
2022-05-10T05:21:19.265-0600 7fcb064db5c0  0 INFO: motr my endpoint: 192.168.180.182@tcp:12345:4:1
2022-05-10T05:21:19.265-0600 7fcb064db5c0  0 INFO: motr ha endpoint: inet:tcp:10.230.241.85@22001
2022-05-10T05:21:19.265-0600 7fcb064db5c0  0 INFO: motr my fid:      0x7200000000000001:0x0
2022-05-10T05:21:19.265-0600 7fcb064db5c0  0 INFO: motr profile fid: 0x7000000000000001:0x51
2022-05-10T05:21:19.265-0600 7fcb064db5c0  0 INFO: init flags:       0
2022-05-10T05:21:19.265-0600 7fcb064db5c0  0 INFO: motr admin endpoint: inet:tcp:10.230.241.85@22502
2022-05-10T05:21:19.265-0600 7fcb064db5c0  0 INFO: motr admin fid:   0x7200000000000001:0x2e
motr[381283]:  ae50  ERROR  [dix/req.c:800:dix_idxop_meta_update_ast_cb]  All items are failed
motr[381283]:  ae50  ERROR  [dix/req.c:800:dix_idxop_meta_update_ast_cb]  All items are failed
motr[381283]:  ae50  ERROR  [dix/req.c:800:dix_idxop_meta_update_ast_cb]  All items are failed
motr[381283]:  5e50  ERROR  [dix/req.c:800:dix_idxop_meta_update_ast_cb]  All items are failed
motr[381283]:  ae50  ERROR  [dix/req.c:800:dix_idxop_meta_update_ast_cb]  All items are failed
2022-05-10T05:21:20.572-0600 7fcb064db5c0  0 Cache miss: name = mgwuser, rc = -2
2022-05-10T05:21:20.578-0600 7fcb064db5c0  0 Put into cache: name = mgwuser
2022-05-10T05:21:20.579-0600 7fcb064db5c0  0 Cache miss: name = test-buckets, rc = -2
2022-05-10T05:21:20.583-0600 7fcb064db5c0  0 Put into cache: name = test-buckets
2022-05-10T05:21:20.596-0600 7fcb064db5c0  0 Put into cache: name = test-buckets
[root@ssc-vm-rhev4-2587 build]#
[root@ssc-vm-rhev4-2587 build]# bin/radosgw-admin bucket stats --uid mgwuser --bucket test-buckets                                   2022-05-10T05:21:36.527-0600 7f90c8c835c0 -1 WARNING: all dangerous and experimental features are enabled.
2022-05-10T05:21:36.545-0600 7f90c8c835c0 -1 WARNING: all dangerous and experimental features are enabled.
2022-05-10T05:21:36.546-0600 7f90c8c835c0 -1 WARNING: all dangerous and experimental features are enabled.
2022-05-10T05:21:36.546-0600 7f90c8c835c0  1 RGW CONF BACKEND STORE = motr
2022-05-10T05:21:36.546-0600 7f90c8c835c0  1 RGW BACKEND STORE = motr
2022-05-10T05:21:36.546-0600 7f90c8c835c0  0 INFO: motr my endpoint: 192.168.180.182@tcp:12345:4:1
2022-05-10T05:21:36.546-0600 7f90c8c835c0  0 INFO: motr ha endpoint: inet:tcp:10.230.241.85@22001
2022-05-10T05:21:36.546-0600 7f90c8c835c0  0 INFO: motr my fid:      0x7200000000000001:0x0
2022-05-10T05:21:36.546-0600 7f90c8c835c0  0 INFO: motr profile fid: 0x7000000000000001:0x51
2022-05-10T05:21:36.546-0600 7f90c8c835c0  0 INFO: init flags:       0
2022-05-10T05:21:36.546-0600 7f90c8c835c0  0 INFO: motr admin endpoint: inet:tcp:10.230.241.85@22502
2022-05-10T05:21:36.546-0600 7f90c8c835c0  0 INFO: motr admin fid:   0x7200000000000001:0x2e
motr[381648]:  9e50  ERROR  [dix/req.c:800:dix_idxop_meta_update_ast_cb]  All items are failed
motr[381648]:  9e50  ERROR  [dix/req.c:800:dix_idxop_meta_update_ast_cb]  All items are failed
motr[381648]:  9e50  ERROR  [dix/req.c:800:dix_idxop_meta_update_ast_cb]  All items are failed
motr[381648]:  6e50  ERROR  [dix/req.c:800:dix_idxop_meta_update_ast_cb]  All items are failed
motr[381648]:  9e50  ERROR  [dix/req.c:800:dix_idxop_meta_update_ast_cb]  All items are failed
2022-05-10T05:21:37.551-0600 7f90c8c835c0  0 Cache miss: name = mgwuser, rc = -2
2022-05-10T05:21:37.565-0600 7f90c8c835c0  0 Put into cache: name = mgwuser
2022-05-10T05:21:37.565-0600 7f90c8c835c0  0 Cache miss: name = test-buckets, rc = -2
2022-05-10T05:21:37.575-0600 7f90c8c835c0  0 Put into cache: name = test-buckets
2022-05-10T05:21:37.575-0600 7f90c8c835c0  0 Cache miss: name = mgwuser, rc = -2
2022-05-10T05:21:37.581-0600 7f90c8c835c0  0 Put into cache: name = mgwuser
2022-05-10T05:21:37.587-0600 7f90c8c835c0  0 Cache miss: name = test-buckets, rc = -2
[
    {
        "bucket": "test-buckets",
        "num_shards": 1,
        "tenant": "",
        "zonegroup": "0956b174-fe14-4f97-8b50-bb7ec5e1cf62",
        "placement_rule": "default",
        "explicit_placement": {
            "data_pool": "",
            "data_extra_pool": "",
            "index_pool": ""
        },
        "id": "",
        "marker": "",
        "index_type": "Normal",
        "owner": "mgwuser",
        "ver": "",
        "master_ver": "",
        "mtime": "0.000000",
        "creation_time": "0.000000",
        "max_marker": "",
        "usage": {},
        "bucket_quota": {
            "enabled": true,
            "check_on_raw": false,
            "max_size": 1024,
            "max_size_kb": 1,
            "max_objects": -1
        },
        "tagset": {
            "team": "c5-solvers12345"
        }
    }
]
2022-05-10T05:21:37.599-0600 7f90c8c835c0  0 Put into cache: name = test-buckets
```


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
