### PR TITLE
rgw_sal_motr: [CORTX-31435] ObjectTagging: Refactoring set and get obj_attrs

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1363,12 +1363,12 @@ void MotrObject::read_bucket_info(std::string& bname, std::string& key, rgw_obj*
     bname = get_bucket_name(this->get_bucket()->get_tenant(), this->get_bucket()->get_name());
     key   = this->get_key().to_str();
   }
+  ldpp_dout(dpp, 20) <<__func__<< ": " << bname << "/" << key << dendl;
 }
 
 int MotrObject::read_obj_attrs(const DoutPrefixProvider* dpp, std::string& bname, std::string& key, bufferlist& bl, rgw_obj* target_obj)
 {
   read_bucket_info(bname, key, target_obj);
-  ldpp_dout(dpp, 20) <<__func__<< ": " << bname << "/" << key << dendl;
   // Get object's metadata (those stored in rgw_bucket_dir_entry).
   if (this->store->get_obj_meta_cache()->get(dpp, key, bl)) {
     // Cache misses.

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1297,26 +1297,13 @@ int MotrObject::set_obj_attrs(const DoutPrefixProvider* dpp, RGWObjectCtx* rctx,
   if (this->category == RGWObjCategory::MultiMeta)
     return 0;
 
-  string bname, key;
-  if (target_obj) {
-    bname = get_bucket_name(target_obj->bucket.tenant, target_obj->bucket.name);
-    key   = target_obj->key.to_str();
-  } else {
-    bname = get_bucket_name(this->get_bucket()->get_tenant(), this->get_bucket()->get_name());
-    key   = this->get_key().to_str();
-  }
-  ldpp_dout(dpp, 20) <<__func__<< ": " << bname << "/" << key << dendl;
-
   // Get object's metadata (those stored in rgw_bucket_dir_entry).
   bufferlist bl, update_bl;
-  string bucket_index_iname = "motr.rgw.bucket.index." + bname;
-  if (this->store->get_obj_meta_cache()->get(dpp, key, bl)) {
-    // Cache miss !
-    int rc = this->store->do_idx_op_by_name(bucket_index_iname, M0_IC_GET, key, bl);
-    if (rc < 0) {
-      ldpp_dout(dpp, 0) <<__func__<< ": Failed to get object's entry from bucket index. rc=" << rc << dendl;
-      return rc;
-    }
+  string bname, key;
+  int r = read_obj_attrs(dpp, bname, key, bl, target_obj);
+  ldpp_dout(dpp, 20) <<__func__<< ": " << bname << "/" << key << dendl;
+  if (r < 0) {
+    return r;
   }
 
   rgw_bucket_dir_entry ent;
@@ -1333,6 +1320,7 @@ int MotrObject::set_obj_attrs(const DoutPrefixProvider* dpp, RGWObjectCtx* rctx,
   encode(attrs, update_bl);
   meta.encode(update_bl);
 
+  string bucket_index_iname = "motr.rgw.bucket.index." + bname;
   int rc = this->store->do_idx_op_by_name(bucket_index_iname, M0_IC_PUT, key, update_bl);
   if (rc < 0) {
     ldpp_dout(dpp, 0) <<__func__<< ": Failed to put object's entry to bucket index. rc=" << rc << dendl;
@@ -1349,30 +1337,12 @@ int MotrObject::get_obj_attrs(RGWObjectCtx* rctx, optional_yield y, const DoutPr
   if (this->category == RGWObjCategory::MultiMeta)
     return 0;
 
-  string bname, key;
-  if (target_obj) {
-    bname = get_bucket_name(target_obj->bucket.tenant, target_obj->bucket.name);
-    key   = target_obj->key.to_str();
-  } else {
-    bname = get_bucket_name(this->get_bucket()->get_tenant(), this->get_bucket()->get_name());
-    key   = this->get_key().to_str();
-  }
-  ldpp_dout(dpp, 20) << "MotrObject::get_obj_attrs(): "
-                    << bname << "/" << key << dendl;
-
-  // Get object's metadata (those stored in rgw_bucket_dir_entry).
   bufferlist bl;
-  if (this->store->get_obj_meta_cache()->get(dpp, key, bl)) {
-    // Cache misses.
-    string bucket_index_iname = "motr.rgw.bucket.index." + bname;
-    int rc = this->store->do_idx_op_by_name(bucket_index_iname, M0_IC_GET, key, bl);
-    if (rc < 0) {
-      ldpp_dout(dpp, 0) << "Failed to get object's entry from bucket index. " << dendl;
-      return rc;
-    }
-
-    // Put into cache.
-    this->store->get_obj_meta_cache()->put(dpp, key, bl);
+  string bname, key;
+  int r = read_obj_attrs(dpp, bname, key, bl, target_obj);
+  ldpp_dout(dpp, 20) <<__func__<< ": " << bname << "/" << key << dendl;
+  if (r < 0) {
+    return r;
   }
 
   rgw_bucket_dir_entry ent;
@@ -1381,6 +1351,36 @@ int MotrObject::get_obj_attrs(RGWObjectCtx* rctx, optional_yield y, const DoutPr
   ent.decode(iter);
   decode(attrs, iter);
 
+  return 0;
+}
+
+void MotrObject::read_bucket_info(std::string& bname, std::string& key, rgw_obj* target_obj)
+{
+  if (target_obj) {
+    bname = get_bucket_name(target_obj->bucket.tenant, target_obj->bucket.name);
+    key   = target_obj->key.to_str();
+  } else {
+    bname = get_bucket_name(this->get_bucket()->get_tenant(), this->get_bucket()->get_name());
+    key   = this->get_key().to_str();
+  }
+}
+
+int MotrObject::read_obj_attrs(const DoutPrefixProvider* dpp, std::string& bname, std::string& key, bufferlist& bl, rgw_obj* target_obj)
+{
+  read_bucket_info(bname, key, target_obj);
+  // Get object's metadata (those stored in rgw_bucket_dir_entry).
+  if (this->store->get_obj_meta_cache()->get(dpp, key, bl)) {
+    // Cache misses.
+    string bucket_index_iname = "motr.rgw.bucket.index." + bname;
+    int rc = this->store->do_idx_op_by_name(bucket_index_iname, M0_IC_GET, key, bl);
+    if (rc < 0) {
+      ldpp_dout(dpp, 0) << "Failed to get object's entry from bucket index. rc=" << rc << dendl;
+      return rc;
+    }
+
+    // Put into cache.
+    this->store->get_obj_meta_cache()->put(dpp, key, bl);
+  }
   return 0;
 }
 

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1301,7 +1301,6 @@ int MotrObject::set_obj_attrs(const DoutPrefixProvider* dpp, RGWObjectCtx* rctx,
   bufferlist bl, update_bl;
   string bname, key;
   int r = read_obj_attrs(dpp, bname, key, bl, target_obj);
-  ldpp_dout(dpp, 20) <<__func__<< ": " << bname << "/" << key << dendl;
   if (r < 0) {
     return r;
   }
@@ -1340,7 +1339,6 @@ int MotrObject::get_obj_attrs(RGWObjectCtx* rctx, optional_yield y, const DoutPr
   bufferlist bl;
   string bname, key;
   int r = read_obj_attrs(dpp, bname, key, bl, target_obj);
-  ldpp_dout(dpp, 20) <<__func__<< ": " << bname << "/" << key << dendl;
   if (r < 0) {
     return r;
   }
@@ -1368,6 +1366,7 @@ void MotrObject::read_bucket_info(std::string& bname, std::string& key, rgw_obj*
 int MotrObject::read_obj_attrs(const DoutPrefixProvider* dpp, std::string& bname, std::string& key, bufferlist& bl, rgw_obj* target_obj)
 {
   read_bucket_info(bname, key, target_obj);
+  ldpp_dout(dpp, 20) <<__func__<< ": " << bname << "/" << key << dendl;
   // Get object's metadata (those stored in rgw_bucket_dir_entry).
   if (this->store->get_obj_meta_cache()->get(dpp, key, bl)) {
     // Cache misses.

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1302,6 +1302,7 @@ int MotrObject::set_obj_attrs(const DoutPrefixProvider* dpp, RGWObjectCtx* rctx,
   string bname, key;
   int r = read_obj_attrs(dpp, bname, key, bl, target_obj);
   if (r < 0) {
+    ldpp_dout(dpp, 0) <<__func__<< ": Failed to read bucket name and key. rc=" << r << dendl;
     return r;
   }
 
@@ -1340,6 +1341,7 @@ int MotrObject::get_obj_attrs(RGWObjectCtx* rctx, optional_yield y, const DoutPr
   string bname, key;
   int r = read_obj_attrs(dpp, bname, key, bl, target_obj);
   if (r < 0) {
+    ldpp_dout(dpp, 0) <<__func__<< ": Failed to read bucket name and key. rc=" << r << dendl;
     return r;
   }
 

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1354,7 +1354,7 @@ int MotrObject::get_obj_attrs(RGWObjectCtx* rctx, optional_yield y, const DoutPr
   return 0;
 }
 
-void MotrObject::read_bucket_info(std::string& bname, std::string& key, rgw_obj* target_obj)
+void MotrObject::read_bucket_info(const DoutPrefixProvider* dpp, std::string& bname, std::string& key, rgw_obj* target_obj)
 {
   if (target_obj) {
     bname = get_bucket_name(target_obj->bucket.tenant, target_obj->bucket.name);
@@ -1368,7 +1368,7 @@ void MotrObject::read_bucket_info(std::string& bname, std::string& key, rgw_obj*
 
 int MotrObject::read_obj_attrs(const DoutPrefixProvider* dpp, std::string& bname, std::string& key, bufferlist& bl, rgw_obj* target_obj)
 {
-  read_bucket_info(bname, key, target_obj);
+  read_bucket_info(dpp, bname, key, target_obj);
   // Get object's metadata (those stored in rgw_bucket_dir_entry).
   if (this->store->get_obj_meta_cache()->get(dpp, key, bl)) {
     // Cache misses.

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1377,7 +1377,7 @@ int MotrObject::read_obj_attrs(const DoutPrefixProvider* dpp, std::string& bname
     string bucket_index_iname = "motr.rgw.bucket.index." + bname;
     int rc = this->store->do_idx_op_by_name(bucket_index_iname, M0_IC_GET, key, bl);
     if (rc < 0) {
-      ldpp_dout(dpp, 0) << "Failed to get object's entry from bucket index. rc=" << rc << dendl;
+      ldpp_dout(dpp, 0) << __func__ << ": failed to get object's entry from bucket index. rc = " << rc << dendl;
       return rc;
     }
 

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -627,7 +627,7 @@ class MotrObject : public Object {
     virtual int get_obj_state(const DoutPrefixProvider* dpp, RGWObjectCtx* rctx, RGWObjState **state, optional_yield y, bool follow_olh = true) override;
     virtual int set_obj_attrs(const DoutPrefixProvider* dpp, RGWObjectCtx* rctx, Attrs* setattrs, Attrs* delattrs, optional_yield y, rgw_obj* target_obj = NULL) override;
     virtual int get_obj_attrs(RGWObjectCtx* rctx, optional_yield y, const DoutPrefixProvider* dpp, rgw_obj* target_obj = NULL) override;
-    virtual void read_bucket_info(std::string& bname, std::string& key, rgw_obj* target_obj = NULL);
+    virtual void read_bucket_info(const DoutPrefixProvider* dpp, std::string& bname, std::string& key, rgw_obj* target_obj = NULL);
     virtual int read_obj_attrs(const DoutPrefixProvider* dpp, std::string& bname, std::string& key, bufferlist& bl, rgw_obj* target_obj = NULL);
     virtual int modify_obj_attrs(RGWObjectCtx* rctx, const char* attr_name, bufferlist& attr_val, optional_yield y, const DoutPrefixProvider* dpp) override;
     virtual int delete_obj_attrs(const DoutPrefixProvider* dpp, RGWObjectCtx* rctx, const char* attr_name, optional_yield y) override;

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -627,6 +627,8 @@ class MotrObject : public Object {
     virtual int get_obj_state(const DoutPrefixProvider* dpp, RGWObjectCtx* rctx, RGWObjState **state, optional_yield y, bool follow_olh = true) override;
     virtual int set_obj_attrs(const DoutPrefixProvider* dpp, RGWObjectCtx* rctx, Attrs* setattrs, Attrs* delattrs, optional_yield y, rgw_obj* target_obj = NULL) override;
     virtual int get_obj_attrs(RGWObjectCtx* rctx, optional_yield y, const DoutPrefixProvider* dpp, rgw_obj* target_obj = NULL) override;
+    virtual void read_bucket_info(std::string& bname, std::string& key, rgw_obj* target_obj = NULL);
+    virtual int read_obj_attrs(const DoutPrefixProvider* dpp, std::string& bname, std::string& key, bufferlist& bl, rgw_obj* target_obj = NULL);
     virtual int modify_obj_attrs(RGWObjectCtx* rctx, const char* attr_name, bufferlist& attr_val, optional_yield y, const DoutPrefixProvider* dpp) override;
     virtual int delete_obj_attrs(const DoutPrefixProvider* dpp, RGWObjectCtx* rctx, const char* attr_name, optional_yield y) override;
     virtual bool is_expired() override;


### PR DESCRIPTION
Problem:
MotrObject::set_obj_attrs() and MotrObject::get_obj_attrs() has similar/common code

Resolution:
Refactor it by moving the common code into a separate function

Signed-off-by: Selvakumar <selva.k.nambi@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
