### PR TITLE
rgw_sal_motr :[CORTX-31533] Fix delete-object API for unversioned object

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1658,25 +1658,41 @@ MotrObject::MotrDeleteOp::MotrDeleteOp(MotrObject *_source, RGWObjectCtx *_rctx)
 // 2. Delete an object when its versioning is turned on.
 int MotrObject::MotrDeleteOp::delete_obj(const DoutPrefixProvider* dpp, optional_yield y)
 {
+  int rc;
+  bufferlist bl;
+  string tenant_bkt_name = get_bucket_name(source->get_bucket()->get_tenant(), source->get_bucket()->get_name());
+  string bucket_index_iname = "motr.rgw.bucket.index." + tenant_bkt_name;
+  std::string delete_key;
+  rgw_bucket_dir_entry ent;
+  rc = source->get_bucket_dir_ent(dpp, ent);
+  if (rc < 0) 
+    return rc;
+
   if (source->have_instance()) {
     rgw_obj_key& key = source->get_key();
+    delete_key = source->get_key().to_str();
     if (key.have_null_instance())
-      key.instance.clear();
+    {
+      // Read null reference key to get null version obj key.
+      rc = source->fetch_null_obj_reference(dpp, delete_key);
+      if (rc < 0)
+        return rc;
+    }
+  }
+  else{
+    if (ent.key.instance == "null")
+    {
+      rc = source->fetch_null_obj_reference(dpp, delete_key);
+      if (rc < 0)
+        return rc;
+    }
   }
 
-  string tenant_bkt_name = get_bucket_name(source->get_bucket()->get_tenant(), source->get_bucket()->get_name());
-  ldpp_dout(dpp, 20) << "delete " << source->get_key().to_str() << " from " << tenant_bkt_name << dendl;
-
-  rgw_bucket_dir_entry ent;
-  int rc = source->get_bucket_dir_ent(dpp, ent);
-  if (rc < 0) {
-    return rc;
-  }
-
+  ldpp_dout(dpp, 20) << "delete " << delete_key << " from " << tenant_bkt_name << dendl;
   //TODO: When integrating with background GC for object deletion,
   // we should consider adding object entry to GC before deleting the metadata.
   // Delete from the cache first.
-  source->store->get_obj_meta_cache()->remove(dpp, source->get_key().to_str());
+  source->store->get_obj_meta_cache()->remove(dpp, delete_key);
 
   if (ent.meta.size == 0) {
     ldpp_dout(dpp, 20) << __func__ << ": Object size is 0, not deleting motr object." << dendl;
@@ -1700,13 +1716,24 @@ int MotrObject::MotrDeleteOp::delete_obj(const DoutPrefixProvider* dpp, optional
     }
   }
   // Finally, delete the object's entry from the bucket index.
-  bufferlist bl;
-  string bucket_index_iname = "motr.rgw.bucket.index." + tenant_bkt_name;
   rc = source->store->do_idx_op_by_name(bucket_index_iname,
-                                            M0_IC_DEL, source->get_key().to_str(), bl);
+                                            M0_IC_DEL, delete_key, bl);
   if (rc < 0) {
     ldpp_dout(dpp, 0) << "Failed to del object's entry from bucket index. " << dendl;
     return rc;
+  }
+
+  // delete null_ref key which holds the null version object reference.
+  if(ent.key.instance == "null")
+  {
+    std::string null_index_key = source->get_name() + "/null"; 
+    rc = source->store->do_idx_op_by_name(bucket_index_iname,
+              M0_IC_DEL, null_index_key, bl);
+    if(rc < 0)
+    {
+      ldpp_dout(dpp, 0) <<__func__<< " ERROR: Unable to delete null object key" << dendl;
+      return rc;
+    }
   }
 
   //result.delete_marker = parent_op.result.delete_marker;

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1666,11 +1666,13 @@ int MotrObject::MotrDeleteOp::delete_obj(const DoutPrefixProvider* dpp, optional
   rgw_bucket_dir_entry ent;
   rc = source->get_bucket_dir_ent(dpp, ent);
   if (rc < 0) 
+  {
+    ldpp_dout(dpp, 0)<<__func__<< ": Failed to get object's entry from bucket index. rc="<< rc << dendl;
     return rc;
-
+  }
   if (source->have_instance()) {
     rgw_obj_key& key = source->get_key();
-    delete_key = source->get_key().to_str();
+    delete_key = key.to_str();
     if (key.have_null_instance())
     {
       // Read null reference key to get null version obj key.


### PR DESCRIPTION
Problem:

delete-object API is not working for unversioned bucket.

Solution:

Pass version-id in key name(obj1[version-id]) while deleting the object.

Signed-off-by: Shriya Deshmukh <shriya.deshmukh@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
