### PR TITLE
rgw_sal_motr: [CORTX-31925] Fix object leak for null version object.

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1888,8 +1888,7 @@ int MotrObject::MotrDeleteOp::delete_obj(const DoutPrefixProvider* dpp, optional
       if (rc < 0)
         return rc;
     }
-  }
-  else {
+  } else {
     // // TODO: Avoid this lookup, Find a another way to fetch null version key.
     if (ent.key.instance == "null") {
       rc = source->fetch_null_obj_reference(dpp, delete_key);

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -699,7 +699,7 @@ class MotrObject : public Object {
     int fetch_null_obj_reference(const DoutPrefixProvider *dpp, std::string& prev_null_obj_key);
     int update_null_reference(const DoutPrefixProvider *dpp, rgw_bucket_dir_entry& ent);
     int update_version_entries(const DoutPrefixProvider *dpp, bool set_is_latest=false);
-    int remove_mobj_and_index_entry(const DoutPrefixProvider* dpp, rgw_bucket_dir_entry& ent, std::string prev_null_obj_key);
+    int remove_mobj_and_index_entry(const DoutPrefixProvider* dpp, rgw_bucket_dir_entry& ent, std::string delete_key);
     uint64_t get_processed_bytes() { return processed_bytes; }
 };
 

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -699,6 +699,7 @@ class MotrObject : public Object {
     int fetch_null_obj_reference(const DoutPrefixProvider *dpp, std::string& prev_null_obj_key);
     int update_null_reference(const DoutPrefixProvider *dpp, rgw_bucket_dir_entry& ent);
     int update_version_entries(const DoutPrefixProvider *dpp, bool set_is_latest=false);
+    int overwrite_null_obj(const DoutPrefixProvider *dpp);
     int remove_mobj_and_index_entry(const DoutPrefixProvider* dpp, rgw_bucket_dir_entry& ent, std::string delete_key);
     uint64_t get_processed_bytes() { return processed_bytes; }
 };

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -699,6 +699,7 @@ class MotrObject : public Object {
     int fetch_null_obj_reference(const DoutPrefixProvider *dpp, std::string& prev_null_obj_key);
     int update_null_reference(const DoutPrefixProvider *dpp, rgw_bucket_dir_entry& ent);
     int update_version_entries(const DoutPrefixProvider *dpp, bool set_is_latest=false);
+    int remove_mobj_and_index_entry(const DoutPrefixProvider* dpp, rgw_bucket_dir_entry& ent, std::string prev_null_obj_key);
     uint64_t get_processed_bytes() { return processed_bytes; }
 };
 

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -700,7 +700,8 @@ class MotrObject : public Object {
     int update_null_reference(const DoutPrefixProvider *dpp, rgw_bucket_dir_entry& ent);
     int update_version_entries(const DoutPrefixProvider *dpp, bool set_is_latest=false);
     int overwrite_null_obj(const DoutPrefixProvider *dpp);
-    int remove_mobj_and_index_entry(const DoutPrefixProvider* dpp, rgw_bucket_dir_entry& ent, std::string delete_key);
+    int remove_mobj_and_index_entry(const DoutPrefixProvider* dpp, rgw_bucket_dir_entry& ent,
+                                    std::string delete_key, std::string bucket_index_iname);
     uint64_t get_processed_bytes() { return processed_bytes; }
 };
 


### PR DESCRIPTION
Problem:
While adding the new null version in the suspended/unversioned bucket
deleting the previous null object from the bucket index only.

Solution:
Delete object from motr store as well as from the bucket index.

Signed-off-by: Shriya Deshmukh <shriya.deshmukh@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
