### PR TITLE
rgw_sal_motr : [CORTX-30347]: DeleteBucketTagging :  Fixed merge_and_save method to incorporate and update deleted attributes

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1055,7 +1055,8 @@ int MotrBucket::list_multiparts(const DoutPrefixProvider *dpp,
   if( max_uploads <= 0 )
 	return rc;
   int upl = max_uploads;
-  upl++;
+  if( marker != "" )
+	upl++;
   vector<string> key_vec(upl);
   vector<bufferlist> val_vec(upl);
   string tenant_bkt_name = get_bucket_name(this->get_tenant(), this->get_name());
@@ -1089,15 +1090,15 @@ int MotrBucket::list_multiparts(const DoutPrefixProvider *dpp,
     auto iter = bl.cbegin();
     ent.decode(iter);
 
+    rgw_obj_key key(ent.key);
     if (prefix.size() &&
-        (0 != ent.key.name.compare(0, prefix.size(), prefix))) {
+        (0 != key.name.compare(0, prefix.size(), prefix))) {
       ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__ <<
         ": skippping \"" << ent.key <<
         "\" because doesn't match prefix" << dendl;
       continue;
     }
 
-    rgw_obj_key key(ent.key);
     uploads.push_back(this->get_multipart_upload(key.name));
     last_obj_key = key;
     ocount++;

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -895,9 +895,8 @@ int MotrBucket::check_quota(const DoutPrefixProvider *dpp, RGWQuotaInfo& user_qu
 
 int MotrBucket::merge_and_store_attrs(const DoutPrefixProvider *dpp, Attrs& new_attrs, optional_yield y)
 {
-  for (auto& it : new_attrs)
-    attrs[it.first] = it.second;
-
+  // Assign updated bucket attributes map to attrs map variable
+  attrs = new_attrs;
   return put_info(dpp, y, ceph::real_time());
 }
 


### PR DESCRIPTION
Motr bucket delete attrs operations fix.

Problem: 
Since we entirely removing the tagset key from attrs. Merging new attrs and existing attrs won't work as expected for all bucket delete attribute operations. Because as per the existing logic if a key not present in newly passed attribute then the program will consider the existing key value pairs itself as final.

Fix posted:
Updated merge and store method logic of motr bucket by assigning the new bucket attrs parameter to mor bucket attrs variable.

Signed-off-by: suryakumar.kumaravelan <suryakumar.kumaravelan@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
