### PR TITLE
rgw: [CORTX-28065] fix issues with non-existing marker in list user api

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -8176,7 +8176,7 @@ next:
 
     formatter->open_array_section("keys");
     int ret = store->list_users(dpp(), metadata_key, marker, max_entries, handle, &truncated, users);
-     if (ret < 0 && ret != ENOENT) {
+     if (ret < 0 && ret != -ENOENT) {
       cerr << "ERROR: can't get key: " << cpp_strerror(-ret) << std::endl;
       return -ret;
     }

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -3693,13 +3693,25 @@ int MotrStore::list_users(const DoutPrefixProvider* dpp, const std::string& meta
                         bool* truncated, std::list<std::string>& users)
 {
   int rc;
+  bufferlist bl;
   if (max_entries <= 0 or max_entries > 1000) {
     max_entries = 1000; 
   }
   vector<string> keys(max_entries + 1);
   vector<bufferlist> vals(max_entries + 1);
+  
+  if(!(marker.empty())){
+    rc = do_idx_op_by_name(RGW_MOTR_USERS_IDX_NAME,
+                                  M0_IC_GET, marker, bl);
+    if (rc < 0) {
+      ldpp_dout(dpp, 0) << "ERROR: Invalid marker. " << rc << dendl;
+      return rc;
+    }
+    else {
+      keys[0] = marker;
+    }
+  }
 
-  keys[0] = marker;
   rc = next_query_by_name(RGW_MOTR_USERS_IDX_NAME, keys, vals);
   if (rc < 0) {
     ldpp_dout(dpp, 0) << "ERROR: NEXT query failed. " << rc << dendl;


### PR DESCRIPTION
list user api was returning all users if a non-existing marker is supplied with the request. This issue is fixed by adding a check whether the supplied marker exists or not.

Signed-off-by: Jeet Jain <jeet.jain@seagate.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
