### PR TITLE
rgw_sal_motr: [CORTX-31312] PutObjectTagging: Update attributes for an object

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1321,10 +1321,12 @@ int MotrObject::set_obj_attrs(const DoutPrefixProvider* dpp, RGWObjectCtx* rctx,
   }
 
   rgw_bucket_dir_entry ent;
-  MotrObject::Meta meta;
-  bufferlist& blr = bl;
-  auto iter = blr.cbegin();
+  auto iter = bl.cbegin();
   ent.decode(iter);
+  rgw::sal::Attrs attrs_dummy;
+  decode(attrs_dummy, iter);
+  MotrObject::Meta meta;
+  meta.decode(iter);
   ent.meta.mtime = ceph::real_clock::now();
   ent.encode(update_bl);
   encode(attrs, update_bl);

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1287,9 +1287,7 @@ int MotrObject::set_obj_attrs(const DoutPrefixProvider* dpp, RGWObjectCtx* rctx,
   bufferlist& blr = bl;
   auto iter = blr.cbegin();
   ent.decode(iter);
-
   ent.meta.mtime = ceph::real_clock::now();
-
   ent.encode(update_bl);
   encode(attrs, update_bl);
 

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1305,8 +1305,7 @@ int MotrObject::set_obj_attrs(const DoutPrefixProvider* dpp, RGWObjectCtx* rctx,
     bname = get_bucket_name(this->get_bucket()->get_tenant(), this->get_bucket()->get_name());
     key   = this->get_key().to_str();
   }
-  ldpp_dout(dpp, 20) << "MotrObject::set_obj_attrs(): "
-                    << bname << "/" << key << dendl;
+  ldpp_dout(dpp, 20) <<__func__<< ": " << bname << "/" << key << dendl;
 
   // Get object's metadata (those stored in rgw_bucket_dir_entry).
   bufferlist bl, update_bl;
@@ -1315,7 +1314,7 @@ int MotrObject::set_obj_attrs(const DoutPrefixProvider* dpp, RGWObjectCtx* rctx,
     // Cache miss !
     int rc = this->store->do_idx_op_by_name(bucket_index_iname, M0_IC_GET, key, bl);
     if (rc < 0) {
-      ldpp_dout(dpp, 0) << "Failed to get object's entry from bucket index. rc=" << rc << dendl;
+      ldpp_dout(dpp, 0) <<__func__<< ": Failed to get object's entry from bucket index. rc=" << rc << dendl;
       return rc;
     }
   }
@@ -1323,8 +1322,10 @@ int MotrObject::set_obj_attrs(const DoutPrefixProvider* dpp, RGWObjectCtx* rctx,
   rgw_bucket_dir_entry ent;
   auto iter = bl.cbegin();
   ent.decode(iter);
-  rgw::sal::Attrs attrs_dummy;
-  decode(attrs_dummy, iter);
+  // Decoding current_attrs before MotrObject::Meta because 
+  // encode and decode always have to be sequential. 
+  rgw::sal::Attrs current_attrs;
+  decode(current_attrs, iter);
   MotrObject::Meta meta;
   meta.decode(iter);
   ent.meta.mtime = ceph::real_clock::now();
@@ -1334,7 +1335,7 @@ int MotrObject::set_obj_attrs(const DoutPrefixProvider* dpp, RGWObjectCtx* rctx,
 
   int rc = this->store->do_idx_op_by_name(bucket_index_iname, M0_IC_PUT, key, update_bl);
   if (rc < 0) {
-    ldpp_dout(dpp, 0) << "Failed to put object's entry to bucket index. rc=" << rc << dendl;
+    ldpp_dout(dpp, 0) <<__func__<< ": Failed to put object's entry to bucket index. rc=" << rc << dendl;
     return rc;
   }
   // Put into cache.

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1279,18 +1279,20 @@ int MotrObject::set_obj_attrs(const DoutPrefixProvider* dpp, RGWObjectCtx* rctx,
     // Cache miss !
     int rc = this->store->do_idx_op_by_name(bucket_index_iname, M0_IC_GET, key, bl);
     if (rc < 0) {
-      ldpp_dout(dpp, 0) << "Failed to get object's entry from bucket index. " << dendl;
+      ldpp_dout(dpp, 0) << "Failed to get object's entry from bucket index. rc=" << rc << dendl;
       return rc;
     }
   }
 
   rgw_bucket_dir_entry ent;
+  MotrObject::Meta meta;
   bufferlist& blr = bl;
   auto iter = blr.cbegin();
   ent.decode(iter);
   ent.meta.mtime = ceph::real_clock::now();
   ent.encode(update_bl);
   encode(attrs, update_bl);
+  meta.encode(update_bl);
 
   int rc = this->store->do_idx_op_by_name(bucket_index_iname, M0_IC_PUT, key, update_bl);
   if (rc < 0) {


### PR DESCRIPTION
Signed-off-by: Selvakumar <selva.k.nambi@seagate.com>

Problem:
PutObjectTagging API is overwriting the metadata of an object since a new instance of rgw_bucket_dir_entry is created. 
Reference: https://github.com/Seagate/cortx-rgw/pull/186#discussion_r866815923

Resolution:
Make sure to just update the metadata, and avoid overwriting rgw_bucket_dir_entry

Results:
```
[root@ssc-vm-rhev4-2587 build]# aws --endpoint=$endpoint s3api put-object-tagging --bucket test-buckets2 --key test-key-111 --tagging '{"TagSet": [{ "Key": "project", "Value": "rgw" }]}'
[root@ssc-vm-rhev4-2587 build]# aws --endpoint=$endpoint s3api get-object --bucket test-buckets2 --key test-key-111 /root/abcd       {
    "AcceptRanges": "bytes",
    "LastModified": "Tue, 17 May 2022 11:44:03 GMT",
    "ContentLength": 10485760,
    "ETag": "\"f1c9645dbc14efddc7d8a322685f26eb\"",
    "ContentType": "binary/octet-stream",
    "Metadata": {}
}
[root@ssc-vm-rhev4-2587 build]#
[root@ssc-vm-rhev4-2587 build]#
[root@ssc-vm-rhev4-2587 build]# aws --endpoint=$endpoint s3api get-object-tagging --bucket test-buckets2 --key test-key-111          {
    "TagSet": [
        {
            "Key": "project",
            "Value": "rgw"
        }
    ]
}

```



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
