### PR TITLE
rgw, rgw_sal_motr: [CORTX-31877] Add features to User Stats Calculation

### DIFF
--- a/src/rgw/rgw_multi.h
+++ b/src/rgw/rgw_multi.h
@@ -22,18 +22,20 @@ class RGWMPObj;
 struct RGWUploadPartInfo {
   uint32_t num;
   uint64_t size;
+  uint64_t size_rounded{0};
   uint64_t accounted_size{0};
   std::string etag;
   ceph::real_time modified;
   RGWObjManifest manifest;
   RGWCompressionInfo cs_info;
 
-  RGWUploadPartInfo() : num(0), size(0) {}
+  RGWUploadPartInfo() : num(0), size(0), size_rounded(0) {}
 
   void encode(bufferlist& bl) const {
     ENCODE_START(4, 2, bl);
     encode(num, bl);
     encode(size, bl);
+    encode(size_rounded, bl);
     encode(etag, bl);
     encode(modified, bl);
     encode(manifest, bl);
@@ -45,6 +47,7 @@ struct RGWUploadPartInfo {
     DECODE_START_LEGACY_COMPAT_LEN(4, 2, 2, bl);
     decode(num, bl);
     decode(size, bl);
+    decode(size_rounded, bl);
     decode(etag, bl);
     decode(modified, bl);
     if (struct_v >= 3)

--- a/src/rgw/rgw_obj_manifest.h
+++ b/src/rgw/rgw_obj_manifest.h
@@ -615,6 +615,7 @@ struct RGWObjState {
   bool has_attrs{false};
   bool exists{false};
   uint64_t size{0}; //< size of raw object
+  uint64_t size_rounded{0}; //  total size of disk including padding
   uint64_t accounted_size{0}; //< size before compression, encryption
   ceph::real_time mtime;
   uint64_t epoch{0};

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -176,6 +176,35 @@ inline std::string get_bucket_name(const std::string& tenant,  const std::string
     return bucket;
 }
 
+int static update_bucket_stats(const DoutPrefixProvider *dpp, MotrStore *store,
+                               std::string owner, std::string bucket_name,
+                               uint64_t size, uint64_t actual_size,
+                               uint64_t num_objects = 1, bool add_stats = true) {
+  uint64_t multiplier = add_stats ? 1 : -1;
+  bufferlist bl;
+  std::string user_stats_iname = "motr.rgw.user.stats." + owner;
+  rgw_bucket_dir_header bkt_header;
+  int rc = store->do_idx_op_by_name(user_stats_iname,
+                            M0_IC_GET, bucket_name, bl);
+  if (rc != 0) {
+    ldpp_dout(dpp, 20) << __func__ << ": Failed to get the bucket header."
+      << " bucket = " << bucket_name << ", ret = " << rc << dendl;
+    return rc;
+  }
+
+  bufferlist::const_iterator bitr = bl.begin();
+  bkt_header.decode(bitr);
+  rgw_bucket_category_stats& bkt_stat = bkt_header.stats[RGWObjCategory::Main];
+  bkt_stat.num_entries += multiplier * num_objects;
+  bkt_stat.total_size += multiplier * size;
+  bkt_stat.actual_size += multiplier * actual_size;
+
+  bl.clear();
+  bkt_header.encode(bl);
+  rc = store->do_idx_op_by_name(user_stats_iname, M0_IC_PUT, bucket_name, bl);
+  return rc;
+}
+
 void MotrMetaCache::invalid(const DoutPrefixProvider *dpp,
                            const string& name)
 {
@@ -1022,8 +1051,7 @@ int MotrBucket::read_stats(const DoutPrefixProvider *dpp, int shard_id,
     RGWStorageStats& s = stats[category];
     s.num_objects = bkt_stat.num_entries;
     s.size = bkt_stat.total_size;
-    s.size_rounded = rgw_rounded_kb(s.size) * 1024;
-    s.size_utilized = bkt_stat.actual_size;
+    s.size_rounded = bkt_stat.actual_size;
   }
   return 0;
 }
@@ -1951,7 +1979,8 @@ int MotrObject::MotrDeleteOp::delete_obj(const DoutPrefixProvider* dpp, optional
       ldpp_dout(dpp, 20) <<  __func__ << "delete " << delete_key << " from "
                             << tenant_bkt_name << dendl;
 
-      rc = source->remove_mobj_and_index_entry(dpp, ent, delete_key, bucket_index_iname);
+      rc = source->remove_mobj_and_index_entry(
+          dpp, ent, delete_key, bucket_index_iname, tenant_bkt_name);
       if (rc < 0) {
         ldpp_dout(dpp, 0) << __func__ << ":Failed to delete the object from Motr."
 	                          <<" key = " << delete_key << dendl;
@@ -1978,7 +2007,8 @@ int MotrObject::MotrDeleteOp::delete_obj(const DoutPrefixProvider* dpp, optional
       if (ent.key.instance == "null") {
         result.version_id = "null";
         source->set_instance(ent.key.instance);
-        rc = source->remove_mobj_and_index_entry(dpp, ent, delete_key, bucket_index_iname);
+        rc = source->remove_mobj_and_index_entry(
+            dpp, ent, delete_key, bucket_index_iname, tenant_bkt_name);
         if (rc < 0) {
           ldpp_dout(dpp, 0) << "Failed to delete the object from Motr. key- "<< delete_key << dendl;
           return rc;
@@ -2033,7 +2063,8 @@ int MotrObject::MotrDeleteOp::delete_obj(const DoutPrefixProvider* dpp, optional
     // Unversioned flow
     // handling empty size object case
     ldpp_dout(dpp, 20) << "delete " << delete_key << " from " << tenant_bkt_name << dendl;
-    rc = source->remove_mobj_and_index_entry(dpp, ent, delete_key, bucket_index_iname);
+    rc = source->remove_mobj_and_index_entry(
+        dpp, ent, delete_key, bucket_index_iname, tenant_bkt_name);
     if (rc < 0) {
       ldpp_dout(dpp, 0) << "Failed to delete the object from Motr. key- "<< delete_key << dendl;
       return rc;
@@ -2052,68 +2083,69 @@ int MotrObject::MotrDeleteOp::delete_obj(const DoutPrefixProvider* dpp, optional
       return rc;
     }
   }
-
-  // Subtract the object_size & count from bucket stats entry in user stats index table.
-  bl.clear();
-  std::string user_stats_iname = "motr.rgw.user.stats." +
-                                 params.bucket_owner.get_id().to_str();
-  rgw_bucket_dir_header bkt_header;
-  rc = source->store->do_idx_op_by_name(user_stats_iname,
-                            M0_IC_GET, tenant_bkt_name, bl);
-  if (rc != 0) {
-    ldpp_dout(dpp, 20) << __func__ << ": Failed to get the bucket header."
-      << " bucket = " << tenant_bkt_name << ", ret = " << rc << dendl;
-    return rc;
-  }
-
-  bufferlist::const_iterator bitr = bl.begin();
-  bkt_header.decode(bitr);
-  rgw_bucket_category_stats& bkt_stat = bkt_header.stats[RGWObjCategory::Main];
-  bkt_stat.num_entries--;
-  bkt_stat.total_size -= ent.meta.size;
-  bkt_stat.actual_size -= ent.meta.size;
-
-  bl.clear();
-  bkt_header.encode(bl);
-  rc = source->store->do_idx_op_by_name(user_stats_iname,
-                            M0_IC_PUT, tenant_bkt_name, bl);
-  if (rc != 0) {
-    ldpp_dout(dpp, 20) << __func__ << ": Failed stats substraction for the "
-      << "bucket/obj = " << tenant_bkt_name << "/" << source->get_name()
-      << ", rc = " << rc << dendl;
-    return rc;
-  }
-  ldpp_dout(dpp, 20) << __func__ << ": Stats subtracted successfully for the "
-      << "bucket/obj = " << tenant_bkt_name << "/" << source->get_name()
-      << ", rc = " << rc << dendl;
-
   return 0;
 }
 
-int MotrObject::remove_mobj_and_index_entry(const DoutPrefixProvider* dpp, rgw_bucket_dir_entry& ent,
-                                      std::string delete_key, std::string bucket_index_iname)
-{
+int MotrObject::remove_mobj_and_index_entry(
+    const DoutPrefixProvider* dpp, rgw_bucket_dir_entry& ent,
+    std::string delete_key, std::string bucket_index_iname,
+    std::string bucket_name) {
   int rc;
   bufferlist bl;
+  uint64_t size_rounded = 0;
+
   // handling empty size object case
-  if (ent.meta.size !=0) {
+  if (ent.meta.size != 0) {
     if (ent.meta.category == RGWObjCategory::MultiMeta) {
       this->set_category(RGWObjCategory::MultiMeta);
-      rc = this->delete_part_objs(dpp);
-    } else
+      rc = this->delete_part_objs(dpp, &size_rounded);
+    } else {
+      // Handling Simple Object Deletion
+      // Open the object if not already open.
+      // No need to close mobj as delete_mobj will open it again
+      if (mobj == nullptr) {
+        rc = this->open_mobj(dpp);
+        if (rc < 0) {
+          ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
+	        RGW_ADDB_FUNC_DELETE_MOBJ,
+	        RGW_ADDB_PHASE_ERROR);
+          return rc;
+        }
+      }
+      uint64_t lid = M0_OBJ_LAYOUT_ID(mobj->ob_attr.oa_layout_id);
+      uint64_t unit_sz = m0_obj_layout_id_to_unit_size(lid);
+      size_rounded = roundup(ent.meta.size, unit_sz);
+
       rc = this->delete_mobj(dpp);
+    }
     if (rc < 0) {
       ldpp_dout(dpp, 0) << "Failed to delete the object " << delete_key  <<" from Motr. " << dendl;
       return rc;
     }
   }
   rc = this->store->do_idx_op_by_name(bucket_index_iname,
-                                              M0_IC_DEL, delete_key, bl);
+                                      M0_IC_DEL, delete_key, bl);
   if (rc < 0) {
     ldpp_dout(dpp, 0) << "Failed to delete object's entry " << delete_key 
                                       << " from bucket index. " << dendl;
     return rc;
   }
+
+  // Subtract object size & count from the bucket stats.
+  if (ent.is_delete_marker())
+    return rc;
+  rc = update_bucket_stats(dpp, this->store, ent.meta.owner, bucket_name,
+                           ent.meta.size, size_rounded, 1, false);
+  if (rc != 0) {
+    ldpp_dout(dpp, 20) << __func__ << ": Failed stats substraction for the "
+      << "bucket/obj = " << bucket_name << "/" << delete_key
+      << ", rc = " << rc << dendl;
+    return rc;
+  }
+  ldpp_dout(dpp, 70) << __func__ << ": Stats subtracted successfully for the "
+      << "bucket/obj = " << bucket_name << "/" << delete_key
+      << ", rc = " << rc << dendl;
+
   return rc;
 }
 
@@ -3009,13 +3041,13 @@ int MotrObject::open_part_objs(const DoutPrefixProvider* dpp,
   return 0;
 }
 
-int MotrObject::delete_part_objs(const DoutPrefixProvider* dpp)
-{
+int MotrObject::delete_part_objs(const DoutPrefixProvider* dpp,
+                                 uint64_t* size_rounded) {
   string version_id = this->get_instance();
   std::unique_ptr<rgw::sal::MultipartUpload> upload;
   upload = this->get_bucket()->get_multipart_upload(this->get_name(), string());
   std::unique_ptr<rgw::sal::MotrMultipartUpload> mupload(static_cast<rgw::sal::MotrMultipartUpload *>(upload.release()));
-  return mupload->delete_parts(dpp, version_id);
+  return mupload->delete_parts(dpp, version_id, size_rounded);
 }
 
 int MotrObject::read_multipart_obj(const DoutPrefixProvider* dpp,
@@ -3306,7 +3338,8 @@ int MotrObject::overwrite_null_obj(const DoutPrefixProvider *dpp)
       if (old_ent.meta.category == RGWObjCategory::MultiMeta)
           obj_type = "multipart object";
       ldpp_dout(dpp, 20) <<__func__<< ": Old " << obj_type << " exists" << dendl;
-      rc = this->remove_mobj_and_index_entry(dpp, old_ent, null_obj_key, bucket_index_iname);
+      rc = this->remove_mobj_and_index_entry(
+          dpp, old_ent, null_obj_key, bucket_index_iname, tenant_bkt_name);
       if (rc == 0) {
           ldpp_dout(dpp, 20) <<__func__<< ": Old " << obj_type << " ["
             << this->get_name() <<  "] deleted succesfully" << dendl;
@@ -3356,6 +3389,9 @@ int MotrAtomicWriter::complete(size_t accounted_size, const std::string& etag,
   ent.meta.etag = etag;
   ent.meta.owner = owner.to_str();
   ent.meta.owner_display_name = obj.get_bucket()->get_owner()->get_display_name();
+  uint64_t lid = M0_OBJ_LAYOUT_ID(obj.meta.layout_id);
+  uint64_t unit_sz = m0_obj_layout_id_to_unit_size(lid);
+  uint64_t size_rounded = roundup(ent.meta.size, unit_sz);
   RGWBucketInfo &info = obj.get_bucket()->get_info();
 
   // Set version and current flag in case of both versioning enabled and suspended case.
@@ -3416,7 +3452,7 @@ int MotrAtomicWriter::complete(size_t accounted_size, const std::string& etag,
   // Insert an entry into bucket index.
   string bucket_index_iname = "motr.rgw.bucket.index." + tenant_bkt_name;
 
-  if( !info.versioning_enabled() ) {
+  if (!info.versioning_enabled()) {
     std::unique_ptr<rgw::sal::Object> old_obj = obj.get_bucket()->get_object(rgw_obj_key(obj.get_name()));
     rgw::sal::MotrObject *old_mobj = static_cast<rgw::sal::MotrObject *>(old_obj.get());
     rc = old_mobj->overwrite_null_obj(dpp);
@@ -3441,35 +3477,15 @@ int MotrAtomicWriter::complete(size_t accounted_size, const std::string& etag,
   store->get_obj_meta_cache()->put(dpp, obj.get_key().to_str(), bl);
 
 
-  // update bucket stats in user stats index.
-  std::string user_stats_iname = "motr.rgw.user.stats." + owner.to_str();
-  bl.clear();
-  rgw_bucket_dir_header bkt_header;
-  rc = store->do_idx_op_by_name(user_stats_iname,
-                            M0_IC_GET, tenant_bkt_name, bl);
-  if (rc != 0) {
-    ldpp_dout(dpp, 20) << __func__ << ": Failed to get the bucket header."
-      << " bucket = " << tenant_bkt_name << ", ret = " << rc << dendl;
-    return rc;
-  }
-  
-  bufferlist::const_iterator bitr = bl.begin();
-  bkt_header.decode(bitr);
-  rgw_bucket_category_stats& bkt_stat = bkt_header.stats[RGWObjCategory::Main];
-  bkt_stat.num_entries++;
-  bkt_stat.total_size += total_data_size;
-  bkt_stat.actual_size += total_data_size;
-
-  bl.clear();
-  bkt_header.encode(bl);
-  rc = store->do_idx_op_by_name(user_stats_iname,
-                            M0_IC_PUT, tenant_bkt_name, bl);
+  // Add object size and count in bucket stats entry.
+  rc = update_bucket_stats(dpp, store, owner.to_str(), tenant_bkt_name,
+                           total_data_size, size_rounded);
   if (rc != 0) {
     ldpp_dout(dpp, 20) << __func__ << ": Failed stats additon for the bucket/obj = "
       << tenant_bkt_name << "/" << obj.get_name() << ", rc = " << rc << dendl;
     return rc;
   }
-  ldpp_dout(dpp, 20) << __func__ << ": Stats added successfully for the bucket/obj = "
+  ldpp_dout(dpp, 70) << __func__ << ": Stats added successfully for the bucket/obj = "
     << tenant_bkt_name << "/" << obj.get_name() << ", rc = " << rc << dendl;
 
   // TODO: We need to handle the object leak caused by parallel object upload by
@@ -3477,10 +3493,12 @@ int MotrAtomicWriter::complete(size_t accounted_size, const std::string& etag,
   return rc;
 }
 
-int MotrMultipartUpload::delete_parts(const DoutPrefixProvider *dpp, std::string version_id)
+int MotrMultipartUpload::delete_parts(const DoutPrefixProvider *dpp, std::string version_id, uint64_t* size_rounded)
 {
   int rc;
   int max_parts = 1000;
+  int total_parts_fetched = 0;
+  uint64_t total_size = 0, total_size_rounded = 0;
   int marker = 0;
   bool truncated = false;
 
@@ -3495,11 +3513,14 @@ int MotrMultipartUpload::delete_parts(const DoutPrefixProvider *dpp, std::string
       return rc;
 
     std::map<uint32_t, std::unique_ptr<MultipartPart>>& parts = this->get_parts();
+    total_parts_fetched += parts.size();
     for (auto part_iter = parts.begin(); part_iter != parts.end(); ++part_iter) {
 
       MultipartPart *mpart = part_iter->second.get();
       MotrMultipartPart *mmpart = static_cast<MotrMultipartPart *>(mpart);
       uint32_t part_num = mmpart->get_num();
+      total_size += mmpart->get_size();
+      total_size_rounded += mmpart->get_size_rounded();
 
       // Delete the part object. Note that the part object is  not
       // inserted into bucket index, only the corresponding motr object
@@ -3520,7 +3541,6 @@ int MotrMultipartUpload::delete_parts(const DoutPrefixProvider *dpp, std::string
     }
   } while (truncated);
 
-  // Delete object part index.
   string tenant_bkt_name = get_bucket_name(bucket->get_tenant(), bucket->get_name());
   string upload_id = get_upload_id();
   string key_name;
@@ -3548,7 +3568,26 @@ int MotrMultipartUpload::delete_parts(const DoutPrefixProvider *dpp, std::string
       return rc;
     }
   }
+  if (size_rounded != nullptr)
+    *size_rounded = total_size_rounded;
 
+  if (get_upload_id().length()) {
+    // Subtract size & count of all the parts if multipart is not completed.
+    rc = update_bucket_stats(dpp, store,
+                             bucket->get_owner()->get_id().to_str(), tenant_bkt_name,
+                             total_size, total_size_rounded, total_parts_fetched, false);
+    if (rc != 0) {
+      ldpp_dout(dpp, 20) << __func__ << ": Failed stats substraction for the "
+        << "bucket/obj = " << tenant_bkt_name << "/" << mp_obj.get_key()
+        << ", rc = " << rc << dendl;
+      return rc;
+    }
+    ldpp_dout(dpp, 70) << __func__ << ": Stats subtracted successfully for the "
+        << "bucket/obj = " << tenant_bkt_name << "/" << mp_obj.get_key()
+        << ", rc = " << rc << dendl;
+  }
+
+  // Delete object part index.
   string obj_part_iname = "motr.rgw.object." + tenant_bkt_name + "." + mp_obj.get_key() + 
                           "." + upload_id + ".parts";
   return store->delete_motr_idx_by_name(obj_part_iname);
@@ -4066,6 +4105,21 @@ int MotrMultipartUpload::complete(const DoutPrefixProvider *dpp,
     ldpp_dout(dpp, 0) << __func__ << ": index operation failed, M0_IC_PUT rc = " << rc << dendl;
     return rc;
   }
+  
+  // Increment size & count for new multipart obj in bucket stats entry.
+  std::string bkt_owner = target_obj->get_bucket()->get_owner()->get_id().to_str();
+  rc = update_bucket_stats(dpp, store, bkt_owner, tenant_bkt_name,
+                           0, 0, total_parts - 1, false);
+  if (rc != 0) {
+    ldpp_dout(dpp, 20) << __func__ << ": Failed stats update for the "
+      << "bucket/obj = " << tenant_bkt_name << "/" << target_obj->get_key().to_str()
+      << ", rc = " << rc << dendl;
+    return rc;
+  }
+  ldpp_dout(dpp, 70) << __func__ << ": Updated stats successfully for the "
+      << "bucket/obj = " << tenant_bkt_name << "/" << target_obj->get_key().to_str()
+      << ", rc = " << rc << dendl;
+
   // Put into metadata cache.
   store->get_obj_meta_cache()->put(dpp, target_obj->get_key().to_str(), update_bl);
 
@@ -4203,8 +4257,14 @@ int MotrMultipartWriter::complete(size_t accounted_size, const std::string& etag
   info.num = part_num;
   info.etag = etag;
   info.size = actual_part_size;
+  uint64_t lid = M0_OBJ_LAYOUT_ID(part_obj->meta.layout_id);
+  uint64_t unit_sz = m0_obj_layout_id_to_unit_size(lid);
+  uint64_t size_rounded = roundup(info.size, unit_sz);
+  info.size_rounded = size_rounded;
   info.accounted_size = accounted_size;
   info.modified = real_clock::now();
+  uint64_t old_part_size = 0, old_part_size_rounded = 0;
+  bool old_part_exist = false;
 
   bool compressed;
   int rc = rgw_compression_info_from_attrset(attrs, compressed, info.cs_info);
@@ -4252,6 +4312,9 @@ int MotrMultipartWriter::complete(size_t accounted_size, const std::string& etag
     snprintf(oid_str, ARRAY_SIZE(oid_str), U128X_F, U128_P(&old_part_obj->meta.oid));
     rgw::sal::MotrObject *old_mobj = static_cast<rgw::sal::MotrObject *>(old_part_obj.get());
     ldpp_dout(dpp, 20) << __func__ << ": Old part with oid [" << oid_str << "] exists" << dendl;
+    old_part_size = old_part_info.accounted_size;
+    old_part_size_rounded = old_part_info.size_rounded;
+    old_part_exist = true;
     // Delete old object
     rc = old_mobj->delete_mobj(dpp);
     if (rc == 0) {
@@ -4267,6 +4330,22 @@ int MotrMultipartWriter::complete(size_t accounted_size, const std::string& etag
     ldpp_dout(dpp, 0) << __func__ << ": failed to add part obj in part index, rc = " << rc << dendl;
     return rc == -ENOENT ? -ERR_NO_SUCH_UPLOAD : rc;
   }
+
+   rc = update_bucket_stats(dpp, store,
+                           head_obj->get_bucket()->get_owner()->get_id().to_str(),
+                           tenant_bkt_name,
+                           actual_part_size - old_part_size,
+                           size_rounded - old_part_size_rounded,
+                           1 - old_part_exist);
+  if (rc != 0) {
+    ldpp_dout(dpp, 20) << __func__ << ": Failed stats update for the "
+      << "obj/part = " << head_obj->get_key().to_str() << "/" << part_num
+      << ", rc = " << rc << dendl;
+    return rc;
+  }
+  ldpp_dout(dpp, 70) << __func__ << ": Updated stats successfully for the "
+      << "obj/part = " << head_obj->get_key().to_str() << "/" << part_num
+      << ", rc = " << rc << dendl;
 
   return 0;
 }

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -692,7 +692,7 @@ class MotrObject : public Object {
     int read_multipart_obj(const DoutPrefixProvider* dpp,
                            int64_t off, int64_t end, RGWGetDataCB* cb,
                            std::map<int, std::unique_ptr<MotrObject>>& part_objs);
-    int delete_part_objs(const DoutPrefixProvider* dpp);
+    int delete_part_objs(const DoutPrefixProvider* dpp, uint64_t* size_rounded);
     void set_category(RGWObjCategory _category) {category = _category;}
     int get_bucket_dir_ent(const DoutPrefixProvider *dpp, rgw_bucket_dir_entry& ent);
     int fetch_null_obj(const DoutPrefixProvider *dpp, bufferlist& bl);
@@ -701,7 +701,8 @@ class MotrObject : public Object {
     int update_version_entries(const DoutPrefixProvider *dpp, bool set_is_latest=false);
     int overwrite_null_obj(const DoutPrefixProvider *dpp);
     int remove_mobj_and_index_entry(const DoutPrefixProvider* dpp, rgw_bucket_dir_entry& ent,
-                                    std::string delete_key, std::string bucket_index_iname);
+                                    std::string delete_key, std::string bucket_index_iname,
+                                    std::string bucket_name);
     uint64_t get_processed_bytes() { return processed_bytes; }
 };
 
@@ -858,6 +859,7 @@ public:
 
   virtual uint32_t get_num() { return info.num; }
   virtual uint64_t get_size() { return info.accounted_size; }
+  virtual uint64_t get_size_rounded() { return info.size_rounded; }
   virtual const std::string& get_etag() { return info.etag; }
   virtual ceph::real_time& get_mtime() { return info.modified; }
 
@@ -912,7 +914,7 @@ public:
 			  const rgw_placement_rule *ptail_placement_rule,
 			  uint64_t part_num,
 			  const std::string& part_num_str) override;
-  int delete_parts(const DoutPrefixProvider *dpp, std::string version_id="");
+  int delete_parts(const DoutPrefixProvider *dpp, std::string version_id="", uint64_t* size_rounded = nullptr);
 };
 
 class MotrStore : public Store {


### PR DESCRIPTION
* rgw_sal_motr: [CORTX-31877] Support Stat counting for Multipart & Obj OverWrite case

In multipart upload, each part upload increments the total object size by part size
and count by one. When the complete multipart is called, the object count is reset to
consider all parts as single object.
On abort size of each part is subtracted and the object count is decremented by number
of parts as well.

Object overwrite case is also hanlded with the same PR which decrement the size of old
obj and increment the size of new obj in case of unversioned bucket. Obj count will
remain the same.

* rgw_sal_motr: [CORTX-31877] handle stats on delete marker delete

Delete marker creating does not increment the stats but deletion of
delete marker was causing object count to go down by 1.
Addressed the same by addition of a delete marker check.

Signed-off-by: Sumedh Anantrao Kulkarni <sumedh.a.kulkarni@seagate.com>

* rgw, rgw_sal_motr: [CORTX-31836] calculate actual size for all types of objects (#287)

Size Rounded is the actual size occupied by an object on disk including
padding required as per the unit and block size.
size_rounded parameter is added in bucket_dir_entry as well as in sal motr
object and part related classes to store the calculated size.

Signed-off-by: Sachin Punadikar <sachin.punadikar@seagate.com>
Signed-off-by: Diwakar92 <diwakar.kumar@seagate.com>
Signed-off-by: Sumedh Anantrao Kulkarni <sumedh.a.kulkarni@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
