### PR TITLE
rgw_rest_user: [CORTX-32088] Accept `check_on_raw` arg for SetUserQuota

### DIFF
--- a/src/rgw/rgw_rest_user.cc
+++ b/src/rgw/rgw_rest_user.cc
@@ -1055,6 +1055,7 @@ void RGWOp_Quota_Set::execute(optional_yield y)
       if (has_max_size_kb) {
         quota.max_size = max_size_kb * 1024;
       }
+      RESTArgs::get_bool(s, "check-on-raw", old_quota->check_on_raw, &quota.check_on_raw);
       RESTArgs::get_bool(s, "enabled", old_quota->enabled, &quota.enabled);
     }
 


### PR DESCRIPTION
Problem:
The quota check for max_size rounds up the new object size to the nearest 4k and compares it to
the total rounded size of all the objects in the bucket. 
This is why, if the object size is less than 4k and the user/bucket quota is enabled, the quota limit
exceed error is raised and the put operation fails.

Solution:
RGWQuotaInfoRawApplier can be used to compare the raw size of an object with the raw size sum of all the 
objects.
To use this Applier we need to set the `check_on_raw` boolean in the user & bucket quota to `true`.

* check_on_raw is by default false and there is no way to set it true.
* Adding an argument in set-quota API to set the check_on_raw value.
* This will allow the user to validate max_size from quota with the size of objects
  instead of rounded size.

Signed-off-by: Sumedh A. Kulkarni <sumedh.a.kulkarni@seagate.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
