### PR TITLE
rgw_sal_motr: [CORTX-30178] Handling null version-id use case, Enabling versioning for Multipart APIs, Delete and Bulk Delete APIs

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -2866,8 +2866,18 @@ int MotrObject::update_null_reference(const DoutPrefixProvider *dpp, rgw_bucket_
   bufferlist::const_iterator iter;
   bufferlist bl, bl_null_idx_val;
   rgw_bucket_dir_entry current_null_key_ref;
-  current_null_key_ref.key.name = this->get_name();
-  current_null_key_ref.key.instance = this->get_instance();
+
+  // Set the key and instance for multipart object from ent structure
+  if (ent.meta.category == RGWObjCategory::MultiMeta)
+  {
+    current_null_key_ref.key.name = ent.key.name;
+    current_null_key_ref.key.instance = ent.key.instance;
+  }
+  else
+  {
+    current_null_key_ref.key.name = this->get_name();
+    current_null_key_ref.key.instance = this->get_instance();
+  }
   current_null_key_ref.encode(bl_null_idx_val);
 
   int motr_rc = this->store->do_idx_op_by_name(bucket_index_iname,
@@ -3519,6 +3529,14 @@ int MotrMultipartUpload::complete(const DoutPrefixProvider *dpp,
                            << " obj accounted size=" << ent.meta.accounted_size << dendl;
   ent.meta.mtime = ceph::real_clock::now();
   ent.meta.etag = etag;
+
+  RGWBucketInfo &info = target_obj->get_bucket()->get_info();
+
+  if (!target_obj->get_key().have_instance()) {
+    // generate-version-id for null version.
+    target_obj->gen_rand_obj_instance_name();
+    ent.key.instance = "null";
+  }
   ent.encode(update_bl);
   encode(attrs, update_bl);
   MotrObject::Meta meta_dummy;
@@ -3562,15 +3580,25 @@ int MotrMultipartUpload::complete(const DoutPrefixProvider *dpp,
     }
   }
 
+  std::unique_ptr<rgw::sal::Object> obj_ver = target_obj->get_bucket()->get_object(rgw_obj_key(target_obj->get_name()));
+  rgw::sal::MotrObject *mobj_ver = static_cast<rgw::sal::MotrObject *>(obj_ver.get());
+
+  if(!info.versioning_enabled())
+  {
+    // if bucket version is suspended/unversioned, then fetch & update previous null
+    // version entry instead of adding new null version entry.
+    int ret_rc;
+    ent.key.instance = target_obj->get_instance();
+    ret_rc = mobj_ver->update_null_reference(dpp, ent);
+    ldpp_dout(dpp, 20) <<__func__<< ": update_null_reference rc : " << ret_rc << dendl;
+  }
+
   // Check for bucket versioning
   // Update existing object version entries in a bucket,
   // in case of both versioning enabled and suspended.
-  RGWBucketInfo &info = target_obj->get_bucket()->get_info();
   if(info.versioned())
   {
     string bucket_index_iname = "motr.rgw.bucket.index." + tenant_bkt_name;
-    std::unique_ptr<rgw::sal::Object> obj_ver = target_obj->get_bucket()->get_object(rgw_obj_key(target_obj->get_name()));
-    rgw::sal::MotrObject *mobj_ver = static_cast<rgw::sal::MotrObject *>(obj_ver.get());
 
     rc = mobj_ver->update_version_entries(dpp);
     ldpp_dout(dpp, 20) << __func__ << ": update_version_entries, rc = " << rc << dendl;

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1528,6 +1528,11 @@ int MotrObject::MotrReadOp::prepare(optional_yield y, const DoutPrefixProvider* 
 
   rgw_bucket_dir_entry ent;
   rc = source->get_bucket_dir_ent(dpp, ent);
+  if(ent.is_delete_marker())
+  {
+    rc = -ENOENT;
+    return rc;
+  }
   if (rc < 0)
     return rc;
 

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1722,6 +1722,9 @@ int MotrObject::MotrDeleteOp::delete_obj(const DoutPrefixProvider* dpp, optional
         if (rc < 0)
           return rc;
       }
+      // delete null reference key
+      if(ent.key.instance == "null")
+        del_null_ref_key = true;
     }
   } else {
     ldpp_dout(dpp, 20) << "delete " << delete_key << " from " << tenant_bkt_name << dendl;
@@ -1844,6 +1847,7 @@ int MotrObject::MotrDeleteOp::delete_obj(const DoutPrefixProvider* dpp, optional
       // delete null reference key.
       del_null_ref_key = true;
    }
+  }
   if(del_null_ref_key)
   {
     bl.clear();
@@ -1855,7 +1859,6 @@ int MotrObject::MotrDeleteOp::delete_obj(const DoutPrefixProvider* dpp, optional
       ldpp_dout(dpp, 0) <<__func__<< " ERROR: Unable to delete null reference key" << dendl;
       return rc;
       }
-    }
   }
   return 0;
 }
@@ -2878,7 +2881,6 @@ int MotrObject::update_null_reference(const DoutPrefixProvider *dpp, rgw_bucket_
     current_null_key_ref.key.instance = this->get_instance();
   }
   current_null_key_ref.encode(bl_null_idx_val);
-
   int motr_rc = this->store->do_idx_op_by_name(bucket_index_iname,
                             M0_IC_GET, null_ref_key, bl);
   ldpp_dout(dpp, 20) <<__func__<< "GET null index entry, rc : " << motr_rc << dendl;

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -693,6 +693,9 @@ class MotrObject : public Object {
     int delete_part_objs(const DoutPrefixProvider* dpp);
     void set_category(RGWObjCategory _category) {category = _category;}
     int get_bucket_dir_ent(const DoutPrefixProvider *dpp, rgw_bucket_dir_entry& ent);
+    int fetch_null_obj(const DoutPrefixProvider *dpp, bufferlist& bl);
+    int fetch_null_obj_reference(const DoutPrefixProvider *dpp, std::string& prev_null_obj_key);
+    int update_null_reference(const DoutPrefixProvider *dpp, rgw_bucket_dir_entry& ent);
     int update_version_entries(const DoutPrefixProvider *dpp);
     uint64_t get_processed_bytes() { return processed_bytes; }
 };

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -696,7 +696,7 @@ class MotrObject : public Object {
     int fetch_null_obj(const DoutPrefixProvider *dpp, bufferlist& bl);
     int fetch_null_obj_reference(const DoutPrefixProvider *dpp, std::string& prev_null_obj_key);
     int update_null_reference(const DoutPrefixProvider *dpp, rgw_bucket_dir_entry& ent);
-    int update_version_entries(const DoutPrefixProvider *dpp);
+    int update_version_entries(const DoutPrefixProvider *dpp, bool set_is_latest=false);
     uint64_t get_processed_bytes() { return processed_bytes; }
 };
 

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -906,7 +906,7 @@ public:
 			  const rgw_placement_rule *ptail_placement_rule,
 			  uint64_t part_num,
 			  const std::string& part_num_str) override;
-  int delete_parts(const DoutPrefixProvider *dpp);
+  int delete_parts(const DoutPrefixProvider *dpp, std::string version_id="");
 };
 
 class MotrStore : public Store {


### PR DESCRIPTION
Merging 'versioning-feature' branch into 'main'

**Problem statement:**
  Need versioning for Multipart APIs, Delete and Bulk Delete APIs, handle null version-id usecase and fix issues for GET and HEAD object API.
  
**Solution**:
Fixed following issues for unversioned/version enabled/version suspended bucket.
1. Simple object null version-id cases.
2. Multipart upload null version-id cases.
3. Fixed delete-object and delete-objects issues.
4. Get and head object issues.

Signed-off-by: Sachitanand Shelake <sachitanand.shelake@seagate.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
