### PR TITLE
rgw_sal_motr: [CORTX-32310] fix obj size on put

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -2935,10 +2935,11 @@ int MotrObject::read_mobj(const DoutPrefixProvider* dpp, int64_t start, int64_t 
     if (start > off)
       skip = start - off;
     if(cb){
-      ldpp_dout(dpp, 20) << __func__  << " call cb to process data" << dendl;
+      ldpp_dout(dpp, 20) <<__func__<< ": return data, skip=" << skip
+                         << " bs=" << bs << " left=" << left << dendl;
       cb->handle_data(bl, skip, (left < bs ? left : bs) - skip);
       if (rc != 0){
-        ldpp_dout(dpp, 0) << __func__ << " handle_data failed rc =" << rc << dendl;
+        ldpp_dout(dpp, 0) <<__func__<< ": handle_data failed rc=" << rc << dendl;
         goto out;
       }
     }
@@ -3439,11 +3440,9 @@ int MotrAtomicWriter::write(bool last)
       acc_data.clear();
       acc_data.append(tmp.c_str(), bs); // make it a single buf
       bi = acc_data.begin();
-      left = bs;
     }
     ldpp_dout(dpp, 20) <<__func__<< ": left=" << left << " bs=" << bs << dendl;
     done = this->populate_bvec(bs, bi);
-    left -= done;
 
     if (last)
       flags |= M0_OOF_LAST;
@@ -3469,7 +3468,8 @@ int MotrAtomicWriter::write(bool last)
       goto err;
     }
 
-    total_data_size += done;
+    total_data_size += left < done ? left : done;
+    left            -= left < done ? left : done;
   }
 
   if (last) {


### PR DESCRIPTION
The regression was introduced at commit 0ed9f66eaeb, after
which the object size recorded in its metadata on put-object
operation is always aligned to the unit size. So if the real
object size is not aligned to its unit size, the recorded
size will be wrong. (So the amount of data on get-object
operation also will be wrong.)

Solution: fix the code at MotrAtomicWriter::write() to
record the real object size in its metadata record.







<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
