### PR TITLE
rgw_sal_motr : [CORTX-31843] Fix delete objects API issues in multipart upload

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -3250,18 +3250,11 @@ int MotrObject::update_null_reference(const DoutPrefixProvider *dpp, rgw_bucket_
   bufferlist::const_iterator iter;
   bufferlist bl, bl_null_idx_val;
   rgw_bucket_dir_entry current_null_key_ref;
-  // Set the key and instance for multipart object from ent structure
-  if (ent.meta.category == RGWObjCategory::MultiMeta)
-  {
-    current_null_key_ref.key.name = ent.key.name;
-    current_null_key_ref.key.instance = ent.key.instance;
-  }
-  else
-  {
-    current_null_key_ref.key.name = this->get_name();
-    current_null_key_ref.key.instance = this->get_instance();
-  }
+ 
+  current_null_key_ref.key.name = this->get_name();
+  current_null_key_ref.key.instance = this->get_instance();
   current_null_key_ref.encode(bl_null_idx_val);
+
   int motr_rc = this->store->do_idx_op_by_name(bucket_index_iname,
                             M0_IC_GET, null_ref_key, bl);
   ldpp_dout(dpp, 20) <<__func__<< "GET null index entry, rc : " << motr_rc << dendl;
@@ -3744,22 +3737,24 @@ int MotrMultipartUpload::list_parts(const DoutPrefixProvider *dpp, CephContext *
     if(ret_rc < 0)
       return ret_rc;
 
-    key_name = ent.key.name + "[" + ent.key.instance + "]";
-
-    // fetch the version-id in case of null version-id
-    if(ent.key.instance == "null")
+    if(!ent.is_delete_marker())
     {
-      ret_rc = mobj_ver->fetch_null_obj_reference(dpp, key_name);
-      if(ret_rc < 0) {
-        ldpp_dout(dpp, 0) << __func__ << " : failed to get null object reference, ret_rc : "<< ret_rc << dendl;
-        return ret_rc;
-      }
-    }
+      key_name = ent.key.name + "[" + ent.key.instance + "]";
 
-    rc = store->get_upload_id(tenant_bkt_name, key_name, upload_id);
-    if (rc < 0) {
-      ldpp_dout(dpp, 0) << __func__ << ": ERROR: get_upload_id failed. rc = " << rc << dendl;
-      return rc;
+      //fetch the version-id in case of null version-id
+      if(ent.key.instance == "null")
+      {
+        ret_rc = mobj_ver->fetch_null_obj_reference(dpp, key_name);
+        if(ret_rc < 0) {
+          ldpp_dout(dpp, 0) << __func__ << " : failed to get null object reference, ret_rc : "<< ret_rc << dendl;
+          return ret_rc;
+        }
+      }
+      rc = store->get_upload_id(tenant_bkt_name, key_name, upload_id);
+      if (rc < 0) {
+        ldpp_dout(dpp, 0) << __func__ << ": ERROR: get_upload_id failed. rc = " << rc << dendl;
+        return rc;
+      }
     }
   }
 
@@ -4025,7 +4020,6 @@ int MotrMultipartUpload::complete(const DoutPrefixProvider *dpp,
   MotrObject::Meta meta_dummy;
   meta_dummy.encode(update_bl);
 
-
   string bucket_index_iname = "motr.rgw.bucket.index." + tenant_bkt_name;
   ldpp_dout(dpp, 20) << __func__ << ": target_obj name=" << target_obj->get_name()
                                   << " target_obj oid=" << target_obj->get_oid() << dendl;
@@ -4072,6 +4066,8 @@ int MotrMultipartUpload::complete(const DoutPrefixProvider *dpp,
     // version entry instead of adding new null version entry.
     int ret_rc;
     ent.key.instance = target_obj->get_instance();
+
+    mobj_ver->set_instance(ent.key.instance);
     ret_rc = mobj_ver->update_null_reference(dpp, ent);
     ldpp_dout(dpp, 20) <<__func__<< ": update_null_reference rc : " << ret_rc << dendl;
   }

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -3739,6 +3739,7 @@ int MotrMultipartUpload::list_parts(const DoutPrefixProvider *dpp, CephContext *
 
     if(!ent.is_delete_marker())
     {
+      // key_name = object_name[version_id]
       key_name = ent.key.name + "[" + ent.key.instance + "]";
 
       //fetch the version-id in case of null version-id

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -3739,7 +3739,7 @@ int MotrMultipartUpload::list_parts(const DoutPrefixProvider *dpp, CephContext *
 
     if(!ent.is_delete_marker())
     {
-      // key_name = object_name[version_id]
+      // key_name = test_obj1[zWs1hl8neLT5wggBth5qjgOzUuXt20E]
       key_name = ent.key.name + "[" + ent.key.instance + "]";
 
       //fetch the version-id in case of null version-id

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -3737,14 +3737,12 @@ int MotrMultipartUpload::list_parts(const DoutPrefixProvider *dpp, CephContext *
     if(ret_rc < 0)
       return ret_rc;
 
-    if(!ent.is_delete_marker())
-    {
+    if(!ent.is_delete_marker()) {
       // key_name = test_obj1[zWs1hl8neLT5wggBth5qjgOzUuXt20E]
       key_name = ent.key.name + "[" + ent.key.instance + "]";
 
       //fetch the version-id in case of null version-id
-      if(ent.key.instance == "null")
-      {
+      if(ent.key.instance == "null") {
         ret_rc = mobj_ver->fetch_null_obj_reference(dpp, key_name);
         if(ret_rc < 0) {
           ldpp_dout(dpp, 0) << __func__ << " : failed to get null object reference, ret_rc : "<< ret_rc << dendl;


### PR DESCRIPTION
Problem Statement:
- Observed crash in delete objects (bulk delete) API in multipart object, when delete marker is present for an object.
- Delete object API is not working for delete marker with --version-id as null parameter.

Solution:
- Added the delete marker condition in the function for multipart objects. If delete marker not present for an object, then fetch the instance and delete the object. 

Signed-off-by: Priyanka Salunke <priyanka.s.salunke@seagate.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
