### PR TITLE
rgw_sal_motr:[CORTX-32120] get-object is failing for invalid  null version-id.

### DIFF
--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -695,8 +695,9 @@ class MotrObject : public Object {
     int delete_part_objs(const DoutPrefixProvider* dpp, uint64_t* size_rounded);
     void set_category(RGWObjCategory _category) {category = _category;}
     int get_bucket_dir_ent(const DoutPrefixProvider *dpp, rgw_bucket_dir_entry& ent);
-    int fetch_null_obj(const DoutPrefixProvider *dpp, bufferlist& bl);
-    int fetch_null_obj_reference(const DoutPrefixProvider *dpp, std::string& prev_null_obj_key);
+    int fetch_null_obj(const DoutPrefixProvider *dpp, bufferlist& bl, bool raise_error=true);
+    int fetch_null_obj_reference(
+      const DoutPrefixProvider *dpp, std::string& prev_null_obj_key, bool raise_error=true);
     int update_null_reference(const DoutPrefixProvider *dpp, rgw_bucket_dir_entry& ent);
     int update_version_entries(const DoutPrefixProvider *dpp, bool set_is_latest=false);
     int overwrite_null_obj(const DoutPrefixProvider *dpp);


### PR DESCRIPTION
Problem Statement:
get-object API is failing for invalid null version-id parameter.

Solution:
Return -2 if key or version-id is not present in the bucket.

Signed-off-by: Shriya Deshmukh <shriya.deshmukh@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
