### PR TITLE
rgw, rgw_sal_motr: [CORTX-31877] Add features to User Stats Calculation

### DIFF
--- a/src/rgw/rgw_multi.h
+++ b/src/rgw/rgw_multi.h
@@ -22,18 +22,20 @@ class RGWMPObj;
 struct RGWUploadPartInfo {
   uint32_t num;
   uint64_t size;
+  uint64_t size_rounded{0};
   uint64_t accounted_size{0};
   std::string etag;
   ceph::real_time modified;
   RGWObjManifest manifest;
   RGWCompressionInfo cs_info;
 
-  RGWUploadPartInfo() : num(0), size(0) {}
+  RGWUploadPartInfo() : num(0), size(0), size_rounded(0) {}
 
   void encode(bufferlist& bl) const {
     ENCODE_START(4, 2, bl);
     encode(num, bl);
     encode(size, bl);
+    encode(size_rounded, bl);
     encode(etag, bl);
     encode(modified, bl);
     encode(manifest, bl);
@@ -45,6 +47,7 @@ struct RGWUploadPartInfo {
     DECODE_START_LEGACY_COMPAT_LEN(4, 2, 2, bl);
     decode(num, bl);
     decode(size, bl);
+    decode(size_rounded, bl);
     decode(etag, bl);
     decode(modified, bl);
     if (struct_v >= 3)

--- a/src/rgw/rgw_obj_manifest.h
+++ b/src/rgw/rgw_obj_manifest.h
@@ -615,6 +615,7 @@ struct RGWObjState {
   bool has_attrs{false};
   bool exists{false};
   uint64_t size{0}; //< size of raw object
+  uint64_t size_rounded{0}; //  total size of disk including padding
   uint64_t accounted_size{0}; //< size before compression, encryption
   ceph::real_time mtime;
   uint64_t epoch{0};

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -701,7 +701,8 @@ class MotrObject : public Object {
     int update_version_entries(const DoutPrefixProvider *dpp, bool set_is_latest=false);
     int overwrite_null_obj(const DoutPrefixProvider *dpp);
     int remove_mobj_and_index_entry(const DoutPrefixProvider* dpp, rgw_bucket_dir_entry& ent,
-                                    std::string delete_key, std::string bucket_index_iname);
+                                    std::string delete_key, std::string bucket_index_iname,
+                                    std::string bucket_name);
     uint64_t get_processed_bytes() { return processed_bytes; }
 };
 

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -692,7 +692,7 @@ class MotrObject : public Object {
     int read_multipart_obj(const DoutPrefixProvider* dpp,
                            int64_t off, int64_t end, RGWGetDataCB* cb,
                            std::map<int, std::unique_ptr<MotrObject>>& part_objs);
-    int delete_part_objs(const DoutPrefixProvider* dpp);
+    int delete_part_objs(const DoutPrefixProvider* dpp, uint64_t* size_rounded);
     void set_category(RGWObjCategory _category) {category = _category;}
     int get_bucket_dir_ent(const DoutPrefixProvider *dpp, rgw_bucket_dir_entry& ent);
     int fetch_null_obj(const DoutPrefixProvider *dpp, bufferlist& bl);
@@ -859,6 +859,7 @@ public:
 
   virtual uint32_t get_num() { return info.num; }
   virtual uint64_t get_size() { return info.accounted_size; }
+  virtual uint64_t get_size_rounded() { return info.size_rounded; }
   virtual const std::string& get_etag() { return info.etag; }
   virtual ceph::real_time& get_mtime() { return info.modified; }
 
@@ -913,7 +914,7 @@ public:
 			  const rgw_placement_rule *ptail_placement_rule,
 			  uint64_t part_num,
 			  const std::string& part_num_str) override;
-  int delete_parts(const DoutPrefixProvider *dpp, std::string version_id="");
+  int delete_parts(const DoutPrefixProvider *dpp, std::string version_id="", uint64_t* size_rounded = nullptr);
 };
 
 class MotrStore : public Store {


### PR DESCRIPTION
Features:
1. Support Stats calculation for multipart objects
2. Correction of Stats counting for object over-write case.
3. Calculation of actual size of a simple object.
4. Calculation of actual size of the multipart object.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
