### PR TITLE
rgw_sal_motr : [CORTX-30149] Fix for handling null version-id issues in multipart upload

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -2863,14 +2863,17 @@ int MotrObject::update_null_reference(const DoutPrefixProvider *dpp, rgw_bucket_
   bufferlist::const_iterator iter;
   bufferlist bl, bl_null_idx_val;
   rgw_bucket_dir_entry current_null_key_ref;
-  current_null_key_ref.key.name = this->get_name();
-  current_null_key_ref.key.instance = this->get_instance();
 
   // Set the key and instance for multipart object from ent structure
   if (ent.meta.category == RGWObjCategory::MultiMeta)
   {
     current_null_key_ref.key.name = ent.key.name;
     current_null_key_ref.key.instance = ent.key.instance;
+  }
+  else
+  {
+    current_null_key_ref.key.name = this->get_name();
+    current_null_key_ref.key.instance = this->get_instance();
   }
   current_null_key_ref.encode(bl_null_idx_val);
 

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -2865,6 +2865,13 @@ int MotrObject::update_null_reference(const DoutPrefixProvider *dpp, rgw_bucket_
   rgw_bucket_dir_entry current_null_key_ref;
   current_null_key_ref.key.name = this->get_name();
   current_null_key_ref.key.instance = this->get_instance();
+
+  // Set the key and instance for multipart object from ent structure
+  if (ent.meta.category == RGWObjCategory::MultiMeta)
+  {
+    current_null_key_ref.key.name = ent.key.name;
+    current_null_key_ref.key.instance = ent.key.instance;
+  }
   current_null_key_ref.encode(bl_null_idx_val);
 
   int motr_rc = this->store->do_idx_op_by_name(bucket_index_iname,
@@ -3507,6 +3514,14 @@ int MotrMultipartUpload::complete(const DoutPrefixProvider *dpp,
                            << " obj accounted size=" << ent.meta.accounted_size << dendl;
   ent.meta.mtime = ceph::real_clock::now();
   ent.meta.etag = etag;
+
+  RGWBucketInfo &info = target_obj->get_bucket()->get_info();
+
+  if (!target_obj->get_key().have_instance()) {
+    // generate-version-id for null version.
+    target_obj->gen_rand_obj_instance_name();
+    ent.key.instance = "null";
+  }
   ent.encode(update_bl);
   encode(attrs, update_bl);
   MotrObject::Meta meta_dummy;
@@ -3548,6 +3563,19 @@ int MotrMultipartUpload::complete(const DoutPrefixProvider *dpp,
           << old_mobj->get_name() <<  "]. Error = " << rc << dendl;
       return rc;
     }
+  }
+
+  std::unique_ptr<rgw::sal::Object> obj_ver = target_obj->get_bucket()->get_object(rgw_obj_key(target_obj->get_name()));
+  rgw::sal::MotrObject *mobj_ver = static_cast<rgw::sal::MotrObject *>(obj_ver.get());
+
+  if(!info.versioning_enabled())
+  {
+    // if bucket version is suspended/unversioned, then fetch & update previous null
+    // version entry instead of adding new null version entry.
+    int ret_rc;
+    ent.key.instance = target_obj->get_instance();
+    ret_rc = mobj_ver->update_null_reference(dpp, ent);
+    ldpp_dout(dpp, 20) <<__func__<< ": update_null_reference rc : " << ret_rc << dendl;
   }
 
   rc = store->do_idx_op_by_name(bucket_index_iname, M0_IC_PUT,


### PR DESCRIPTION
Problem Statement:
Multipart-upload is not working as expected for null version-id scenarios.

Solution:
To handle the null version-id cases in multipart upload API, created null reference key(obj/null) at the time of object PUT(same way as we used in case of normal obj)

Signed-off-by: Priyanka Salunke [priyanka.s.salunke@seagate.com]

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
