### PR TITLE
rgw_sal_motr: [CORTX-30149] Added versioning support for complete multipart upload API

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -3260,13 +3260,29 @@ int MotrMultipartUpload::complete(const DoutPrefixProvider *dpp,
     }
   }
 
+  // Check for bucket versioning
+  // Update existing object version entries in a bucket,
+  // in case of both versioning enabled and suspended.
+  RGWBucketInfo &info = target_obj->get_bucket()->get_info();
+  if(info.versioned())
+  {
+    string bucket_index_iname = "motr.rgw.bucket.index." + tenant_bkt_name;
+    std::unique_ptr<rgw::sal::Object> obj_ver = target_obj->get_bucket()->get_object(rgw_obj_key(target_obj->get_name()));
+    rgw::sal::MotrObject *mobj_ver = static_cast<rgw::sal::MotrObject *>(obj_ver.get());
+
+    rc = mobj_ver->update_version_entries(dpp);
+    ldpp_dout(dpp, 20) << "MotrMultipartUpload::complete(): update_version_entries, rc: " << rc << dendl;
+    if (rc < 0)
+      return rc;
+  }
+
   rc = store->do_idx_op_by_name(bucket_index_iname, M0_IC_PUT,
-                                target_obj->get_name(), update_bl);
+                                target_obj->get_key().to_str(), update_bl);
   if (rc < 0)
     return rc;
 
   // Put into metadata cache.
-  store->get_obj_meta_cache()->put(dpp, target_obj->get_name(), update_bl);
+  store->get_obj_meta_cache()->put(dpp, target_obj->get_key().to_str(), update_bl);
 
   // Now we can remove it from bucket multipart index.
   ldpp_dout(dpp, 20) << "MotrMultipartUpload::complete(): remove from bucket multipartindex " << dendl;


### PR DESCRIPTION
Problem Statement:
- Complete multipart upload API overwrites the object entry in bucket versioning case. 

Solution:
- In the MotrMultipartUpload::complete() function, added a check for versioning. 
- PUT the new key as objectname_versionid in complete() function.
- Used the MotrObject::update_version_entries() function to update the older object version entries.

Signed-off-by: Priyanka Salunke <priyanka.s.salunke@seagate.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
