### PR TITLE
rgw_sal_motr:[CORTX-32208] Incorrect NextKeyMarker and NextVersionIdMarker present  in truncated ListObjectVersions responses

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1289,7 +1289,7 @@ int MotrBucket::list(const DoutPrefixProvider *dpp, ListParams& params, int max,
         auto iter = vals[i].cbegin();
         ent.decode(iter);
         std::string null_ref_key = ent.key.name + NULL_REF;
-        if(keys[i] == null_ref_key){
+        if (keys[i] == null_ref_key) {
           ldpp_dout(dpp, 70) << __func__ << ": skipping key "<<keys[i]<<dendl;
             continue;
         }
@@ -1300,7 +1300,13 @@ int MotrBucket::list(const DoutPrefixProvider *dpp, ListParams& params, int max,
           }
           if (keycount == max) {
             // One extra key is successfully fetched.
-            results.next_marker = keys[i-1];
+            rgw_bucket_dir_entry next_ent;
+            auto iter = vals[i-1].cbegin();
+            next_ent.decode(iter);
+            // e.g. - keys[i-1] : object1[version-id]
+            // here, marker_name : object1 & marker_instance: version-id
+            results.next_marker.name = next_ent.key.name;
+            results.next_marker.instance = next_ent.key.instance;
             results.is_truncated = true;
             ldpp_dout(dpp, 20) << __func__ << ": adding key "<<keys[i-1]<<" to next_marker"<<dendl;
             break;


### PR DESCRIPTION
Problem statement:
Incorrect NextKeyMarker and NextVersionIdMarker present  in truncated ListObjectVersions responses.

Solution:
Parse the index-key(obj[version-id]) and asssign key_name(obj) to NextKeyMarker
and instance(version-id) to NextVersionIdMarker.

Signed-off-by: Shriya Deshmukh <shriya.deshmukh@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
