### PR TITLE
rgw: [CORTX-31956] Fix IAM Policy Condition Key `s3:signatureversion`

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -914,6 +914,25 @@ void rgw_build_iam_environment(rgw::sal::Store* store,
   } else {
     s->env.emplace("sts:authentication", "false");
   }
+
+  i = m.find("HTTP_AUTHORIZATION");
+  ldpp_dout(s, 0) << "HTTP_AUTHORIZATION: " << i->second <<dendl;
+  if (i != m.end()) {
+    std::size_t pos = (i->second).find("AWS4-HMAC-SHA256");
+    if (pos != string::npos) {
+      s->env.emplace("s3:signatureversion", "AWS4-HMAC-SHA256");
+      ldpp_dout(s, 20) << "Request signature version: 4" << dendl;
+    }
+    else {
+      pos = (i->second).find("AWS");
+      if (pos != string::npos) {
+        s->env.emplace("s3:signatureversion", "AWS");
+        ldpp_dout(s, 20) << "Request signature version: 2" << dendl;
+      }
+    }
+  } else {
+    ldpp_dout(s, 0) << "Signature version is not specified" << dendl;
+  }
 }
 
 void rgw_bucket_object_pre_exec(struct req_state *s)


### PR DESCRIPTION
Capture signature version from request header and pass it along to policy verification steps to make s3:signatureversion work with IAM policies.

Signed-off-by: Jeet Jain <jeet.jain@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
