### PR TITLE
rgw_sal_motr: [CORTX-32291] fix crash on reading mpart obj

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -2885,6 +2885,7 @@ int MotrObject::read_mobj(const DoutPrefixProvider* dpp, int64_t start, int64_t 
     if ((size_t)off + bs >= obj_size) {
       bs = roundup(obj_size - off, get_unit_sz());
       flags |= M0_OOF_LAST;
+      ldpp_dout(dpp, 20) <<__func__<< ": off=" << off << " bs=" << bs << " obj_size=" << obj_size << dendl;
     } else if (left < bs) {
       // Somewhere in the middle of the object.
       bs = this->get_optimal_bs(left, true); // multiple of units
@@ -3241,6 +3242,7 @@ int MotrObject::get_part_objs(const DoutPrefixProvider* dpp,
       ldpp_dout(dpp, 20) << __func__ << ": off = " << off << ", size = " << part_size << dendl;
       mobj->part_off = off;
       mobj->part_size = part_size;
+      mobj->set_obj_size(part_size);
       mobj->part_num = part_num;
       mobj->meta = mmpart->meta;
 


### PR DESCRIPTION
This is a regression introduced at commit 4fd026b0139: the
size of motr object part (obj_size) is not set and, as result,
bs becomes zero at read_mobj() here:

    // At the last parity group we must read up to the last
    // object's unit and provide the M0_OOF_LAST flag, so
    // that in case of degraded read mode, libmotr could
    // know which units to use for the data recovery.
    if ((size_t)off + bs >= obj_size) {
      bs = roundup(obj_size - off, get_unit_sz());
      flags |= M0_OOF_LAST;

Which eventually leads to crash at bl.append_hole(bs).

Solution: initialise part obj_size at get_part_objs().


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
