### PR TITLE
rgw_sal_motr: [CORTX-31438] Fix for overwrite of multipart object with simple object

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1802,12 +1802,8 @@ int MotrAtomicWriter::prepare(optional_yield y)
     return 0;
 
   rgw_bucket_dir_entry ent;
-  int rc = old_obj.get_bucket_dir_ent(dpp, ent);
-  if (rc == 0) {
-    ldpp_dout(dpp, 20) << __func__ << ": object exists." << dendl;
-  }
 
-  rc = m0_bufvec_empty_alloc(&buf, MAX_BUFVEC_NR) ?:
+  int rc = m0_bufvec_empty_alloc(&buf, MAX_BUFVEC_NR) ?:
            m0_bufvec_alloc(&attr, MAX_BUFVEC_NR, 1) ?:
            m0_indexvec_alloc(&ext, MAX_BUFVEC_NR);
   if (rc != 0)
@@ -2737,17 +2733,46 @@ int MotrAtomicWriter::complete(size_t accounted_size, const std::string& etag,
   string tenant_bkt_name = get_bucket_name(obj.get_bucket()->get_tenant(), obj.get_bucket()->get_name());
   // Insert an entry into bucket index.
   string bucket_index_iname = "motr.rgw.bucket.index." + tenant_bkt_name;
+
+  if( !info.versioning_enabled() )
+  {
+	std::string obj_type = "simple object";
+        MotrObject::Meta old_meta;
+  	rgw_bucket_dir_entry old_ent;
+  	bufferlist old_check_bl;	
+	// Before updating bucket index with entry for new object, check if
+  	// old object exists. Perform M0_IC_GET operation on bucket index.
+  	rc = store->do_idx_op_by_name(bucket_index_iname, M0_IC_GET,
+                                obj.get_name(), old_check_bl);
+  	if (rc == 0 && old_check_bl.length() > 0) {
+    		auto ent_iter = old_check_bl.cbegin();
+    		old_ent.decode(ent_iter);
+    		rgw::sal::Attrs dummy;
+    		decode(dummy, ent_iter);
+    		old_meta.decode(ent_iter);
+    		std::unique_ptr<rgw::sal::Object> old_obj = obj.get_bucket()->get_object(rgw_obj_key(obj.get_name()));
+    		rgw::sal::MotrObject *old_mobj = static_cast<rgw::sal::MotrObject *>(old_obj.get());
+    		if (old_ent.meta.category == RGWObjCategory::MultiMeta) {
+      			obj_type = "multipart object";
+      			old_mobj->set_category(RGWObjCategory::MultiMeta);
+    		}
+    	ldpp_dout(dpp, 20) << "MotrAtomicWriter::complete(): Old " << obj_type << " exists" << dendl;
+    	// Delete old object
+    	rc = old_mobj->delete_object(dpp, NULL, y, true);
+	if (rc == 0) {
+      		ldpp_dout(dpp, 20) << "MotrAtomicWriter::complete(): Old " << obj_type << " ["
+          	<< old_mobj->get_name() <<  "] deleted succesfully" << dendl;
+    	} else {
+      		ldpp_dout(dpp, 0) << "MotrAtomicWriter::complete(): Failed to delete old " << obj_type << " ["
+          	<< old_mobj->get_name() <<  "]. Error = " << rc << dendl;
+      		return rc;
+    	}
+  	}
+  }
   rc = store->do_idx_op_by_name(bucket_index_iname,
                                 M0_IC_PUT, obj.get_key().to_str(), bl);
   if (rc == 0)
     store->get_obj_meta_cache()->put(dpp, obj.get_key().to_str(), bl);
-
-  if (rc == 0 && !info.versioning_enabled())
-      // Delete old object data if exists.
-      old_obj.delete_mobj(dpp);
-
-  if (rc != 0)
-    obj.delete_mobj(dpp);
 
   // TODO: We need to handle the object leak caused by parallel object upload by
   // making use of background gc, which is currently not enabled for motr.

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1789,8 +1789,7 @@ MotrAtomicWriter::MotrAtomicWriter(const DoutPrefixProvider *dpp,
               ptail_placement_rule(_ptail_placement_rule),
               olh_epoch(_olh_epoch),
               unique_tag(_unique_tag),
-              obj(_store, _head_obj->get_key(), _head_obj->get_bucket()),
-              old_obj(_store, _head_obj->get_key(), _head_obj->get_bucket()) {}
+              obj(_store, _head_obj->get_key(), _head_obj->get_bucket()) {}
 
 static const unsigned MAX_BUFVEC_NR = 256;
 
@@ -2521,7 +2520,6 @@ void MotrAtomicWriter::cleanup()
   m0_bufvec_free2(&buf);
   acc_data.clear();
   obj.close_mobj();
-  old_obj.close_mobj();
 }
 
 unsigned MotrAtomicWriter::populate_bvec(unsigned len, bufferlist::iterator &bi)
@@ -2756,14 +2754,14 @@ int MotrAtomicWriter::complete(size_t accounted_size, const std::string& etag,
       			obj_type = "multipart object";
       			old_mobj->set_category(RGWObjCategory::MultiMeta);
     		}
-    	ldpp_dout(dpp, 20) << "MotrAtomicWriter::complete(): Old " << obj_type << " exists" << dendl;
+    	ldpp_dout(dpp, 20) <<__func__<< ": Old " << obj_type << " exists" << dendl;
     	// Delete old object
     	rc = old_mobj->delete_object(dpp, NULL, y, true);
 	if (rc == 0) {
-      		ldpp_dout(dpp, 20) << "MotrAtomicWriter::complete(): Old " << obj_type << " ["
+      		ldpp_dout(dpp, 20) <<__func__<< ": Old " << obj_type << " ["
           	<< old_mobj->get_name() <<  "] deleted succesfully" << dendl;
     	} else {
-      		ldpp_dout(dpp, 0) << "MotrAtomicWriter::complete(): Failed to delete old " << obj_type << " ["
+      		ldpp_dout(dpp, 0) << __func__<<": Failed to delete old " << obj_type << " ["
           	<< old_mobj->get_name() <<  "]. Error = " << rc << dendl;
       		return rc;
     	}

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -714,7 +714,6 @@ class MotrAtomicWriter : public Writer {
   uint64_t olh_epoch;
   const std::string& unique_tag;
   MotrObject obj;
-  MotrObject old_obj;
   uint64_t total_data_size; // for total data being uploaded
   bufferlist acc_data;  // accumulated data
   uint64_t   acc_off; // accumulated data offset


### PR DESCRIPTION
Problem:- When doing multipart object overwrite using simple object,
	multipart object parts was not getting deleted,resulting in leak.
Solution:- Added a code in MotrAtomicWriter::complete function, so that
	   it will check whether the old object which is present in bucket
	   is multipart or simple object,according to that it will call the
           respective functions to delete the object.

Signed-off-by: dharmendra-jyani <dharmendra.jyani@seagate.com>



## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

