### PR TITLE
rgw_sal_motr : [CORTX-30180] Fix for is-latest flag issue

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -2640,7 +2640,7 @@ int MotrAtomicWriter::complete(size_t accounted_size, const std::string& etag,
   ent.meta.owner_display_name = obj.get_bucket()->get_owner()->get_display_name();
   RGWBucketInfo &info = obj.get_bucket()->get_info();
 
-  // info.versioned() returns true for both version suspended and enabled case.
+  // Set version and current flag in case of both versioning enabled and suspended case.
   if (info.versioned())
     ent.flags = rgw_bucket_dir_entry::FLAG_VER | rgw_bucket_dir_entry::FLAG_CURRENT;
   ldpp_dout(dpp, 20) <<__func__<< ": key=" << obj.get_key().to_str()
@@ -2665,9 +2665,8 @@ int MotrAtomicWriter::complete(size_t accounted_size, const std::string& etag,
   ldpp_dout(dpp, 20) <<__func__<< ": lid=0x" << std::hex << obj.meta.layout_id
                                                            << dendl;
 
-  // info.versioned() returns true for bucket versioning suspended and enabled case.
-  // Call the MotrObject::update_version_entries() function, to update existing object version entries 
-  // in both versioning enabled and suspended bucket.
+  // Update existing object version entries in a bucket,
+  // in case of both versioning enabled and suspended.
   if (info.versioned()) {
     // get the list of all versioned objects with the same key and
     // unset their FLAG_CURRENT later, if do_idx_op_by_name() is successful.

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -2639,7 +2639,9 @@ int MotrAtomicWriter::complete(size_t accounted_size, const std::string& etag,
   ent.meta.owner = owner.to_str();
   ent.meta.owner_display_name = obj.get_bucket()->get_owner()->get_display_name();
   RGWBucketInfo &info = obj.get_bucket()->get_info();
-  if (info.versioning_enabled())
+
+  // info.versioned() returns true for both version suspended and enabled case.
+  if (info.versioned())
     ent.flags = rgw_bucket_dir_entry::FLAG_VER | rgw_bucket_dir_entry::FLAG_CURRENT;
   ldpp_dout(dpp, 20) <<__func__<< ": key=" << obj.get_key().to_str()
                     << " etag: " << etag << " user_data=" << user_data << dendl;
@@ -2662,7 +2664,11 @@ int MotrAtomicWriter::complete(size_t accounted_size, const std::string& etag,
   obj.meta.encode(bl);
   ldpp_dout(dpp, 20) <<__func__<< ": lid=0x" << std::hex << obj.meta.layout_id
                                                            << dendl;
-  if (info.versioning_enabled()) {
+
+  // info.versioned() returns true for bucket versioning suspended and enabled case.
+  // Call the MotrObject::update_version_entries() function, to update existing object version entries 
+  // in both versioning enabled and suspended bucket.
+  if (info.versioned()) {
     // get the list of all versioned objects with the same key and
     // unset their FLAG_CURRENT later, if do_idx_op_by_name() is successful.
     // Note: without distributed lock on the index - it is possible that 2


### PR DESCRIPTION
## Problem description:
Observed 2 issues with is-latest flag during list-object-versions API:
- is-latest flag set for two versions of the same object
- is-latest flag is not getting updated in list-object-versions API

Issues observed with is-latest flag:
```
[root@ssc-vm-rhev4-2551 ~]# aws --endpoint=http://10.230.249.130:8000 s3api list-object-versions --bucket test-bucket11
{"Versions": [
  { "ETag": ""f1c9645dbc14efddc7d8a322685f26eb"",
    "Size": 10485760,
    "StorageClass": "STANDARD",
    "Key": "test-obj1",
    "VersionId": "null",
    "IsLatest": true,
    "LastModified": "2022-05-11T08:42:56.117Z",
    "Owner": 
    { "DisplayName": "test",
      "ID": "test"
    }
   },
   {"ETag": ""f1c9645dbc14efddc7d8a322685f26eb"","Size": 10485760,
    "StorageClass": "STANDARD",
    "Key": "test-obj1",
    "VersionId": "zWuU7XGZHelDEVS06G23gS5y4C9dMhx",
    "IsLatest": true,
    "LastModified": "2022-05-11T08:42:22.965Z",
    "Owner": 
    {"DisplayName": "test",
     "ID": "test"
    }
   }
 ]
}
[root@ssc-vm-rhev4-2551 ~]#
```


## Solution:
To update existing object version entries (is-latest flag) in both versioning enabled and suspended bucket, call needs to be done to  `MotrObject::update_version_entries()`. 
In the current behavior, the update_version_entries() method gets invoked in the bucket versioning enable case. Hence, replace the `info.versioning_enabled()` with `info.versioned()`. 



Test result: After adding the fix, getting expected values for is-latest flag as following:
```
[root@ssc-vm-rhev4-2319 build]# aws s3api list-object-versions --bucket test-bucket11 --prefix obj1 --endpoint http://localhost:8000   
{
    "Versions": [
        {
            "ETag": "\"ab5cdab32e8356762ab186f27c65630c\"",
            "Size": 5924,
            "StorageClass": "STANDARD",
            "Key": "obj1",
            "VersionId": "null",
            "IsLatest": true,
            "LastModified": "2022-05-16T12:52:11.695Z",
            "Owner": {
                "DisplayName": "test-user1",
                "ID": "ps-user"
            }
        },
        {
            "ETag": "\"ab5cdab32e8356762ab186f27c65630c\"",
            "Size": 5924,
            "StorageClass": "STANDARD",
            "Key": "obj1",
            "VersionId": "1vdHasLPWbC711ToKB2p3v0plolCTuR",
            "IsLatest": false,
            "LastModified": "2022-05-16T12:53:05.040Z",
            "Owner": {
                "DisplayName": "test-user1",
                "ID": "ps-user"
            }
        },
        {
            "ETag": "\"ab5cdab32e8356762ab186f27c65630c\"",
            "Size": 5924,
            "StorageClass": "STANDARD",
            "Key": "obj1",
            "VersionId": "t1Pp2SrbCY1elxc1QjgzoRnLqt4VYAF",
            "IsLatest": false,
            "LastModified": "2022-05-16T12:53:06.595Z",
            "Owner": {
                "DisplayName": "test-user1",
                "ID": "ps-user"
            }
        }
    ]
}
```

Signed-off-by: Priyanka Salunke <priyanka.s.salunke@seagate.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
