### PR TITLE
rgw_sal_motr: [CORTX-32135] Fix for mismatch in response for `List Objects` with delimiter

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -5259,7 +5259,7 @@ int MotrStore::next_query_by_name(string idx_name,
       if (!delim.empty())
         pos = key.find(delim, prefix.length());
       if (pos != std::string::npos) { // DIR entry
-        dir.assign(key, 0, pos + 1);
+        dir.assign(key, 0, pos + delim.length());
         if (dir.compare(0, prefix.length(), prefix) != 0)
           goto out;
         if (i + k == 0 || dir != key_out[i + k - 1]) // a new one


### PR DESCRIPTION
Values in `CommonPrefixes` were restricted to one character after delimiter, updated length from one to delimiter's length to match values of `CommonPrefixes` as per AWS specifications

Signed-off-by: Jeet Jain <jeet.jain@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->


## Tests
### Before Fix
```
$ aws s3api list-objects --bucket test-bucket-932492 --delimiter "education" --endpoint-url http://127.0.0.1:8000 --profile mgwuser 
{
    "Contents": [
        {
            "Key": "german/personal/11mfile",
            "LastModified": "2022-06-16T09:18:04.662Z",
            "ETag": "\"c8d4d0fa8e22369f05c6013405dddd1f\"",
            "Size": 5242880,
            "StorageClass": "STANDARD",
            "Owner": {
                "DisplayName": "mgwuser",
                "ID": "mgwuser"
            }
        },
        {
            "Key": "lipsa/personal/11mfile",
            "LastModified": "2022-06-16T09:18:24.851Z",
            "ETag": "\"c8d4d0fa8e22369f05c6013405dddd1f\"",
            "Size": 5242880,
            "StorageClass": "STANDARD",
            "Owner": {
                "DisplayName": "mgwuser",
                "ID": "mgwuser"
            }
        }
    ],
    "CommonPrefixes": [
        {
            "Prefix": "german/e"
        },
        {
            "Prefix": "lipsa/e"
        }
    ]
}
```
### After Fix
```
$ aws s3api list-objects --bucket test-bucket-932492 --delimiter "education" --endpoint-url http://127.0.0.1:8000 --profile mgwuser 
{
    "Contents": [
        {
            "Key": "german/personal/11mfile",
            "LastModified": "2022-06-16T09:18:04.662Z",
            "ETag": "\"c8d4d0fa8e22369f05c6013405dddd1f\"",
            "Size": 5242880,
            "StorageClass": "STANDARD",
            "Owner": {
                "DisplayName": "mgwuser",
                "ID": "mgwuser"
            }
        },
        {
            "Key": "lipsa/personal/11mfile",
            "LastModified": "2022-06-16T09:18:24.851Z",
            "ETag": "\"c8d4d0fa8e22369f05c6013405dddd1f\"",
            "Size": 5242880,
            "StorageClass": "STANDARD",
            "Owner": {
                "DisplayName": "mgwuser",
                "ID": "mgwuser"
            }
        }
    ],
    "CommonPrefixes": [
        {
            "Prefix": "german/education"
        },
        {
            "Prefix": "lipsa/education"
        }
    ]
}
```
<hr>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests
 
<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
