### PR TITLE
rgw_sal_motr: [CORTX-30363] Fix user-stats bug for user with no buckets

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -226,6 +226,9 @@ int MotrUser::list_buckets(const DoutPrefixProvider *dpp, const string& marker,
   if (rc < 0) {
     ldpp_dout(dpp, 0) <<  __func__ << ": ERROR: NEXT query failed. " << rc << dendl;
     return rc;
+  } else if (rc == 0) {
+    ldpp_dout(dpp, 0) <<  __func__ << ": No buckets to list. " << rc << dendl;
+    return rc;
   }
 
   // Process the returned pairs to add into BucketList.
@@ -402,34 +405,31 @@ int MotrUser::read_stats(const DoutPrefixProvider *dpp,
   std::string user_stats_iname = "motr.rgw.user.stats." + info.user_id.to_str();
   rgw_bucket_dir_header bkt_header;
 
-  do
-  {
-      rc = store->next_query_by_name(user_stats_iname, keys, vals);
-      if (rc < 0) {
-          ldpp_dout(dpp, 20) << __func__ << ": failed to get the user stats info for user  = "
-                            << info.user_id.to_str() << dendl;
-          return rc;
+  do {
+    rc = store->next_query_by_name(user_stats_iname, keys, vals);
+    if (rc < 0) {
+      ldpp_dout(dpp, 20) << __func__ << ": failed to get the user stats info for user  = "
+                        << info.user_id.to_str() << dendl;
+      return rc;
+    } else if (rc == 0) {
+      ldpp_dout(dpp, 20) << __func__ << ": No bucket to fetch the stats." << dendl;
+      return rc;
+    }
+    num_of_entries = rc;
+
+    for (int i = 0 ; i < num_of_entries; i++) {
+      bufferlist::const_iterator bitr = vals[i].begin();
+      bkt_header.decode(bitr);
+
+      for (const auto& pair : bkt_header.stats) {
+        const rgw_bucket_category_stats& header_stats = pair.second;
+        stats->num_objects += header_stats.num_entries;
+        stats->size += header_stats.total_size;
+        stats->size_rounded += rgw_rounded_kb(header_stats.actual_size) * 1024;
       }
-      num_of_entries = rc;
-
-    for (int i = 0 ; i < num_of_entries; i++)
-    {
-        bufferlist::const_iterator bitr = vals[i].begin();
-        bkt_header.decode(bitr);
-
-        for (const auto& pair : bkt_header.stats) 
-        {
-          const rgw_bucket_category_stats& header_stats = pair.second;
-
-          stats->num_objects += header_stats.num_entries;
-          stats->size += header_stats.total_size;
-          stats->size_rounded += rgw_rounded_kb(header_stats.actual_size) * 1024;
-
-        }
     }
     keys[0] = keys[num_of_entries-1]; // keys[0] will be used as a marker in next loop.
-  }
-  while(num_of_entries == max_entries);
+  } while(num_of_entries == max_entries);
 
   return 0;
 }
@@ -4261,6 +4261,9 @@ int MotrStore::next_query_by_name(string idx_name,
     if (rc < 0) {
       ldout(cctx, 0) << __func__ << ": ERROR: NEXT query failed. " << rc << dendl;
       goto out;
+    } else if (rc == 0) {
+      ldout(cctx, 20) << __func__ << ": No more entries in the table." << dendl;
+      goto out;
     }
 
     string dir;
@@ -4307,7 +4310,7 @@ int MotrStore::next_query_by_name(string idx_name,
 
 out:
   m0_idx_fini(&idx);
-  return rc < 0 ? rc : i + k;
+  return rc <= 0 ? rc : i + k;
 }
 
 int MotrStore::delete_motr_idx_by_name(string iname)

--- a/src/rgw/rgw_usage.cc
+++ b/src/rgw/rgw_usage.cc
@@ -146,8 +146,14 @@ int RGWUsage::show(const DoutPrefixProvider *dpp, rgw::sal::Store* store,
     formatter->close_section(); // summary
   }
   
+  // Added storage stats for a user as part of usage API
+  // Steps - 1. Sync the user stats
+  //         2. Read the stats & add them in the StorageStats section
+  ret = rgw_user_sync_all_stats(dpp, store, user, null_yield);
 
-  // section: StorageStats per user
+  if (ret < 0)
+    ldpp_dout(dpp, 20) << __func__ << ": User Stats Sync failed, "
+                       << "stats can be old." << dendl;
 
   constexpr bool omit_utilized_stats = false;
   RGWStorageStats stats(omit_utilized_stats);
@@ -156,24 +162,23 @@ int RGWUsage::show(const DoutPrefixProvider *dpp, rgw::sal::Store* store,
 
   ret = user->read_stats(dpp, null_yield, &stats, &last_stats_sync, &last_stats_update);
 
-  if (ret < 0) {
-    formatter->close_section(); // usage
+  if (ret == 0) {
+    formatter->open_object_section("StorageStats"); // StorageStats
+    encode_json("size", stats.size, formatter);
+    encode_json("size_actual", stats.size_rounded, formatter);
+    encode_json("size_kb", rgw_rounded_kb(stats.size), formatter);
+    encode_json("size_kb_actual", rgw_rounded_kb(stats.size_rounded), formatter);
+    encode_json("num_objects", stats.num_objects, formatter);
+    utime_t last_sync_ut(last_stats_sync);
+    encode_json("last_stats_sync", last_sync_ut, formatter);
+    utime_t last_update_ut(last_stats_update);
+    encode_json("last_stats_update", last_update_ut, formatter);
+    formatter->close_section(); // StorageStats
     flusher.flush();
-    return ret;
+  } else {
+    ldpp_dout(dpp, 20) << __func__ << ": Failed to fetch the user stats."
+                       << " ret = " << ret << dendl;
   }
-
-  formatter->open_object_section("StorageStats"); // StorageStats
-  encode_json("size", stats.size, formatter);
-  encode_json("size_actual", stats.size_rounded, formatter);
-  encode_json("size_kb", rgw_rounded_kb(stats.size), formatter);
-  encode_json("size_kb_actual", rgw_rounded_kb(stats.size_rounded), formatter);
-  encode_json("num_objects", stats.num_objects, formatter);
-  utime_t last_sync_ut(last_stats_sync);
-  encode_json("last_stats_sync", last_sync_ut, formatter);
-  utime_t last_update_ut(last_stats_update);
-  encode_json("last_stats_update", last_update_ut, formatter);
-  formatter->close_section(); // StorageStats
-  flusher.flush();
 
   formatter->close_section(); // usage
   flusher.flush();


### PR DESCRIPTION
Issue:
- next_query_by_name() crashes when zero entries are returned and so does
  list_buckets() and read_stats().
- Fixing the issue by returning 0 when no entries are present in the index.

Signed-off-by: Sumedh A. Kulkarni <sumedh.a.kulkarni@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
