### PR TITLE
rgw_sal_motr: [CORTX-31638] add log for motr object details

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -2292,9 +2292,8 @@ int MotrObject::create_mobj(const DoutPrefixProvider *dpp, uint64_t sz)
   }
   expected_obj_size = sz;
 
-  char fid_str[M0_FID_STR_LEN];
-  snprintf(fid_str, ARRAY_SIZE(fid_str), U128X_F, U128_P(&meta.oid));
-  ldpp_dout(dpp, 20) <<__func__<< ": sz=" << sz << " oid=" << fid_str << dendl;
+  ldpp_dout(dpp, 20) << __func__ << ": key=" << this->get_key().to_str() << ", meta:oid=[0x" << std::hex
+                                 << meta.oid.u_hi << ":0x" << std::hex  << meta.oid.u_lo << "]" << dendl;
 
   int64_t lid = m0_layout_find_by_objsz(store->instance, nullptr, sz);
   if (lid <= 0) {
@@ -2337,8 +2336,10 @@ int MotrObject::create_mobj(const DoutPrefixProvider *dpp, uint64_t sz)
 
   meta.layout_id = mobj->ob_attr.oa_layout_id;
   meta.pver      = mobj->ob_attr.oa_pver;
-  ldpp_dout(dpp, 20) <<__func__<< ": lid=0x" << std::hex << meta.layout_id
-                     << std::dec << " rc = " << rc << dendl;
+  ldpp_dout(dpp, 20) << __func__ << ": key=" << this->get_key() << ", meta:oid=[0x" << std::hex << meta.oid.u_hi
+                                  << ":0x" << std::hex << meta.oid.u_lo << "], meta:pvid=[0x" << std::hex
+                                  << meta.pver.f_container << ":0x" << std::hex << meta.pver.f_key
+                                  << "], meta:layout_id=0x" << std::hex << meta.layout_id << dendl;
 
   ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
        RGW_ADDB_FUNC_CREATE_MOBJ,
@@ -2351,9 +2352,8 @@ int MotrObject::create_mobj(const DoutPrefixProvider *dpp, uint64_t sz)
 
 int MotrObject::open_mobj(const DoutPrefixProvider *dpp)
 {
-  char fid_str[M0_FID_STR_LEN];
-  snprintf(fid_str, ARRAY_SIZE(fid_str), U128X_F, U128_P(&meta.oid));
-  ldpp_dout(dpp, 20) <<__func__<< ": oid=" << fid_str << dendl;
+  ldpp_dout(dpp, 20) << __func__ << ": key=" << this->get_key().to_str() << ", meta:oid=[0x" << std::hex
+                                 << meta.oid.u_hi  << ":0x" << std::hex  << meta.oid.u_lo << "]" << dendl;
 
   ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
        RGW_ADDB_FUNC_OPEN_MOBJ,
@@ -2365,8 +2365,8 @@ int MotrObject::open_mobj(const DoutPrefixProvider *dpp)
     rc = this->get_bucket_dir_ent(dpp, ent);
     if (rc < 0) {
       ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-	   RGW_ADDB_FUNC_OPEN_MOBJ,
-	   RGW_ADDB_PHASE_ERROR);
+           RGW_ADDB_FUNC_OPEN_MOBJ,
+           RGW_ADDB_PHASE_ERROR);
       ldpp_dout(dpp, 0) << __func__ << ": ERROR: get_bucket_dir_ent failed: rc = " << rc << dendl;
       return rc;
     }
@@ -2374,9 +2374,9 @@ int MotrObject::open_mobj(const DoutPrefixProvider *dpp)
 
   if (meta.layout_id == 0) {
     ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-	 RGW_ADDB_FUNC_OPEN_MOBJ,
-	 RGW_ADDB_PHASE_DONE);
-
+         RGW_ADDB_FUNC_OPEN_MOBJ,
+         RGW_ADDB_PHASE_DONE);
+    ldpp_dout(dpp, 0) << __func__ << ": ERROR: did not find motr obj details." << dendl;
     return -ENOENT;
   }
 
@@ -2389,11 +2389,14 @@ int MotrObject::open_mobj(const DoutPrefixProvider *dpp)
   mobj->ob_attr.oa_layout_id = meta.layout_id;
   mobj->ob_attr.oa_pver      = meta.pver;
   mobj->ob_entity.en_flags  |= M0_ENF_META;
+  ldpp_dout(dpp, 20) << __func__ << ": key=" << this->get_key().to_str() << ", meta:oid=[0x" << std::hex << meta.oid.u_hi
+                                 << ":0x" << meta.oid.u_lo << "], meta:pvid=[0x" << std::hex << meta.pver.f_container
+                                 << ":0x" << meta.pver.f_key << "], meta:layout_id=0x" << std::hex << meta.layout_id << dendl;
   rc = m0_entity_open(&mobj->ob_entity, &op);
   if (rc != 0) {
     ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-	 RGW_ADDB_FUNC_OPEN_MOBJ,
-	 RGW_ADDB_PHASE_ERROR);
+         RGW_ADDB_FUNC_OPEN_MOBJ,
+         RGW_ADDB_PHASE_ERROR);
 
     ldpp_dout(dpp, 0) << __func__ << ": ERROR: m0_entity_open() failed: rc =" << rc << dendl;
     this->close_mobj();
@@ -2408,8 +2411,8 @@ int MotrObject::open_mobj(const DoutPrefixProvider *dpp)
 
   if (rc < 0) {
     ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-	 RGW_ADDB_FUNC_OPEN_MOBJ,
-	 RGW_ADDB_PHASE_ERROR);
+         RGW_ADDB_FUNC_OPEN_MOBJ,
+         RGW_ADDB_PHASE_ERROR);
     ldpp_dout(dpp, 10) << __func__ << ": ERROR: failed to open motr object: rc =" << rc << dendl;
     this->close_mobj();
     return rc;
@@ -3414,19 +3417,23 @@ int MotrAtomicWriter::complete(size_t accounted_size, const std::string& etag,
   }
   RGWBucketInfo &info = obj.get_bucket()->get_info();
 
-  // Set version and current flag in case of both versioning enabled and suspended case.
-  if (info.versioned())
-    ent.flags = rgw_bucket_dir_entry::FLAG_VER | rgw_bucket_dir_entry::FLAG_CURRENT;
-  ldpp_dout(dpp, 20) <<__func__<< ": key=" << obj.get_key().to_str()
-                    << " etag: " << etag << " user_data=" << user_data << dendl;
-  if (user_data)
-    ent.meta.user_data = *user_data;
-
   if (!obj.get_key().have_instance()) {
     // generate-version-id for null version.
     obj.gen_rand_obj_instance_name();
     ent.key.instance = "null";
    }
+
+  // Set version and current flag in case of both versioning enabled and suspended case.
+  if (info.versioned())
+    ent.flags = rgw_bucket_dir_entry::FLAG_VER | rgw_bucket_dir_entry::FLAG_CURRENT;
+
+  ldpp_dout(dpp, 20) << __func__ << ": key=" << obj.get_key().to_str() << ", meta:oid=[0x" << std::hex << obj.meta.oid.u_hi
+                                 << ":0x" << obj.meta.oid.u_lo << "], meta:pvid=[0x" << std::hex << obj.meta.pver.f_container
+                                 << ":0x" << obj.meta.pver.f_key << "], meta:layout_id=0x" << std::hex << obj.meta.layout_id
+                                 << " etag=" << etag << " user_data=" << user_data << dendl;
+  if (user_data)
+    ent.meta.user_data = *user_data;
+
   ent.encode(bl);
 
   if (info.obj_lock_enabled() && info.obj_lock.has_rule()) {
@@ -3442,8 +3449,7 @@ int MotrAtomicWriter::complete(size_t accounted_size, const std::string& etag,
   }
   encode(attrs, bl);
   obj.meta.encode(bl);
-  ldpp_dout(dpp, 20) <<__func__<< ": lid=0x" << std::hex << obj.meta.layout_id
-                                                           << dendl;
+
   // Update existing object version entries in a bucket,
   // in case of both versioning enabled and suspended.
   if (info.versioned()) {
@@ -3847,9 +3853,10 @@ int MotrMultipartUpload::list_parts(const DoutPrefixProvider *dpp, CephContext *
 
     ldpp_dout(dpp, 20) << __func__ << ": part_num=" << info.num
                                              << " part_size=" << info.size << dendl;
-    ldpp_dout(dpp, 20) << __func__ << ": meta:oid=[" << meta.oid.u_hi << "," << meta.oid.u_lo
-                                              << "], meta:pvid=[" << meta.pver.f_container << "," << meta.pver.f_key
-                                              << "], meta:layout id=" << meta.layout_id << dendl;
+    ldpp_dout(dpp, 20) << __func__ << ": key=" << mp_obj.get_key() << ", meta:oid=[0x" << std::hex << meta.oid.u_hi
+                                   << ":0x" << std::hex << meta.oid.u_lo << "], meta:pvid=[0x" << std::hex
+                                   << meta.pver.f_container << ":0x" << std::hex << meta.pver.f_key
+                                   << "], meta:layout_id=0x" << std::hex << meta.layout_id << dendl;
 
     if ((int)info.num > marker) {
       last_num = info.num;
@@ -5219,8 +5226,8 @@ int MotrStore::create_motr_idx_by_name(string iname)
   if (rc != 0) {
     ldout(cctx, 0) << __func__ << ": ERROR: m0_entity_create() failed, rc= " << rc << dendl;
     ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-	 RGW_ADDB_FUNC_CREATE_IDX_BY_NAME,
-	 RGW_ADDB_PHASE_ERROR);
+         RGW_ADDB_FUNC_CREATE_IDX_BY_NAME,
+         RGW_ADDB_PHASE_ERROR);
     goto out;
   }
   ADDB(RGW_ADDB_REQUEST_TO_MOTR_ID, addb_logger.get_id(), m0_sm_id_get(&op->op_sm));
@@ -5233,8 +5240,8 @@ int MotrStore::create_motr_idx_by_name(string iname)
   if (rc != 0 && rc != -EEXIST) {
     ldout(cctx, 0) << __func__ << ": ERROR: index create failed, rc = " << rc << dendl;
     ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-	 RGW_ADDB_FUNC_CREATE_IDX_BY_NAME,
-	 RGW_ADDB_PHASE_ERROR);
+         RGW_ADDB_FUNC_CREATE_IDX_BY_NAME,
+         RGW_ADDB_PHASE_ERROR);
     goto out;
   }
 


### PR DESCRIPTION
## Problem
There is no log that have s3 obj name with motr object details in single log line.

## Solution
Add log corelating s3 object key with motr obj details like oid, fid, lid.

Signed-off-by: saurabh jain <saurabh.jain2@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
