### PR TITLE
rgw_sal_motr: [CORTX-32141] fix possible RMW on writes

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1413,8 +1413,7 @@ uint64_t MotrStore::get_new_req_id()
 
   addb_logger.set_id(req_id);
   ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-       RGW_ADDB_FUNC_GET_NEW_REQ_ID,
-       RGW_ADDB_PHASE_START);
+       RGW_ADDB_FUNC_GET_NEW_REQ_ID, RGW_ADDB_PHASE_START);
   
   return req_id;
 }
@@ -2107,8 +2106,7 @@ int MotrObject::remove_mobj_and_index_entry(
         rc = this->open_mobj(dpp);
         if (rc < 0) {
           ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
-	        RGW_ADDB_FUNC_DELETE_MOBJ,
-	        RGW_ADDB_PHASE_ERROR);
+               RGW_ADDB_FUNC_DELETE_MOBJ, RGW_ADDB_PHASE_ERROR);
           return rc;
         }
       }
@@ -2486,13 +2484,11 @@ int MotrAtomicWriter::prepare(optional_yield y)
 int MotrObject::create_mobj(const DoutPrefixProvider *dpp, uint64_t sz)
 {
   ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-       RGW_ADDB_FUNC_CREATE_MOBJ,
-       RGW_ADDB_PHASE_START);
+       RGW_ADDB_FUNC_CREATE_MOBJ, RGW_ADDB_PHASE_START);
 
   if (mobj != nullptr) {
     ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-	 RGW_ADDB_FUNC_CREATE_MOBJ,
-	 RGW_ADDB_PHASE_ERROR);
+         RGW_ADDB_FUNC_CREATE_MOBJ, RGW_ADDB_PHASE_ERROR);
     ldpp_dout(dpp, 0) <<__func__<< "ERROR: object is already opened" << dendl;
     
     return -EINVAL;
@@ -2501,8 +2497,7 @@ int MotrObject::create_mobj(const DoutPrefixProvider *dpp, uint64_t sz)
   int rc = m0_ufid_next(&ufid_gr, 1, &meta.oid);
   if (rc != 0) {
     ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-	 RGW_ADDB_FUNC_CREATE_MOBJ,
-	 RGW_ADDB_PHASE_ERROR);
+         RGW_ADDB_FUNC_CREATE_MOBJ, RGW_ADDB_PHASE_ERROR);
     ldpp_dout(dpp, 0) <<__func__<< "ERROR: m0_ufid_next() failed: " << rc << dendl;
 
     return rc;
@@ -2527,8 +2522,7 @@ int MotrObject::create_mobj(const DoutPrefixProvider *dpp, uint64_t sz)
   rc = m0_entity_create(nullptr, &mobj->ob_entity, &op);
   if (rc != 0) {
     ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-	 RGW_ADDB_FUNC_CREATE_MOBJ,
-	 RGW_ADDB_PHASE_ERROR);
+         RGW_ADDB_FUNC_CREATE_MOBJ, RGW_ADDB_PHASE_ERROR);
     this->close_mobj();
     ldpp_dout(dpp, 0) << __func__ << ": ERROR: m0_entity_create() failed, rc = " << rc << dendl;
     return rc;
@@ -2544,8 +2538,7 @@ int MotrObject::create_mobj(const DoutPrefixProvider *dpp, uint64_t sz)
 
   if (rc != 0) {
     ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-	 RGW_ADDB_FUNC_CREATE_MOBJ,
-	 RGW_ADDB_PHASE_ERROR);
+         RGW_ADDB_FUNC_CREATE_MOBJ, RGW_ADDB_PHASE_ERROR);
     this->close_mobj();
     ldpp_dout(dpp, 0) << __func__ << ": ERROR: failed to create motr object. rc = " << rc << dendl;
     return rc;
@@ -2559,8 +2552,7 @@ int MotrObject::create_mobj(const DoutPrefixProvider *dpp, uint64_t sz)
                                   << "], meta:layout_id=0x" << std::hex << meta.layout_id << dendl;
 
   ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-       RGW_ADDB_FUNC_CREATE_MOBJ,
-       RGW_ADDB_PHASE_DONE);
+       RGW_ADDB_FUNC_CREATE_MOBJ, RGW_ADDB_PHASE_DONE);
   // TODO: add key:user+bucket+key+obj.meta.oid value:timestamp to
   // gc.queue.index. See more at github.com/Seagate/cortx-rgw/issues/7.
 
@@ -2573,8 +2565,7 @@ int MotrObject::open_mobj(const DoutPrefixProvider *dpp)
                                  << meta.oid.u_hi  << ":0x" << std::hex  << meta.oid.u_lo << "]" << dendl;
 
   ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-       RGW_ADDB_FUNC_OPEN_MOBJ,
-       RGW_ADDB_PHASE_START);
+       RGW_ADDB_FUNC_OPEN_MOBJ, RGW_ADDB_PHASE_START);
 
   int rc;
   if (meta.layout_id == 0) {
@@ -2582,8 +2573,7 @@ int MotrObject::open_mobj(const DoutPrefixProvider *dpp)
     rc = this->get_bucket_dir_ent(dpp, ent);
     if (rc < 0) {
       ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-           RGW_ADDB_FUNC_OPEN_MOBJ,
-           RGW_ADDB_PHASE_ERROR);
+           RGW_ADDB_FUNC_OPEN_MOBJ, RGW_ADDB_PHASE_ERROR);
       ldpp_dout(dpp, 0) << __func__ << ": ERROR: get_bucket_dir_ent failed: rc = " << rc << dendl;
       return rc;
     }
@@ -2591,8 +2581,7 @@ int MotrObject::open_mobj(const DoutPrefixProvider *dpp)
 
   if (meta.layout_id == 0) {
     ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-         RGW_ADDB_FUNC_OPEN_MOBJ,
-         RGW_ADDB_PHASE_DONE);
+         RGW_ADDB_FUNC_OPEN_MOBJ, RGW_ADDB_PHASE_DONE);
     ldpp_dout(dpp, 0) << __func__ << ": ERROR: did not find motr obj details." << dendl;
     return -ENOENT;
   }
@@ -2612,13 +2601,12 @@ int MotrObject::open_mobj(const DoutPrefixProvider *dpp)
   rc = m0_entity_open(&mobj->ob_entity, &op);
   if (rc != 0) {
     ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-         RGW_ADDB_FUNC_OPEN_MOBJ,
-         RGW_ADDB_PHASE_ERROR);
-
+         RGW_ADDB_FUNC_OPEN_MOBJ, RGW_ADDB_PHASE_ERROR);
     ldpp_dout(dpp, 0) << __func__ << ": ERROR: m0_entity_open() failed: rc =" << rc << dendl;
     this->close_mobj();
     return rc;
   }
+
   ADDB(RGW_ADDB_REQUEST_TO_MOTR_ID, addb_logger.get_id(), m0_sm_id_get(&op->op_sm));
   m0_op_launch(&op, 1);
   rc = m0_op_wait(op, M0_BITS(M0_OS_FAILED, M0_OS_STABLE), M0_TIME_NEVER) ?:
@@ -2628,16 +2616,14 @@ int MotrObject::open_mobj(const DoutPrefixProvider *dpp)
 
   if (rc < 0) {
     ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-         RGW_ADDB_FUNC_OPEN_MOBJ,
-         RGW_ADDB_PHASE_ERROR);
+         RGW_ADDB_FUNC_OPEN_MOBJ, RGW_ADDB_PHASE_ERROR);
     ldpp_dout(dpp, 10) << __func__ << ": ERROR: failed to open motr object: rc =" << rc << dendl;
     this->close_mobj();
     return rc;
   }
 
   ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-       RGW_ADDB_FUNC_OPEN_MOBJ,
-       RGW_ADDB_PHASE_DONE);
+       RGW_ADDB_FUNC_OPEN_MOBJ, RGW_ADDB_PHASE_DONE);
   ldpp_dout(dpp, 20) <<__func__<< ": exit. rc =" << rc << dendl;
 
   return 0;
@@ -2650,15 +2636,12 @@ int MotrObject::delete_mobj(const DoutPrefixProvider *dpp)
   snprintf(fid_str, ARRAY_SIZE(fid_str), U128X_F, U128_P(&meta.oid));
 
   ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-       RGW_ADDB_FUNC_DELETE_MOBJ,
-       RGW_ADDB_PHASE_START);
+       RGW_ADDB_FUNC_DELETE_MOBJ, RGW_ADDB_PHASE_START);
 
   if (!meta.oid.u_hi || !meta.oid.u_lo) {
     ldpp_dout(dpp, 20) << __func__ << ": invalid motr object oid=" << fid_str << dendl;
     ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-	 RGW_ADDB_FUNC_DELETE_MOBJ,
-	 RGW_ADDB_PHASE_ERROR);
-
+         RGW_ADDB_FUNC_DELETE_MOBJ, RGW_ADDB_PHASE_ERROR);
     return -EINVAL;
   }
   ldpp_dout(dpp, 20) << __func__ << ": deleting motr object oid=" << fid_str << dendl;
@@ -2668,9 +2651,7 @@ int MotrObject::delete_mobj(const DoutPrefixProvider *dpp)
     rc = this->open_mobj(dpp);
     if (rc < 0) {
       ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-	   RGW_ADDB_FUNC_DELETE_MOBJ,
-	   RGW_ADDB_PHASE_ERROR);
-      
+           RGW_ADDB_FUNC_DELETE_MOBJ, RGW_ADDB_PHASE_ERROR);
       return rc;
     }
   }
@@ -2682,10 +2663,10 @@ int MotrObject::delete_mobj(const DoutPrefixProvider *dpp)
   if (rc != 0) {
     ldpp_dout(dpp, 0) << __func__ << ": ERROR: m0_entity_delete() failed. rc = " << rc << dendl;
     ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-	 RGW_ADDB_FUNC_DELETE_MOBJ,
-	 RGW_ADDB_PHASE_ERROR);
+         RGW_ADDB_FUNC_DELETE_MOBJ, RGW_ADDB_PHASE_ERROR);
     return rc;
   }
+
   ADDB(RGW_ADDB_REQUEST_TO_MOTR_ID, addb_logger.get_id(), m0_sm_id_get(&op->op_sm));
   m0_op_launch(&op, 1);
   rc = m0_op_wait(op, M0_BITS(M0_OS_FAILED, M0_OS_STABLE), M0_TIME_NEVER) ?:
@@ -2696,14 +2677,12 @@ int MotrObject::delete_mobj(const DoutPrefixProvider *dpp)
   if (rc < 0) {
     ldpp_dout(dpp, 0) << __func__ << ": ERROR: failed to open motr object. rc = " << rc << dendl;
     ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-	 RGW_ADDB_FUNC_DELETE_MOBJ,
-	 RGW_ADDB_PHASE_ERROR);
+         RGW_ADDB_FUNC_DELETE_MOBJ, RGW_ADDB_PHASE_ERROR);
     return rc;
   }
 
   ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-       RGW_ADDB_FUNC_DELETE_MOBJ,
-       RGW_ADDB_PHASE_DONE);
+       RGW_ADDB_FUNC_DELETE_MOBJ, RGW_ADDB_PHASE_DONE);
 
   this->close_mobj();
 
@@ -2721,6 +2700,7 @@ void MotrObject::close_mobj()
 int MotrObject::write_mobj(const DoutPrefixProvider *dpp, bufferlist&& in_buffer, uint64_t offset)
 {
   int rc;
+  uint32_t flags = M0_OOF_FULL;
   int64_t bs, left;
   struct m0_op *op;
   char *start, *p;
@@ -2731,14 +2711,12 @@ int MotrObject::write_mobj(const DoutPrefixProvider *dpp, bufferlist&& in_buffer
   bufferlist data = std::move(in_buffer);
 
   ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-       RGW_ADDB_FUNC_WRITE_MOBJ,
-       RGW_ADDB_PHASE_START);
+       RGW_ADDB_FUNC_WRITE_MOBJ, RGW_ADDB_PHASE_START);
 
   left = data.length();
   if (left == 0) {
     ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-	 RGW_ADDB_FUNC_WRITE_MOBJ,
-	 RGW_ADDB_PHASE_DONE);
+         RGW_ADDB_FUNC_WRITE_MOBJ, RGW_ADDB_PHASE_DONE);
     
     return 0;
   }
@@ -2788,10 +2766,10 @@ int MotrObject::write_mobj(const DoutPrefixProvider *dpp, bufferlist&& in_buffer
   if (rc != 0) {
     ldpp_dout(dpp, 0) <<__func__<< ": buffer allocation failed, rc =" << rc << dendl;
     ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-	 RGW_ADDB_FUNC_WRITE_MOBJ,
-	 RGW_ADDB_PHASE_ERROR);
+         RGW_ADDB_FUNC_WRITE_MOBJ, RGW_ADDB_PHASE_ERROR);
     goto out;
   }
+
   ldpp_dout(dpp, 20) <<__func__<< ": left=" << left << " bs=" << bs << dendl;
   if (io_ctxt.accumulated_buffer_list.size() > 0) {
     // We have IO buffers accumulated. Transform it into single buffer.
@@ -2812,7 +2790,7 @@ int MotrObject::write_mobj(const DoutPrefixProvider *dpp, bufferlist&& in_buffer
   for (p = start; left > 0; left -= bs, p += bs, offset += bs) {
     if (left < bs) {
       bs = this->get_optimal_bs(left, true);
-      mobj->ob_entity.en_flags |= M0_ENF_NO_RMW;
+      flags |= M0_OOF_LAST;
     }
     if (left < bs) {
       ldpp_dout(dpp, 20) <<__func__<< " left ="<< left << ",bs=" << bs << ", Padding [" << (bs - left) << "] bytes" << dendl;
@@ -2827,12 +2805,11 @@ int MotrObject::write_mobj(const DoutPrefixProvider *dpp, bufferlist&& in_buffer
 
     ldpp_dout(dpp, 20) <<__func__<< ": write buffer bytes=[" << bs << "], at offset=[" << offset << "]" << dendl;
     op = nullptr;
-    rc = m0_obj_op(this->mobj, M0_OC_WRITE, &ext, &buf, &attr, 0, 0, &op);
+    rc = m0_obj_op(this->mobj, M0_OC_WRITE, &ext, &buf, &attr, 0, flags, &op);
     if (rc != 0) {
       ldpp_dout(dpp, 0) <<__func__<< ": write failed, m0_obj_op rc="<< rc << dendl;
       ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-           RGW_ADDB_FUNC_WRITE_MOBJ,
-           RGW_ADDB_PHASE_ERROR);
+           RGW_ADDB_FUNC_WRITE_MOBJ, RGW_ADDB_PHASE_ERROR);
       goto out;
     }
     ADDB(RGW_ADDB_REQUEST_TO_MOTR_ID, addb_logger.get_id(), m0_sm_id_get(&op->op_sm));
@@ -2844,16 +2821,13 @@ int MotrObject::write_mobj(const DoutPrefixProvider *dpp, bufferlist&& in_buffer
     if (rc != 0) {
       ldpp_dout(dpp, 0) <<__func__<< ": write failed, m0_op_wait rc="<< rc << dendl;
       ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-           RGW_ADDB_FUNC_WRITE_MOBJ,
-           RGW_ADDB_PHASE_ERROR);
+           RGW_ADDB_FUNC_WRITE_MOBJ, RGW_ADDB_PHASE_ERROR);
       goto out;
     }
   }
 
   ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-       RGW_ADDB_FUNC_WRITE_MOBJ,
-       RGW_ADDB_PHASE_DONE);
-
+       RGW_ADDB_FUNC_WRITE_MOBJ, RGW_ADDB_PHASE_DONE);
 out:
   m0_indexvec_free(&ext);
   m0_bufvec_free(&attr);
@@ -2938,6 +2912,7 @@ int MotrObject::read_mobj(const DoutPrefixProvider* dpp, int64_t start, int64_t 
            RGW_ADDB_FUNC_READ_MOBJ, RGW_ADDB_PHASE_ERROR);
       goto out;
     }
+
     ADDB(RGW_ADDB_REQUEST_TO_MOTR_ID, addb_logger.get_id(), m0_sm_id_get(&op->op_sm));
     m0_op_launch(&op, 1);
     rc = m0_op_wait(op, M0_BITS(M0_OS_FAILED, M0_OS_STABLE), M0_TIME_NEVER) ?:
@@ -2969,7 +2944,6 @@ int MotrObject::read_mobj(const DoutPrefixProvider* dpp, int64_t start, int64_t 
 
   ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
        RGW_ADDB_FUNC_READ_MOBJ, RGW_ADDB_PHASE_DONE);
-
 out:
   m0_indexvec_free(&ext);
   m0_bufvec_free(&attr);
@@ -3411,10 +3385,11 @@ unsigned MotrAtomicWriter::populate_bvec(unsigned len, bufferlist::iterator &bi)
   return done;
 }
 
-int MotrAtomicWriter::write()
+int MotrAtomicWriter::write(bool last)
 {
   int rc;
-  int64_t bs, left;
+  uint32_t flags = M0_OOF_FULL;
+  int64_t bs, done, left;
   struct m0_op *op;
   bufferlist::iterator bi;
 
@@ -3440,16 +3415,17 @@ int MotrAtomicWriter::write()
     }
   }
 
-  total_data_size += left;
-
-  bs = obj.get_optimal_bs(left);
+  bs = obj.get_optimal_bs(left, last);
+  ldpp_dout(dpp, 20) <<__func__<< ": left=" << left << " bs=" << bs
+                               << " last=" << last << dendl;
   bi = acc_data.begin();
   while (left > 0) {
     if (left < bs) {
-      bs = obj.get_optimal_bs(left, true);
-      obj.mobj->ob_entity.en_flags |= M0_ENF_NO_RMW;
+      if (!last)
+        break; // accumulate more data
+      bs = obj.get_optimal_bs(left, last);
     }
-    if (left < bs) {
+    if (left < bs) { // align data to unit-size
       ldpp_dout(dpp, 20) <<__func__<< " Padding [" << (bs - left) << "] bytes" << dendl;
       acc_data.append_zero(bs - left);
       auto off = bi.get_off();
@@ -3461,10 +3437,14 @@ int MotrAtomicWriter::write()
       left = bs;
     }
     ldpp_dout(dpp, 20) <<__func__<< ": left=" << left << " bs=" << bs << dendl;
-    left -= this->populate_bvec(bs, bi);
+    done = this->populate_bvec(bs, bi);
+    left -= done;
+
+    if (last)
+      flags |= M0_OOF_LAST;
 
     op = nullptr;
-    rc = m0_obj_op(obj.mobj, M0_OC_WRITE, &ext, &buf, &attr, 0, 0, &op);
+    rc = m0_obj_op(obj.mobj, M0_OC_WRITE, &ext, &buf, &attr, 0, flags, &op);
     if (rc != 0) {
       ldpp_dout(dpp, 0) <<__func__<< ": write failed, m0_obj_op rc="<< rc << dendl;
       ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
@@ -3483,18 +3463,31 @@ int MotrAtomicWriter::write()
       ldpp_dout(dpp, 0) <<__func__<< ": write failed, m0_op_wait rc="<< rc << dendl;
       goto err;
     }
+
+    total_data_size += done;
   }
-  acc_data.clear();
+
+  if (last) {
+    acc_data.clear();
+  } else if (bi.get_remaining() < acc_data.length()) {
+    // Clear from the accumulator what has been written already.
+    // XXX Optimise this, if possible, to avoid copying.
+    ldpp_dout(dpp, 0) <<__func__<< ": cleanup "<< acc_data.length() -
+                                                  bi.get_remaining()
+                                << " bytes from the accumulator" << dendl;
+    bufferlist tmp;
+    bi.copy(bi.get_remaining(), tmp);
+    acc_data.clear();
+    acc_data.append(std::move(tmp));
+  }
 
   ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
        RGW_ADDB_FUNC_WRITE, RGW_ADDB_PHASE_DONE);
-
   return 0;
 
 err:
   ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
        RGW_ADDB_FUNC_WRITE, RGW_ADDB_PHASE_ERROR);
-
   this->cleanup();
   return rc;
 }
@@ -3510,7 +3503,7 @@ int MotrAtomicWriter::process(bufferlist&& data, uint64_t offset)
   if (data.length() == 0) { // last call, flush data
     int rc = 0;
     if (acc_data.length() != 0)
-      rc = this->write();
+      rc = this->write(true);
     this->cleanup();
     return rc;
   }
@@ -3613,7 +3606,7 @@ int MotrAtomicWriter::complete(size_t accounted_size, const std::string& etag,
   addb_logger.set_id(req_id);
 
   if (acc_data.length() != 0) { // check again, just in case
-    rc = this->write();
+    rc = this->write(true);
     this->cleanup();
     if (rc != 0)
       return rc;
@@ -5066,8 +5059,7 @@ int MotrStore::do_idx_op(struct m0_idx *idx, enum m0_idx_opcode opcode,
   struct m0_op *op = nullptr;
 
   ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-       RGW_ADDB_FUNC_DO_IDX_OP,
-       RGW_ADDB_PHASE_START);
+       RGW_ADDB_FUNC_DO_IDX_OP, RGW_ADDB_PHASE_START);
   rc = m0_bufvec_empty_alloc(&k, 1);
   if (rc != 0) {
     ldout(cctx, 0) << __func__ <<": ERROR: failed to allocate key bufvec. rc =" << rc << dendl;
@@ -5083,8 +5075,7 @@ int MotrStore::do_idx_op(struct m0_idx *idx, enum m0_idx_opcode opcode,
       ldout(cctx, 0) << __func__ << ": ERROR: failed to allocate value bufvec, rc = " << rc << dendl;
       rc = -ENOMEM;
       ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-	   RGW_ADDB_FUNC_DO_IDX_OP,
-	   RGW_ADDB_PHASE_ERROR);
+           RGW_ADDB_FUNC_DO_IDX_OP, RGW_ADDB_PHASE_ERROR);
       goto out;
     }
   }
@@ -5103,8 +5094,7 @@ int MotrStore::do_idx_op(struct m0_idx *idx, enum m0_idx_opcode opcode,
   if (rc != 0) {
     ldout(cctx, 0) << __func__ << ": ERROR: failed to init index op: " << rc << dendl;
     ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-	 RGW_ADDB_FUNC_DO_IDX_OP,
-	 RGW_ADDB_PHASE_ERROR);
+         RGW_ADDB_FUNC_DO_IDX_OP, RGW_ADDB_PHASE_ERROR);
     goto out;
   }
 
@@ -5118,8 +5108,7 @@ int MotrStore::do_idx_op(struct m0_idx *idx, enum m0_idx_opcode opcode,
   if (rc != 0) {
     ldout(cctx, 0) << __func__ << ": ERROR: op failed: " << rc << dendl;
     ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-	 RGW_ADDB_FUNC_DO_IDX_OP,
-	 RGW_ADDB_PHASE_ERROR);
+         RGW_ADDB_FUNC_DO_IDX_OP, RGW_ADDB_PHASE_ERROR);
     goto out;
   }
 
@@ -5127,8 +5116,7 @@ int MotrStore::do_idx_op(struct m0_idx *idx, enum m0_idx_opcode opcode,
     ldout(cctx, 0) << __func__ << ": ERROR: idx op failed: " << rc_i << dendl;
     rc = rc_i;
     ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-	 RGW_ADDB_FUNC_DO_IDX_OP,
-	 RGW_ADDB_PHASE_ERROR);
+         RGW_ADDB_FUNC_DO_IDX_OP, RGW_ADDB_PHASE_ERROR);
     goto out;
   }
 
@@ -5138,9 +5126,7 @@ int MotrStore::do_idx_op(struct m0_idx *idx, enum m0_idx_opcode opcode,
   }
 
   ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-       RGW_ADDB_FUNC_DO_IDX_OP,
-       RGW_ADDB_PHASE_DONE);
-
+       RGW_ADDB_FUNC_DO_IDX_OP, RGW_ADDB_PHASE_DONE);
 out:
   m0_bufvec_free2(&k);
   if (opcode == M0_IC_GET)
@@ -5164,16 +5150,14 @@ int MotrStore::do_idx_next_op(struct m0_idx *idx,
   struct m0_op *op = nullptr;
 
   ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-       RGW_ADDB_FUNC_DO_IDX_NEXT_OP,
-       RGW_ADDB_PHASE_START);
+       RGW_ADDB_FUNC_DO_IDX_NEXT_OP, RGW_ADDB_PHASE_START);
 
   rc = m0_bufvec_empty_alloc(&k, nr_kvp)?:
        m0_bufvec_empty_alloc(&v, nr_kvp);
   if (rc != 0) {
     ldout(cctx, 0) << __func__ << ": ERROR: failed to allocate kv bufvecs" << dendl;
     ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-	 RGW_ADDB_FUNC_DO_IDX_NEXT_OP,
-	 RGW_ADDB_PHASE_ERROR);
+         RGW_ADDB_FUNC_DO_IDX_NEXT_OP, RGW_ADDB_PHASE_ERROR);
     return rc;
   }
 
@@ -5183,8 +5167,7 @@ int MotrStore::do_idx_next_op(struct m0_idx *idx,
   if (rc != 0) {
     ldout(cctx, 0) << __func__ << ": ERROR: failed to init index op: " << rc << dendl;
     ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-	 RGW_ADDB_FUNC_DO_IDX_NEXT_OP,
-	 RGW_ADDB_PHASE_ERROR);
+         RGW_ADDB_FUNC_DO_IDX_NEXT_OP, RGW_ADDB_PHASE_ERROR);
     goto out;
   }
 
@@ -5198,8 +5181,7 @@ int MotrStore::do_idx_next_op(struct m0_idx *idx,
   if (rc != 0) {
     ldout(cctx, 0) << __func__ << ": ERROR: op failed: " << rc << dendl;
     ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-	 RGW_ADDB_FUNC_DO_IDX_NEXT_OP,
-	 RGW_ADDB_PHASE_ERROR);
+         RGW_ADDB_FUNC_DO_IDX_NEXT_OP, RGW_ADDB_PHASE_ERROR);
     goto out;
   }
 
@@ -5216,9 +5198,7 @@ int MotrStore::do_idx_next_op(struct m0_idx *idx,
   }
 
   ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-       RGW_ADDB_FUNC_DO_IDX_NEXT_OP,
-       RGW_ADDB_PHASE_DONE);
-
+       RGW_ADDB_FUNC_DO_IDX_NEXT_OP, RGW_ADDB_PHASE_DONE);
 out:
   k.ov_vec.v_nr = i;
   v.ov_vec.v_nr = i;
@@ -5323,8 +5303,7 @@ int MotrStore::delete_motr_idx_by_name(string iname)
   ldout(cctx, 20) << __func__ << ": iname=" << iname << dendl;
 
   ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-       RGW_ADDB_FUNC_DELETE_IDX_BY_NAME,
-       RGW_ADDB_PHASE_START);
+       RGW_ADDB_FUNC_DELETE_IDX_BY_NAME, RGW_ADDB_PHASE_START);
 
   index_name_to_motr_fid(iname, &idx_id);
   m0_idx_init(&idx, &container.co_realm, &idx_id);
@@ -5333,8 +5312,7 @@ int MotrStore::delete_motr_idx_by_name(string iname)
   if (rc < 0) {
     ldout(cctx, 0) << __func__ <<": m0_entity_delete failed, rc = " << rc << dendl;
     ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-	 RGW_ADDB_FUNC_DELETE_IDX_BY_NAME,
-	 RGW_ADDB_PHASE_ERROR);
+         RGW_ADDB_FUNC_DELETE_IDX_BY_NAME, RGW_ADDB_PHASE_ERROR);
     goto out;
   }
 
@@ -5353,17 +5331,14 @@ int MotrStore::delete_motr_idx_by_name(string iname)
   else if (rc < 0) {
     ldout(cctx, 0) << __func__ << ": ERROR: index create failed. rc = " << rc << dendl;
     ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-	 RGW_ADDB_FUNC_DELETE_IDX_BY_NAME,
-	 RGW_ADDB_PHASE_ERROR);
+         RGW_ADDB_FUNC_DELETE_IDX_BY_NAME, RGW_ADDB_PHASE_ERROR);
     goto out;
   }
 
   ldout(cctx, 20) << __func__ << ": delete_motr_idx_by_name rc =" << rc << dendl;
 
   ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-       RGW_ADDB_FUNC_DELETE_IDX_BY_NAME,
-       RGW_ADDB_PHASE_DONE);
-
+       RGW_ADDB_FUNC_DELETE_IDX_BY_NAME, RGW_ADDB_PHASE_DONE);
 out:
   ldout(cctx, 20) << "delete_motr_idx_by_name rc=" << rc << dendl;
   m0_idx_fini(&idx);
@@ -5443,8 +5418,7 @@ int MotrStore::create_motr_idx_by_name(string iname)
   struct m0_uint128 id;
 
   ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-       RGW_ADDB_FUNC_CREATE_IDX_BY_NAME,
-       RGW_ADDB_PHASE_START);
+       RGW_ADDB_FUNC_CREATE_IDX_BY_NAME, RGW_ADDB_PHASE_START);
 
   index_name_to_motr_fid(iname, &id);
   m0_idx_init(&idx, &container.co_realm, &id);
@@ -5455,10 +5429,10 @@ int MotrStore::create_motr_idx_by_name(string iname)
   if (rc != 0) {
     ldout(cctx, 0) << __func__ << ": ERROR: m0_entity_create() failed, rc= " << rc << dendl;
     ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-         RGW_ADDB_FUNC_CREATE_IDX_BY_NAME,
-         RGW_ADDB_PHASE_ERROR);
+         RGW_ADDB_FUNC_CREATE_IDX_BY_NAME, RGW_ADDB_PHASE_ERROR);
     goto out;
   }
+
   ADDB(RGW_ADDB_REQUEST_TO_MOTR_ID, addb_logger.get_id(), m0_sm_id_get(&op->op_sm));
   m0_op_launch(&op, 1);
   rc = m0_op_wait(op, M0_BITS(M0_OS_FAILED, M0_OS_STABLE), M0_TIME_NEVER) ?:
@@ -5469,15 +5443,12 @@ int MotrStore::create_motr_idx_by_name(string iname)
   if (rc != 0 && rc != -EEXIST) {
     ldout(cctx, 0) << __func__ << ": ERROR: index create failed, rc = " << rc << dendl;
     ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-         RGW_ADDB_FUNC_CREATE_IDX_BY_NAME,
-         RGW_ADDB_PHASE_ERROR);
+         RGW_ADDB_FUNC_CREATE_IDX_BY_NAME, RGW_ADDB_PHASE_ERROR);
     goto out;
   }
 
   ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
-       RGW_ADDB_FUNC_CREATE_IDX_BY_NAME,
-       RGW_ADDB_PHASE_DONE);
-
+       RGW_ADDB_FUNC_CREATE_IDX_BY_NAME, RGW_ADDB_PHASE_DONE);
 out:
   m0_idx_fini(&idx);
   return rc;

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -791,7 +791,7 @@ class MotrAtomicWriter : public Writer {
   // Process a bufferlist
   virtual int process(bufferlist&& data, uint64_t offset) override;
 
-  int write();
+  int write(bool last=false);
 
   // complete the operation and make its result visible to clients
   virtual int complete(size_t accounted_size, const std::string& etag,


### PR DESCRIPTION
If the maximum size of accumulation buffer (32M) is not multiple
of object's parity group size, the writing of blocks will happen
with RMW (read modify write), which is not only suboptimal, but
also is not supported by the degraded mode I/O in Motr.

Solution: don't write all the accumulated data on every write()
call, but only when it is the last write() call for the object.
And when it's not the last call, continue accumulation up to the
optimal bs, and write in full bs.

Also, use M0_OOF_LAST flag to avoid RMW on writing the last
non-fully-spanned parity groups.

Note: this PR must be landed after https://github.com/Seagate/cortx-motr/pull/1866.

Closes #289.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
