### PR TITLE
CORTX-30363:User level stats counting for Motr SAL layer

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -366,6 +366,41 @@ int MotrUser::read_stats(const DoutPrefixProvider *dpp,
     ceph::real_time *last_stats_sync,
     ceph::real_time *last_stats_update)
 {
+  int rc, num_of_entries, max_entries = 100; // to fetch in chunks of 100
+  vector<string> keys(max_entries);
+  vector<bufferlist> vals(max_entries);
+  std::string user_stats_iname = "motr.rgw.user.stats." + info.user_id.to_str();
+  rgw_bucket_dir_header bkt_header;
+
+  do
+  {
+      rc = store->next_query_by_name(user_stats_iname, keys, vals);
+      if (rc < 0) {
+          ldpp_dout(dpp, 20) << __func__ << ": failed to get the user stats info for user  = "
+                            << info.user_id.to_str() << dendl;
+          return rc;
+      }
+      num_of_entries = rc;
+
+    for (int i = 0 ; i < num_of_entries; i++)
+    {
+        bufferlist::const_iterator bitr = vals[i].begin();
+        bkt_header.decode(bitr);
+
+        for (const auto& pair : bkt_header.stats) 
+        {
+          const rgw_bucket_category_stats& header_stats = pair.second;
+
+          stats->num_objects += header_stats.num_entries;
+          stats->size += header_stats.total_size;
+          stats->size_rounded += rgw_rounded_kb(header_stats.actual_size) * 1024;
+
+        }
+    }
+    keys[0] = keys[num_of_entries-1]; // keys[0] will be used as a marker in next loop.
+  }
+  while(num_of_entries == max_entries);
+
   return 0;
 }
 
@@ -384,7 +419,7 @@ int MotrUser::read_usage(const DoutPrefixProvider *dpp, uint64_t start_epoch, ui
     bool *is_truncated, RGWUsageIter& usage_iter,
     map<rgw_user_bucket, rgw_usage_log_entry>& usage)
 {
-  return 0;
+  return -ENOENT;
 }
 
 int MotrUser::trim_usage(const DoutPrefixProvider *dpp, uint64_t start_epoch, uint64_t end_epoch)
@@ -953,7 +988,7 @@ int MotrBucket::read_usage(const DoutPrefixProvider *dpp, uint64_t start_epoch, 
     RGWUsageIter& usage_iter,
     map<rgw_user_bucket, rgw_usage_log_entry>& usage)
 {
-  return 0;
+  return -ENOENT;
 }
 
 int MotrBucket::trim_usage(const DoutPrefixProvider *dpp, uint64_t start_epoch, uint64_t end_epoch)
@@ -3829,7 +3864,7 @@ int MotrStore::read_all_usage(const DoutPrefixProvider *dpp, uint64_t start_epoc
     RGWUsageIter& usage_iter,
     map<rgw_user_bucket, rgw_usage_log_entry>& usage)
 {
-  return 0;
+  return -ENOENT;
 }
 
 int MotrStore::trim_all_usage(const DoutPrefixProvider *dpp, uint64_t start_epoch, uint64_t end_epoch)

--- a/src/rgw/rgw_usage.cc
+++ b/src/rgw/rgw_usage.cc
@@ -167,7 +167,7 @@ int RGWUsage::show(const DoutPrefixProvider *dpp, rgw::sal::Store* store,
       return ret;
   }
 
-  formatter->open_array_section("StorageStats");
+  formatter->open_object_section("StorageStats");
   encode_json("size", stats.size, formatter);
   encode_json("size_actual", stats.size_rounded, formatter);
   encode_json("size_kb", rgw_rounded_kb(stats.size), formatter);


### PR DESCRIPTION
Problem : User level stats counting for Motr SAL layer
Solution : Fetched stats from newly added user stats table
Signed-off-by: Diwakar92 <diwakar.kumar@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
