### PR TITLE
rgw_sal_motr : [CORTX-30178] Fix for handling null version-id issues 

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -2226,7 +2226,7 @@ int MotrObject::get_bucket_dir_ent(const DoutPrefixProvider *dpp, rgw_bucket_dir
   bufferlist bl;
   bufferlist::const_iterator iter;
 
-  // get an extra null entry
+  // Read the null index entry
   std::string null_version_key = this->get_name() + "/null";
   bufferlist bl_null;
   bufferlist::const_iterator iter1;
@@ -2340,8 +2340,8 @@ int MotrObject::get_bucket_dir_ent(const DoutPrefixProvider *dpp, rgw_bucket_dir
 
       int i = 1;
       for (; i < rc; ++i) {
-        if (vals[i].length() == 0)
-          break;
+        // if (vals[i].length() == 0)
+        //   break;
 
         iter = vals[i].cbegin();
         ent.decode(iter);
@@ -2384,9 +2384,7 @@ int MotrObject::update_version_entries(const DoutPrefixProvider *dpp)
   vector<bufferlist> vals(max);
   string tenant_bkt_name = get_bucket_name(this->get_bucket()->get_tenant(), this->get_bucket()->get_name());
   string bucket_index_iname = "motr.rgw.bucket.index." + tenant_bkt_name;
-  //RGWBucketInfo &info = this->get_bucket()->get_info();
   std::string null_version_key = this->get_name() + "/null";
-
 
   keys[0] = this->get_name();
   rc = store->next_query_by_name(bucket_index_iname, keys, vals);
@@ -2896,9 +2894,7 @@ int MotrAtomicWriter::complete(size_t accounted_size, const std::string& etag,
     // TODO: update the current version (unset the flag) and insert the new current
     // version can be launched in one motr op. This requires change at do_idx_op()
     // and do_idx_op_by_name().
-    ldpp_dout(dpp, 20) <<__func__<< "*** Going to update_version_entries " << dendl;
     rc = obj.update_version_entries(dpp);
-    ldpp_dout(dpp, 20) <<__func__<< "*** Back to complete...why?" << dendl;
     if (rc < 0)
       return rc;
   }
@@ -2909,7 +2905,7 @@ int MotrAtomicWriter::complete(size_t accounted_size, const std::string& etag,
     // version entry instead of adding new null version entry.
     int ret_rc;
     ret_rc = obj.update_null_version_index(dpp, ent);
-    ldpp_dout(dpp, 20) <<__func__<< ": return code of update_null_version_index : " << ret_rc << dendl;
+    ldpp_dout(dpp, 20) <<__func__<< ": update_null_version_index rc : " << ret_rc << dendl;
   }
   string tenant_bkt_name = get_bucket_name(obj.get_bucket()->get_tenant(), obj.get_bucket()->get_name());
   // Insert an entry into bucket index.

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1078,6 +1078,19 @@ int MotrBucket::list(const DoutPrefixProvider *dpp, ListParams& params, int max,
     }
   }
 
+  // Sort the object versions
+  vector<rgw_bucket_dir_entry>::iterator iter;
+
+  for (iter = results.objs.begin(); iter != results.objs.end(); ++iter) {
+    std::sort(results.objs.begin(), results.objs.end(), [](const rgw_bucket_dir_entry& res1, const rgw_bucket_dir_entry& res2)
+    {
+      if (res1.key.name == res2.key.name)
+        return res1.meta.mtime > res2.meta.mtime;
+      else
+        return res1.key.name < res2.key.name;
+    });
+  }
+
   return 0;
 }
 

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1078,18 +1078,16 @@ int MotrBucket::list(const DoutPrefixProvider *dpp, ListParams& params, int max,
     }
   }
 
-  // Sort the object versions
+  // Sort by object versions
   vector<rgw_bucket_dir_entry>::iterator iter;
 
-  for (iter = results.objs.begin(); iter != results.objs.end(); ++iter) {
-    std::sort(results.objs.begin(), results.objs.end(), [](const rgw_bucket_dir_entry& res1, const rgw_bucket_dir_entry& res2)
-    {
-      if (res1.key.name == res2.key.name)
-        return res1.meta.mtime > res2.meta.mtime;
-      else
-        return res1.key.name < res2.key.name;
-    });
-  }
+  std::sort(results.objs.begin(), results.objs.end(), [](const rgw_bucket_dir_entry& res1, const rgw_bucket_dir_entry& res2)
+  {
+    if (res1.key.name == res2.key.name)
+      return res1.meta.mtime > res2.meta.mtime;
+    else
+      return res1.key.name < res2.key.name;
+  });
 
   return 0;
 }

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -2192,7 +2192,7 @@ out:
   return rc;
 }
 
-int MotrObject::get_index_key(const DoutPrefixProvider *dpp, std::string& prev_null_obj_key)
+int MotrObject::fetch_null_obj_reference(const DoutPrefixProvider *dpp, std::string& prev_null_obj_key)
 {
   int rc = 0;
   // Read the null index entry
@@ -2222,7 +2222,7 @@ int MotrObject::get_index_key(const DoutPrefixProvider *dpp, std::string& prev_n
   return rc;
 }
 
-int MotrObject::fetch_null_obj_reference(const DoutPrefixProvider *dpp, bufferlist& bl)
+int MotrObject::fetch_null_obj(const DoutPrefixProvider *dpp, bufferlist& bl)
 {
   int rc = 0;
   string tenant_bkt_name = get_bucket_name(this->get_bucket()->get_tenant(), this->get_bucket()->get_name());
@@ -2231,7 +2231,7 @@ int MotrObject::fetch_null_obj_reference(const DoutPrefixProvider *dpp, bufferli
 
   // Get content of the key and replace it's instance with null
   // then add into cache
-  rc = this->get_index_key(dpp, prev_null_obj_key);
+  rc = this->fetch_null_obj_reference(dpp, prev_null_obj_key);
   if (rc < 0)
      return rc;
 
@@ -2267,7 +2267,7 @@ int MotrObject::get_bucket_dir_ent(const DoutPrefixProvider *dpp, rgw_bucket_dir
   {
     if(this->get_key().have_null_instance())
     {
-      rc = this->fetch_null_obj_reference(dpp, bl);
+      rc = this->fetch_null_obj(dpp, bl);
       // error log handled in above function.
       if (rc < 0)
         return rc;

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -2721,7 +2721,7 @@ int MotrObject::update_null_reference(const DoutPrefixProvider *dpp, rgw_bucket_
                 M0_IC_DEL, prev_null_obj_key, bl);
     if(rc < 0)
     { 
-      ldpp_dout(dpp, 0) <<__func__<< " ERROR: Unable to null object key" << dendl;
+      ldpp_dout(dpp, 0) <<__func__<< " ERROR: Unable to delete null object key" << dendl;
       return rc;
     }
     ldpp_dout(dpp, 20) <<__func__<< " : DELETE previous cache entry" << dendl;

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -691,7 +691,9 @@ class MotrObject : public Object {
     int delete_part_objs(const DoutPrefixProvider* dpp);
     void set_category(RGWObjCategory _category) {category = _category;}
     int get_bucket_dir_ent(const DoutPrefixProvider *dpp, rgw_bucket_dir_entry& ent);
-    int update_null_version_index(const DoutPrefixProvider *dpp, rgw_bucket_dir_entry& ent);
+    int fetch_null_obj_reference(const DoutPrefixProvider *dpp, bufferlist& bl);
+    int get_index_key(const DoutPrefixProvider *dpp, std::string& prev_null_obj_key);
+    int update_null_reference(const DoutPrefixProvider *dpp, rgw_bucket_dir_entry& ent);
     int update_version_entries(const DoutPrefixProvider *dpp);
     uint64_t get_processed_bytes() { return processed_bytes; }
 };

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -691,8 +691,8 @@ class MotrObject : public Object {
     int delete_part_objs(const DoutPrefixProvider* dpp);
     void set_category(RGWObjCategory _category) {category = _category;}
     int get_bucket_dir_ent(const DoutPrefixProvider *dpp, rgw_bucket_dir_entry& ent);
-    int fetch_null_obj_reference(const DoutPrefixProvider *dpp, bufferlist& bl);
-    int get_index_key(const DoutPrefixProvider *dpp, std::string& prev_null_obj_key);
+    int fetch_null_obj(const DoutPrefixProvider *dpp, bufferlist& bl);
+    int fetch_null_obj_reference(const DoutPrefixProvider *dpp, std::string& prev_null_obj_key);
     int update_null_reference(const DoutPrefixProvider *dpp, rgw_bucket_dir_entry& ent);
     int update_version_entries(const DoutPrefixProvider *dpp);
     uint64_t get_processed_bytes() { return processed_bytes; }

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -691,7 +691,7 @@ class MotrObject : public Object {
     int delete_part_objs(const DoutPrefixProvider* dpp);
     void set_category(RGWObjCategory _category) {category = _category;}
     int get_bucket_dir_ent(const DoutPrefixProvider *dpp, rgw_bucket_dir_entry& ent);
-    void update_null_version_index(const DoutPrefixProvider *dpp, rgw_bucket_dir_entry& ent);
+    int update_null_version_index(const DoutPrefixProvider *dpp, rgw_bucket_dir_entry& ent);
     int update_version_entries(const DoutPrefixProvider *dpp);
     uint64_t get_processed_bytes() { return processed_bytes; }
 };

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -691,6 +691,7 @@ class MotrObject : public Object {
     int delete_part_objs(const DoutPrefixProvider* dpp);
     void set_category(RGWObjCategory _category) {category = _category;}
     int get_bucket_dir_ent(const DoutPrefixProvider *dpp, rgw_bucket_dir_entry& ent);
+    void update_null_version_index(const DoutPrefixProvider *dpp, rgw_bucket_dir_entry& ent);
     int update_version_entries(const DoutPrefixProvider *dpp);
     uint64_t get_processed_bytes() { return processed_bytes; }
 };


### PR DESCRIPTION
Problem Statement:
Observed several issues of null version-id in list-object-versions, HEAD and GET object API.
Issues and approaches are noted in the confluence document here - https://seagate-systems.atlassian.net/wiki/spaces/PUB/pages/1007091811/Findings+on+RGW+versioning+issues+WIP

Solution:
To handle null version-id cases, followed following approach:
- Generate version-id for null versioned object and append that with _null string.
   Example: obj1 will be stored as zWuUXuFIHgyDjydaFnK-ffezsDuFdpw_null.
- Create an additional index entry for all objects to hold the metadata of null version (Key : obj1[null])
- In case of suspended and un-versioned bucket, update the value of additional null entry (Key : obj1[null])

Signed-off-by: Priyanka Salunke [priyanka.s.salunke@seagate.com]

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
