### PR TITLE
WIP:rgw_sal_motr.cc: [CORTX-31836] Implement "size_actual" calculation per object

### DIFF
--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -193,6 +193,7 @@ inline std::ostream& operator<<(std::ostream& out, RGWObjCategory c) {
 struct rgw_bucket_dir_entry_meta {
   RGWObjCategory category;
   uint64_t size;
+  uint64_t actual_size;
   ceph::real_time mtime;
   std::string etag;
   std::string owner;
@@ -204,12 +205,13 @@ struct rgw_bucket_dir_entry_meta {
   bool appendable;
 
   rgw_bucket_dir_entry_meta() :
-    category(RGWObjCategory::None), size(0), accounted_size(0), appendable(false) { }
+    category(RGWObjCategory::None), size(0), actual_size(0), accounted_size(0), appendable(false) { }
 
   void encode(ceph::buffer::list &bl) const {
     ENCODE_START(7, 3, bl);
     encode(category, bl);
     encode(size, bl);
+    encode(actual_size, bl);
     encode(mtime, bl);
     encode(etag, bl);
     encode(owner, bl);
@@ -226,6 +228,7 @@ struct rgw_bucket_dir_entry_meta {
     DECODE_START_LEGACY_COMPAT_LEN(6, 3, 3, bl);
     decode(category, bl);
     decode(size, bl);
+    decode(actual_size, bl);
     decode(mtime, bl);
     decode(etag, bl);
     decode(owner, bl);

--- a/src/rgw/rgw_obj_manifest.h
+++ b/src/rgw/rgw_obj_manifest.h
@@ -615,6 +615,7 @@ struct RGWObjState {
   bool has_attrs{false};
   bool exists{false};
   uint64_t size{0}; //< size of raw object
+  uint64_t actual_size{0};
   uint64_t accounted_size{0}; //< size before compression, encryption
   ceph::real_time mtime;
   uint64_t epoch{0};


### PR DESCRIPTION
Problem : Bucket stats count shows 'size' and 'size_actual' as same with Motr as backend.
Solution : Added block size allotted during object creation to size_actual.

Signed-off-by: Diwakar92 <diwakar.kumar@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
