### PR TITLE
rgw_sal_motr : [CORTX-30149] Fix multipart object issues in Delete Object API for unversioned bucket

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1729,7 +1729,7 @@ int MotrObject::MotrDeleteOp::delete_obj(const DoutPrefixProvider* dpp, optional
       {
         // delete object permanently.
         result.version_id = ent.key.instance;
-        if (source->category == RGWObjCategory::MultiMeta)
+        if (ent.meta.category == RGWObjCategory::MultiMeta)
           rc = source->delete_part_objs(dpp);
         else
           rc = source->delete_mobj(dpp);
@@ -1823,7 +1823,7 @@ int MotrObject::MotrDeleteOp::delete_obj(const DoutPrefixProvider* dpp, optional
       // Unversioned flow
       if(ent.meta.size !=0 )
       {
-        if (source->category == RGWObjCategory::MultiMeta)
+        if (ent.meta.category == RGWObjCategory::MultiMeta)
           rc = source->delete_part_objs(dpp);
         else
           rc = source->delete_mobj(dpp);
@@ -2863,7 +2863,6 @@ int MotrObject::update_null_reference(const DoutPrefixProvider *dpp, rgw_bucket_
   bufferlist::const_iterator iter;
   bufferlist bl, bl_null_idx_val;
   rgw_bucket_dir_entry current_null_key_ref;
-
   // Set the key and instance for multipart object from ent structure
   if (ent.meta.category == RGWObjCategory::MultiMeta)
   {
@@ -3099,9 +3098,24 @@ int MotrMultipartUpload::delete_parts(const DoutPrefixProvider *dpp)
   // Delete object part index.
   string tenant_bkt_name = get_bucket_name(bucket->get_tenant(), bucket->get_name());
   string upload_id = get_upload_id();
-  
+  string key_name;
+
   if (upload_id.length() == 0){
-    rc = store->get_upload_id(tenant_bkt_name, mp_obj.get_key(), upload_id);
+    std::unique_ptr<rgw::sal::Object> obj_ver = this->bucket->get_object(rgw_obj_key(this->get_key()));
+    rgw::sal::MotrObject *mobj_ver = static_cast<rgw::sal::MotrObject *>(obj_ver.get());
+
+    // if the bucket is unversioned and instance is empty
+    // then fetch the null object reference to get instance.
+    if(mobj_ver->get_instance() == "")
+    {
+      int ret_rc = mobj_ver->fetch_null_obj_reference(dpp, key_name);
+      if(ret_rc < 0) {
+        ldpp_dout(dpp, 0) << __func__ << " : failed to get null object reference, ret_rc : "<< ret_rc << dendl;
+        return ret_rc;
+      }
+    }
+
+    rc = store->get_upload_id(tenant_bkt_name, key_name, upload_id);
     if (rc < 0) {
       ldpp_dout(dpp, 0) << "ERROR: get_upload_id failed. " << rc << dendl;
       return rc;


### PR DESCRIPTION
Problem Statement:
Delete object API is not working as expected for multipart upload object for unversioned bucket after adding null version-id code changes

Solution:
For unversioned bucket, Pass the key name as `objectname[version_id]` to the delete object API for multipart object.

Signed-off-by: Priyanka Salunke <priyanka.s.salunke@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
