### PR TITLE
rgw_sal_motr: [CORTX-31201] Add User & Bucket Quota Validation

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -39,6 +39,7 @@ extern "C" {
 #include "rgw_sal.h"
 #include "rgw_sal_motr.h"
 #include "rgw_bucket.h"
+#include "rgw_quota.h"
 #include "motr/addb/rgw_addb.h"
 
 #define dout_subsys ceph_subsys_rgw
@@ -1091,11 +1092,19 @@ int MotrBucket::check_empty(const DoutPrefixProvider *dpp, optional_yield y)
   return 0;
 }
 
-int MotrBucket::check_quota(const DoutPrefixProvider *dpp, RGWQuotaInfo& user_quota, RGWQuotaInfo& bucket_quota, uint64_t obj_size,
-    optional_yield y, bool check_size_only)
-{
-  /* Not Handled in the first pass as stats are also needed */
-  return 0;
+int MotrBucket::check_quota(const DoutPrefixProvider *dpp,
+    RGWQuotaInfo& user_quota, RGWQuotaInfo& bucket_quota,
+    uint64_t obj_size, optional_yield y, bool check_size_only) {
+  RGWQuotaHandler* quota_handler = \
+    RGWQuotaHandler::generate_handler(dpp, store, false);
+
+  ldpp_dout(dpp, 20) << __func__ << ": called. check_size_only = "
+     << check_size_only << ", obj_size = " << obj_size << dendl;
+
+  int rc = quota_handler->check_quota(dpp, info.owner, info.bucket,
+                                      user_quota, bucket_quota,
+                                      check_size_only ? 0 : 1, obj_size, y);
+  return rc;
 }
 
 int MotrBucket::merge_and_store_attrs(const DoutPrefixProvider *dpp, Attrs& new_attrs, optional_yield y)


### PR DESCRIPTION
### Support User & Bucket Quota Validation
- User & Bucket Quota is compared and validated at Object Put operation to ensure that quota limits are not breached.
- `MotrBucket::check_quota()` function is implemented for the same.
```
JFYI:
* There are 2 types of bucket quotas. 
  1. Bucket quota applied to a specific bucket 
  2. User level bucket quota
* If a bucket quota is added for a particular bucket it will take precedence over User level bucket quota.
```

Signed-off-by: Sumedh A. Kulkarni <sumedh.a.kulkarni@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
