### PR TITLE
rgw: [CORTX-32034] Fixed same Sid issue in put-user-policy operation

### DIFF
--- a/src/rgw/rgw_iam_policy.cc
+++ b/src/rgw/rgw_iam_policy.cc
@@ -164,6 +164,7 @@ static const actpair actpairs[] =
 
 struct PolicyParser;
 
+static std::unordered_set<std::string> sid_set;
 const Keyword top[1]{"<Top>", TokenKind::pseudo, TokenID::Top, 0, false,
     false};
 const Keyword cond_key[1]{"<Condition Key>", TokenKind::cond_key,
@@ -311,7 +312,7 @@ struct PolicyParser : public BaseReaderHandler<UTF8<>, PolicyParser> {
   }
 
   PolicyParser(CephContext* cct, const string& tenant, Policy& policy)
-    : cct(cct), tenant(tenant), policy(policy) {}
+    : cct(cct), tenant(tenant), policy(policy) {sid_set.clear();}
   PolicyParser(const PolicyParser& policy) = delete;
 
   bool StartObject() {
@@ -512,6 +513,11 @@ bool ParseState::do_string(CephContext* cct, const char* s, size_t l) {
     // Statement
 
   } else if (w->id == TokenID::Sid) {
+    std::string sid(s, l);
+    if (sid_set.find(sid) != sid_set.end()) {
+      return false;
+    }
+    sid_set.insert(sid);
     t->sid.emplace(s, l);
   } else if ((w->id == TokenID::Effect) && k &&
 	     k->kind == TokenKind::effect_key) {


### PR DESCRIPTION
**Problem** : Same SID's allowed in put-user-policy operation

**Root Cause**: There is no check for detecting same SIDs in a policy document

**Solution** : Introduced a new set sid_set and adding each sid to it.
                       If sid is already present, we are throwing error "MalformedPolicyDocument"

Signed-off-by: Sanal Kaarthikeyan 


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
