### PR TITLE
rgw_sal_motr: [CORTX-31567] fix bogus degraded reads

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -2051,14 +2051,10 @@ int MotrObject::write_mobj(const DoutPrefixProvider *dpp, bufferlist&& in_buffer
   start = data.c_str();
   for (p = start; left > 0; left -= bs, p += bs, offset += bs) {
     if (left < bs) {
-      // This is the last I/O.
-      // Pad to allign with unit size (and not the group size) and 
-      // set M0_ENF_NO_RMW flag to force no RMW
+      bs = this->get_optimal_bs(left);
       mobj->ob_entity.en_flags |= M0_ENF_NO_RMW;
-      uint64_t lid = M0_OBJ_LAYOUT_ID(meta.layout_id);
-      unsigned unit_sz = m0_obj_layout_id_to_unit_size(lid);
-
-      bs = roundup(left, unit_sz);
+    }
+    if (left < bs) {
       ldpp_dout(dpp, 20) <<__func__<< " left ="<< left << ",bs=" << bs << ", Padding [" << (bs - left) << "] bytes" << dendl;
       data.append_zero(bs - left);
       p = data.c_str();
@@ -2132,16 +2128,11 @@ int MotrObject::read_mobj(const DoutPrefixProvider* dpp, int64_t off, int64_t en
 
   left = end - off;
   for (; left > 0; off += actual) {
+    if (left < bs)
+      bs = this->get_optimal_bs(left);
     actual = bs;
-    if (left < bs) {
-      uint64_t lid = M0_OBJ_LAYOUT_ID(meta.layout_id);
-      unsigned unit_sz = m0_obj_layout_id_to_unit_size(lid);
-      bs = roundup(left, unit_sz);
+    if (left < bs)
       actual = left;
-    }
-
-    mobj->ob_entity.en_flags |= M0_OOF_HOLE;
-
     ldpp_dout(dpp, 20) << "MotrObject::read_mobj(): off=" << off <<
                                             " actual=" << actual << dendl;
     bufferlist bl;
@@ -2156,12 +2147,12 @@ int MotrObject::read_mobj(const DoutPrefixProvider* dpp, int64_t off, int64_t en
     op = nullptr;
     if( start >= ( block_start_off + bs )) 
     {
-	block_start_off += bs;
-	ldpp_dout(dpp, 70) << "MotrObject::read_mobj(): block_start_off=" << block_start_off <<dendl;
-	continue;
+      block_start_off += bs;
+      ldpp_dout(dpp, 70) << "MotrObject::read_mobj(): block_start_off=" << block_start_off <<dendl;
+      continue;
     }
     if( bloff != 0 )
-	bloff = start - block_start_off;
+      bloff = start - block_start_off;
 
     rc = m0_obj_op(this->mobj, M0_OC_READ, &ext, &buf, &attr, 0, 0, &op);
     ldpp_dout(dpp, 20) << "MotrObject::read_mobj(): init read op rc=" << rc << dendl;
@@ -2512,10 +2503,8 @@ unsigned MotrObject::get_optimal_bs(unsigned len)
   max_bs = roundup(max_bs, grp_sz); // multiple of group size
   if (len >= max_bs)
     return max_bs;
-  else if (len <= grp_sz)
-    return grp_sz;
   else
-    return roundup(len, grp_sz);
+    return roundup(len, unit_sz);
 }
 
 void MotrAtomicWriter::cleanup()
@@ -2582,16 +2571,12 @@ int MotrAtomicWriter::write()
   bi = acc_data.begin();
   while (left > 0) {
     if (left < bs) {
-      // Pad to allign with unit size (and not the group size) and 
-      // set M0_ENF_NO_RMW flag to force no RMW
+      bs = obj.get_optimal_bs(left);
       obj.mobj->ob_entity.en_flags |= M0_ENF_NO_RMW;
-      uint64_t lid = M0_OBJ_LAYOUT_ID(obj.meta.layout_id);
-      unsigned unit_sz = m0_obj_layout_id_to_unit_size(lid);
-
-      unsigned left_alligned_unit_sz = roundup(left, unit_sz);
-      ldpp_dout(dpp, 20) <<__func__<< " Padding [" << (left_alligned_unit_sz - left) << "] bytes" << dendl;
-      acc_data.append_zero(left_alligned_unit_sz - left);
-      bs = left_alligned_unit_sz;
+    }
+    if (left < bs) {
+      ldpp_dout(dpp, 20) <<__func__<< " Padding [" << (bs - left) << "] bytes" << dendl;
+      acc_data.append_zero(bs - left);
       auto off = bi.get_off();
       bufferlist tmp;
       acc_data.splice(off, bs, &tmp);


### PR DESCRIPTION
Reading object can happen beyond the object size, rounded up to the parity group size. For example, when reading 200M object with 4+2 EC configuration and 4M unit size, the last parity group will be written partially with NO_RMW flag (see #178), but during read we try to read all the units from the last  group (including the ones that were not written). This triggers degraded read, which not only slows down the performance, but also, sometimes, when some parity unit(s) is/are not available (for some reason), the read can fail completely (as the number of failed units will be greater than K).

Solution: round up the reading size up to the unit size instead of the parity group size and don't try to read units that were not written.

Closes #216.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
