### PR TITLE
rgw_sal_motr: [CORTX-32326] fix redundant mdata i/o

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -190,8 +190,8 @@ int static update_bucket_stats(const DoutPrefixProvider *dpp, MotrStore *store,
   int rc = store->do_idx_op_by_name(user_stats_iname,
                             M0_IC_GET, bucket_name, bl);
   if (rc != 0) {
-    ldpp_dout(dpp, 20) << __func__ << ": Failed to get the bucket header."
-      << " bucket = " << bucket_name << ", ret = " << rc << dendl;
+    ldpp_dout(dpp, 20) <<__func__<< ": Failed to get the bucket header."
+      << " bucket=" << bucket_name << ", ret=" << rc << dendl;
     return rc;
   }
 
@@ -218,7 +218,7 @@ int MotrMetaCache::put(const DoutPrefixProvider *dpp,
                        const string& name,
                        const bufferlist& data)
 {
-  ldpp_dout(dpp, 0) << "Put into cache: name = " << name << dendl;
+  ldpp_dout(dpp, 0) << "Put into cache: name=" << name << dendl;
 
   ObjectCacheInfo info;
   info.status = 0;
@@ -231,7 +231,7 @@ int MotrMetaCache::put(const DoutPrefixProvider *dpp,
   // Inform other rgw instances. Do nothing if it gets some error?
   int rc = distribute_cache(dpp, name, info, UPDATE_OBJ);
   if (rc < 0)
-      ldpp_dout(dpp, 0) << __func__ <<": ERROR: failed to distribute cache for " << name << dendl;
+      ldpp_dout(dpp, 0) <<__func__<<": ERROR: failed to distribute cache for " << name << dendl;
 
   return 0;
 }
@@ -252,11 +252,11 @@ int MotrMetaCache::get(const DoutPrefixProvider *dpp,
     data.clear();
 
     it.copy_all(data);
-    ldpp_dout(dpp, 0) << "Cache hit: name = " << name << dendl;
+    ldpp_dout(dpp, 0) << "Cache hit: name=" << name << dendl;
     return 0;
   }
-  ldpp_dout(dpp, 0) << "Cache miss: name = " << name << ", rc = "<< rc << dendl;
-  if(rc == -ENODATA)
+  ldpp_dout(dpp, 0) << "Cache miss: name=" << name << ", rc="<< rc << dendl;
+  if (rc == -ENODATA)
     return -ENOENT;
 
   return rc;
@@ -271,10 +271,10 @@ int MotrMetaCache::remove(const DoutPrefixProvider *dpp,
   ObjectCacheInfo info;
   int rc = distribute_cache(dpp, name, info, INVALIDATE_OBJ);
   if (rc < 0) {
-    ldpp_dout(dpp, 0) << "ERROR: " <<__func__<< ": failed to distribute cache: rc = " << rc << dendl;
+    ldpp_dout(dpp, 0) << "ERROR: " <<__func__<< ": failed to distribute cache: rc=" << rc << dendl;
   }
 
-  ldpp_dout(dpp, 0) << "Remove from cache: name = " << name << dendl;
+  ldpp_dout(dpp, 0) << "Remove from cache: name=" << name << dendl;
   return 0;
 }
 
@@ -311,7 +311,7 @@ int MotrUser::list_buckets(const DoutPrefixProvider *dpp, const string& marker,
   vector<bufferlist> vals(max);
   bool is_truncated = false;
 
-  ldpp_dout(dpp, 20) << __func__ << ": list_user_buckets: marker=" << marker
+  ldpp_dout(dpp, 20) <<__func__<< ": list_user_buckets: marker=" << marker
                     << " end_marker=" << end_marker
                     << " max=" << max << dendl;
 
@@ -321,10 +321,10 @@ int MotrUser::list_buckets(const DoutPrefixProvider *dpp, const string& marker,
   keys[0] = marker;
   rc = store->next_query_by_name(user_info_iname, keys, vals);
   if (rc < 0) {
-    ldpp_dout(dpp, 0) <<  __func__ << ": ERROR: NEXT query failed. " << rc << dendl;
+    ldpp_dout(dpp, 0) << __func__<< ": ERROR: NEXT query failed." << rc << dendl;
     return rc;
   } else if (rc == 0) {
-    ldpp_dout(dpp, 0) <<  __func__ << ": No buckets to list. " << rc << dendl;
+    ldpp_dout(dpp, 0) << __func__<< ": No buckets to list." << rc << dendl;
     return rc;
   }
 
@@ -419,20 +419,20 @@ int MotrUser::create_bucket(const DoutPrefixProvider* dpp,
     // Create a new bucket: (1) Add a key/value pair in the
     // bucket instance index. (2) Create a new bucket index.
     MotrBucket* mbucket = static_cast<MotrBucket*>(bucket.get());
-    // "put_info" accepts boolean value mentioning whether to create new or update existing. 
+    // "put_info" accepts boolean value mentioning whether to create new or update existing.
     // "yield" is not a boolean flag hence explicitly passing true to create a new record.
     ret = mbucket->put_info(dpp, true, ceph::real_time())? :
           mbucket->create_bucket_index() ? :
           mbucket->create_multipart_indices();
     if (ret < 0) {
-      ldpp_dout(dpp, 0) << __func__ << ": ERROR: failed to create bucket indices! " << ret << dendl;
+      ldpp_dout(dpp, 0) <<__func__<< ": ERROR: failed to create bucket indices!" << ret << dendl;
       return ret;
     }
 
     // Insert the bucket entry into the user info index.
     ret = mbucket->link_user(dpp, this, y);
     if (ret < 0) {
-      ldpp_dout(dpp, 0) << __func__ << ": ERROR: failed to add bucket entry! " << ret << dendl;
+      ldpp_dout(dpp, 0) <<__func__<< ": ERROR: failed to add bucket entry!" << ret << dendl;
       return ret;
     }
 
@@ -446,13 +446,13 @@ int MotrUser::create_bucket(const DoutPrefixProvider* dpp,
                               M0_IC_PUT, bkt_name, blst);
 
     if (ret != 0) {
-      ldpp_dout(dpp, 20) << __func__ << ": Failed to add the stats entry "
-        << "for the bucket = " << bkt_name << ", ret = " << ret << dendl;
+      ldpp_dout(dpp, 20) <<__func__<< ": Failed to add the stats entry "
+        << "for the bucket=" << bkt_name << ", ret=" << ret << dendl;
       return ret;
     }
-    
-    ldpp_dout(dpp, 20) << __func__ << ": Added an empty stats entry for "
-        << "the bucket = " << bkt_name << ", ret = " << ret << dendl; 
+
+    ldpp_dout(dpp, 20) <<__func__<< ": Added an empty stats entry for "
+        << "the bucket=" << bkt_name << ", ret=" << ret << dendl;
   } else {
     return -EEXIST;
     // bucket->set_version(ep_objv);
@@ -469,14 +469,14 @@ int MotrUser::read_attrs(const DoutPrefixProvider* dpp, optional_yield y)
   int rc = 0;
   if (not attrs.empty())
     return rc;
-  
+
   struct MotrUserInfo muinfo;
   bufferlist bl;
   if (store->get_user_cache()->get(dpp, info.user_id.to_str(), bl)) {
     // Cache miss
     rc = store->do_idx_op_by_name(RGW_MOTR_USERS_IDX_NAME,
                                       M0_IC_GET, info.user_id.to_str(), bl);
-    ldpp_dout(dpp, 20) << __func__ << ": do_idx_op_by_name, rc = "  << rc << dendl;
+    ldpp_dout(dpp, 20) <<__func__<< ": do_idx_op_by_name, rc=" << rc << dendl;
     if (rc < 0)
         return rc;
     // Put into cache.
@@ -486,7 +486,7 @@ int MotrUser::read_attrs(const DoutPrefixProvider* dpp, optional_yield y)
   auto iter = blr.cbegin();
   muinfo.decode(iter);
   attrs = muinfo.attrs;
-  ldpp_dout(dpp, 20) << __func__ << ": user attributes fetched successfully." << dendl;
+  ldpp_dout(dpp, 20) <<__func__<< ": user attributes fetched successfully." << dendl;
 
   return rc;
 }
@@ -505,11 +505,11 @@ int MotrUser::read_stats(const DoutPrefixProvider *dpp,
   do {
     rc = store->next_query_by_name(user_stats_iname, keys, vals);
     if (rc < 0) {
-      ldpp_dout(dpp, 20) << __func__ << ": failed to get the user stats info for user  = "
+      ldpp_dout(dpp, 20) <<__func__<< ": failed to get the user stats info for user  = "
                         << info.user_id.to_str() << dendl;
       return rc;
     } else if (rc == 0) {
-      ldpp_dout(dpp, 20) << __func__ << ": No bucket to fetch the stats." << dendl;
+      ldpp_dout(dpp, 20) <<__func__<< ": No bucket to fetch the stats." << dendl;
       return rc;
     }
     num_of_entries = rc;
@@ -561,12 +561,12 @@ int MotrUser::load_user_from_idx(const DoutPrefixProvider *dpp,
 {
   struct MotrUserInfo muinfo;
   bufferlist bl;
-  ldpp_dout(dpp, 20) << __func__ << ": info.user_id.id = "  << info.user_id.id << dendl;
+  ldpp_dout(dpp, 20) <<__func__<< ": info.user_id.id=" << info.user_id.id << dendl;
   if (store->get_user_cache()->get(dpp, info.user_id.to_str(), bl)) {
     // Cache misses
     int rc = store->do_idx_op_by_name(RGW_MOTR_USERS_IDX_NAME,
                                       M0_IC_GET, info.user_id.to_str(), bl);
-    ldpp_dout(dpp, 20) << __func__ << ": do_idx_op_by_name(), rc = "  << rc << dendl;
+    ldpp_dout(dpp, 20) <<__func__<< ": do_idx_op_by_name(), rc=" << rc << dendl;
     if (rc < 0)
         return rc;
 
@@ -631,13 +631,13 @@ int MotrUser::store_user(const DoutPrefixProvider* dpp,
   RGWObjVersionTracker objv_tr = {};
   obj_version& obj_ver = objv_tr.read_version;
 
-  ldpp_dout(dpp, 20) << __func__ << ": User = " << info.user_id.id << dendl;
+  ldpp_dout(dpp, 20) <<__func__<< ": User=" << info.user_id.id << dendl;
   orig_info.user_id = info.user_id;
   // XXX: we open and close motr idx 2 times in this method:
   // 1) on load_user_from_idx() here and 2) on do_idx_op_by_name(PUT) below.
   // Maybe this can be optimised later somewhow.
   int rc = load_user_from_idx(dpp, store, orig_info, nullptr, &objv_tr);
-  ldpp_dout(dpp, 10) << __func__ << ": load_user_from_idx, rc = " << rc << dendl;
+  ldpp_dout(dpp, 10) <<__func__<< ": load_user_from_idx, rc=" << rc << dendl;
 
   // Check if the user already exists
   if (rc == 0 && obj_ver.ver > 0) {
@@ -666,12 +666,12 @@ int MotrUser::store_user(const DoutPrefixProvider* dpp,
   muinfo.encode(bl);
   rc = store->do_idx_op_by_name(RGW_MOTR_USERS_IDX_NAME,
                                 M0_IC_PUT, info.user_id.to_str(), bl);
-  ldpp_dout(dpp, 10) << __func__ << ": store user to motr index: rc = " << rc << dendl;
+  ldpp_dout(dpp, 10) <<__func__<< ": store user to motr index: rc=" << rc << dendl;
   if (rc == 0) {
     objv_tracker.read_version = obj_ver;
     objv_tracker.write_version = obj_ver;
   }
-  
+
   // Store access key in access key index
   if (!info.access_keys.empty()) {
     std::string access_key;
@@ -691,7 +691,7 @@ int MotrUser::store_user(const DoutPrefixProvider* dpp,
     for (auto key : access_key_tracker) {
       if (!info.get_key(key)) {
         key_for_deletion = key;
-        ldpp_dout(dpp, 0) << __func__ << ": deleting access key: " << key_for_deletion << dendl;
+        ldpp_dout(dpp, 0) <<__func__<< ": deleting access key: " << key_for_deletion << dendl;
         store->delete_access_key(dpp, y, key_for_deletion);
         if (rc < 0) {
           ldpp_dout(dpp, 0) << __func__ << ": unable to delete access key" << rc << dendl;
@@ -712,7 +712,7 @@ int MotrUser::store_user(const DoutPrefixProvider* dpp,
   // to this bucket.
   rc = create_user_info_idx();
   if (rc < 0 && rc != -EEXIST) {
-    ldpp_dout(dpp, 0) << __func__ << ": failed to create user info index: rc = " << rc << dendl;
+    ldpp_dout(dpp, 0) <<__func__<< ": failed to create user info index: rc=" << rc << dendl;
     goto out;
   }
 
@@ -721,7 +721,7 @@ int MotrUser::store_user(const DoutPrefixProvider* dpp,
   rc = create_user_stats_idx();
   if (rc < 0 && rc != -EEXIST) {
     ldpp_dout(dpp, 0) << __func__
-      << "Failed to create user stats index: rc = " << rc << dendl;
+      << "Failed to create user stats index: rc=" << rc << dendl;
     goto out;
   }
 
@@ -749,7 +749,7 @@ int MotrUser::remove_user(const DoutPrefixProvider* dpp, optional_yield y)
     for(auto acc_key = info.access_keys.begin(); acc_key != info.access_keys.end(); acc_key++) {
       auto access_key = acc_key->first;
       rc = store->delete_access_key(dpp, y, access_key);
-      // TODO 
+      // TODO
       // Check error code for access_key does not exist
       // Continue to next step only if delete failed because key doesn't exists
       if (rc < 0){
@@ -758,19 +758,19 @@ int MotrUser::remove_user(const DoutPrefixProvider* dpp, optional_yield y)
     }
   }
 
-  //Delete email id 
+  //Delete email id
   if (!info.user_email.empty()) {
     rc = store->do_idx_op_by_name(RGW_IAM_MOTR_EMAIL_KEY,
 		             M0_IC_DEL, info.user_email, bl);
     if (rc < 0 && rc != -ENOENT) {
-       ldpp_dout(dpp, 0) << __func__ << ": unable to delete email id " << rc << dendl;
+       ldpp_dout(dpp, 0) <<__func__<< ": unable to delete email id " << rc << dendl;
     }
   }
-  
+
   // Delete user info index
   string user_info_iname = "motr.rgw.user.info." + info.user_id.to_str();
   store->delete_motr_idx_by_name(user_info_iname);
-  ldpp_dout(dpp, 10) << __func__ << ": deleted user info index - " << user_info_iname << dendl;
+  ldpp_dout(dpp, 10) <<__func__<< ": deleted user info index - " << user_info_iname << dendl;
 
   // Delete user stats index
   string user_stats_iname = "motr.rgw.user.stats." + info.user_id.to_str();
@@ -781,11 +781,11 @@ int MotrUser::remove_user(const DoutPrefixProvider* dpp, optional_yield y)
   rc = store->do_idx_op_by_name(RGW_MOTR_USERS_IDX_NAME,
                            M0_IC_DEL, info.user_id.to_str(), bl);
   if (rc < 0){
-    ldpp_dout(dpp, 0) << __func__ << ": unable to delete user from user index " << rc << dendl;
+    ldpp_dout(dpp, 0) <<__func__<< ": unable to delete user from user index " << rc << dendl;
     return rc;
   }
 
-  // TODO 
+  // TODO
   // Delete email for user
   // rc = store->do_idx_op_by_name(RGW_IAM_MOTR_EMAIL_KEY,
   //                          M0_IC_DEL, info.user_email, bl);
@@ -801,12 +801,12 @@ int MotrBucket::remove_bucket(const DoutPrefixProvider *dpp, bool delete_childre
 {
   int ret;
   string tenant_bkt_name = get_bucket_name(info.bucket.tenant, info.bucket.name);
-  ldpp_dout(dpp, 20) << __func__ << ": entry =" << tenant_bkt_name << dendl;
+  ldpp_dout(dpp, 20) <<__func__<< ": entry=" << tenant_bkt_name << dendl;
 
   // Refresh info
   ret = load_bucket(dpp, y);
   if (ret < 0) {
-    ldpp_dout(dpp, 0) <<  __func__ << ": ERROR: load_bucket failed rc = " << ret << dendl;
+    ldpp_dout(dpp, 0) << __func__<< ": ERROR: load_bucket failed rc=" << ret << dendl;
     return ret;
   }
 
@@ -830,7 +830,7 @@ int MotrBucket::remove_bucket(const DoutPrefixProvider *dpp, bool delete_childre
 
     // If result contains entries, bucket is not empty.
     if (!results.objs.empty() && !delete_children) {
-      ldpp_dout(dpp, 0) << __func__ << ": ERROR: could not remove non-empty bucket " << info.bucket.name << dendl;
+      ldpp_dout(dpp, 0) <<__func__<< ": ERROR: could not remove non-empty bucket " << info.bucket.name << dendl;
       return -ENOTEMPTY;
     }
 
@@ -839,7 +839,7 @@ int MotrBucket::remove_bucket(const DoutPrefixProvider *dpp, bool delete_childre
       /* xxx dang */
       ret = rgw_remove_object(dpp, store, this, key);
       if (ret < 0 && ret != -ENOENT) {
-        ldpp_dout(dpp, 0) << __func__ << ": ERROR: rgw_remove_object failed rc = " << ret << dendl;
+        ldpp_dout(dpp, 0) <<__func__<< ": ERROR: rgw_remove_object failed rc=" << ret << dendl;
 	      return ret;
       }
     }
@@ -855,7 +855,7 @@ int MotrBucket::remove_bucket(const DoutPrefixProvider *dpp, bool delete_childre
   string bucket_multipart_iname = "motr.rgw.bucket." + tenant_bkt_name + ".multiparts";
   ret = store->delete_motr_idx_by_name(bucket_multipart_iname);
   if (ret < 0) {
-    ldpp_dout(dpp, 0) << __func__ << ": ERROR: failed to remove multipart index rc = " << ret << dendl;
+    ldpp_dout(dpp, 0) <<__func__<< ": ERROR: failed to remove multipart index rc=" << ret << dendl;
     return ret;
   }
 
@@ -867,18 +867,18 @@ int MotrBucket::remove_bucket(const DoutPrefixProvider *dpp, bool delete_childre
                             M0_IC_DEL, tenant_bkt_name, blst);
 
   if (ret != 0) {
-    ldpp_dout(dpp, 20) << __func__ << ": Failed to delete the stats entry "
-                      << "for the bucket = " << tenant_bkt_name
-                      << ", ret = " << ret << dendl;
+    ldpp_dout(dpp, 20) <<__func__<< ": Failed to delete the stats entry "
+                      << "for the bucket=" << tenant_bkt_name
+                      << ", ret=" << ret << dendl;
   }
   else
-    ldpp_dout(dpp, 20) << __func__ << ": Deleted the stats successfully for the "
-                      << " bucket = " << tenant_bkt_name << dendl;
+    ldpp_dout(dpp, 20) <<__func__<< ": Deleted the stats successfully for the "
+                      << " bucket=" << tenant_bkt_name << dendl;
 
   // 5. Remove the bucket from user info index. (unlink user)
   ret = this->unlink_user(dpp, info.owner, y);
   if (ret < 0) {
-    ldpp_dout(dpp, 0) << __func__ << ": ERROR: unlink_user failed rc = " << ret << dendl;
+    ldpp_dout(dpp, 0) <<__func__<< ": ERROR: unlink_user failed rc=" << ret << dendl;
     return ret;
   }
 
@@ -886,7 +886,7 @@ int MotrBucket::remove_bucket(const DoutPrefixProvider *dpp, bool delete_childre
   string bucket_index_iname = "motr.rgw.bucket.index." + tenant_bkt_name;
   ret = store->delete_motr_idx_by_name(bucket_index_iname);
   if (ret < 0) {
-    ldpp_dout(dpp, 0) << __func__ << ": ERROR: unlink_user failed rc = " << ret << dendl;
+    ldpp_dout(dpp, 0) <<__func__<< ": ERROR: unlink_user failed rc=" << ret << dendl;
     return ret;
   }
 
@@ -894,7 +894,7 @@ int MotrBucket::remove_bucket(const DoutPrefixProvider *dpp, bool delete_childre
   bufferlist bl;
   ret = store->get_bucket_inst_cache()->remove(dpp, tenant_bkt_name);
   if (ret < 0) {
-    ldpp_dout(dpp, 0) << __func__ << ": ERROR: failed to remove bucket instance from cache rc = "
+    ldpp_dout(dpp, 0) <<__func__<< ": ERROR: failed to remove bucket instance from cache rc="
       << ret << dendl;
     return ret;
   }
@@ -902,7 +902,7 @@ int MotrBucket::remove_bucket(const DoutPrefixProvider *dpp, bool delete_childre
   ret = store->do_idx_op_by_name(RGW_MOTR_BUCKET_INST_IDX_NAME,
                                   M0_IC_DEL, tenant_bkt_name, bl);
   if (ret < 0) {
-    ldpp_dout(dpp, 0) << __func__ << ": ERROR: failed to remove bucket instance rc = "
+    ldpp_dout(dpp, 0) <<__func__<< ": ERROR: failed to remove bucket instance rc="
       << ret << dendl;
     return ret;
   }
@@ -922,12 +922,12 @@ int MotrBucket::remove_bucket(const DoutPrefixProvider *dpp, bool delete_childre
         * NoSuchKey */
         ret = -ERR_NO_SUCH_BUCKET;
       }
-      ldpp_dout(dpp, 0) << __func__ << ": ERROR: forward to master failed. ret=" << ret << dendl;
+      ldpp_dout(dpp, 0) <<__func__<< ": ERROR: forward to master failed. ret=" << ret << dendl;
       return ret;
     }
   }
 
-  ldpp_dout(dpp, 20) << __func__ << ": exit=" << tenant_bkt_name << dendl;
+  ldpp_dout(dpp, 20) <<__func__<< ": exit=" << tenant_bkt_name << dendl;
 
   return ret;
 }
@@ -945,7 +945,7 @@ int MotrBucket::put_info(const DoutPrefixProvider *dpp, bool exclusive, ceph::re
   struct MotrBucketInfo mbinfo;
   string tenant_bkt_name = get_bucket_name(info.bucket.tenant, info.bucket.name);
 
-  ldpp_dout(dpp, 20) << __func__ << ": bucket_id=" << info.bucket.bucket_id << dendl;
+  ldpp_dout(dpp, 20) <<__func__<< ": bucket_id=" << info.bucket.bucket_id << dendl;
   mbinfo.info = info;
   mbinfo.bucket_attrs = attrs;
   mbinfo.mtime = _mtime;
@@ -968,10 +968,10 @@ int MotrBucket::load_bucket(const DoutPrefixProvider *dpp, optional_yield y, boo
   string tenant_bkt_name = get_bucket_name(info.bucket.tenant, info.bucket.name);
   if (store->get_bucket_inst_cache()->get(dpp, tenant_bkt_name, bl)) {
     // Cache misses.
-    ldpp_dout(dpp, 20) << __func__ << ": name =" << tenant_bkt_name << dendl;
+    ldpp_dout(dpp, 20) <<__func__<< ": name=" << tenant_bkt_name << dendl;
     int rc = store->do_idx_op_by_name(RGW_MOTR_BUCKET_INST_IDX_NAME,
                                       M0_IC_GET, tenant_bkt_name, bl);
-    ldpp_dout(dpp, 20) << __func__ << ": do_idx_op_by_name, rc = " << rc << dendl;
+    ldpp_dout(dpp, 20) <<__func__<< ": do_idx_op_by_name, rc=" << rc << dendl;
     if (rc < 0)
       return rc;
     store->get_bucket_inst_cache()->put(dpp, tenant_bkt_name, bl);
@@ -983,7 +983,7 @@ int MotrBucket::load_bucket(const DoutPrefixProvider *dpp, optional_yield y, boo
   mbinfo.decode(iter); //Decode into MotrBucketInfo.
 
   info = mbinfo.info;
-  ldpp_dout(dpp, 20) << __func__ << ": bucket_id=" << info.bucket.bucket_id << dendl;
+  ldpp_dout(dpp, 20) <<__func__<< ": bucket_id=" << info.bucket.bucket_id << dendl;
   rgw_placement_rule placement_rule;
   placement_rule.name = "default";
   placement_rule.storage_class = "STANDARD";
@@ -1010,7 +1010,7 @@ int MotrBucket::link_user(const DoutPrefixProvider* dpp, User* new_user, optiona
   new_bucket.creation_time = creation_time;
   new_bucket.encode(bl);
   std::time_t ctime = ceph::real_clock::to_time_t(new_bucket.creation_time);
-  ldpp_dout(dpp, 20) << __func__ << ": got creation time: "
+  ldpp_dout(dpp, 20) <<__func__<< ": got creation time: "
                      << std::put_time(std::localtime(&ctime), "%F %T") << dendl;
   string tenant_bkt_name = get_bucket_name(info.bucket.tenant, info.bucket.name);
 
@@ -1042,7 +1042,7 @@ int MotrBucket::read_stats(const DoutPrefixProvider *dpp, int shard_id,
   int rc = this->store->do_idx_op_by_name(user_stats_iname,
                                   M0_IC_GET, info.bucket.get_key(), bl);
   if (rc < 0) {
-    ldpp_dout(dpp, 20) << __func__ << ": failed to get the bucket stats for bucket = "
+    ldpp_dout(dpp, 20) <<__func__<< ": failed to get the bucket stats for bucket = "
                        << info.bucket.get_key() << dendl;
     return rc;
   }
@@ -1081,7 +1081,7 @@ int MotrBucket::create_multipart_indices()
   string bucket_multipart_iname = "motr.rgw.bucket." + tenant_bkt_name + ".multiparts";
   rc = store->create_motr_idx_by_name(bucket_multipart_iname);
   if (rc < 0) {
-    ldout(store->cctx, 0) << __func__ << ": failed to create bucket multipart index "
+    ldout(store->cctx, 0) <<__func__<< ": failed to create bucket multipart index "
                           << bucket_multipart_iname << dendl;
     return rc;
   }
@@ -1136,8 +1136,8 @@ int MotrBucket::check_quota(const DoutPrefixProvider *dpp,
   RGWQuotaHandler* quota_handler = \
     RGWQuotaHandler::generate_handler(dpp, store, false);
 
-  ldpp_dout(dpp, 20) << __func__ << ": called. check_size_only = "
-     << check_size_only << ", obj_size = " << obj_size << dendl;
+  ldpp_dout(dpp, 20) <<__func__<< ": called. check_size_only = "
+     << check_size_only << ", obj_size=" << obj_size << dendl;
 
   int rc = quota_handler->check_quota(dpp, info.owner, info.bucket,
                                       user_quota, bucket_quota,
@@ -1237,7 +1237,7 @@ int MotrBucket::list(const DoutPrefixProvider *dpp, ListParams& params, int max,
 
   string tenant_bkt_name = get_bucket_name(info.bucket.tenant, info.bucket.name);
 
-  ldpp_dout(dpp, 20) << __func__ << ": bucket=" << tenant_bkt_name
+  ldpp_dout(dpp, 20) <<__func__<< ": bucket=" << tenant_bkt_name
                     << " prefix=" << params.prefix
                     << " marker=" << params.marker
                     << " max=" << max << dendl;
@@ -1261,7 +1261,7 @@ int MotrBucket::list(const DoutPrefixProvider *dpp, ListParams& params, int max,
     else
       keys[0].append(" ");
   }
-  
+
   results.is_truncated = false;
   int keycount=0;
   std::string next_key;
@@ -1271,15 +1271,15 @@ int MotrBucket::list(const DoutPrefixProvider *dpp, ListParams& params, int max,
     rc = store->next_query_by_name(bucket_index_iname, keys, vals, params.prefix,
                                    params.delim);
     if (rc < 0) {
-      ldpp_dout(dpp, 0) << __func__ << ": ERROR: next_query_by_name failed, rc = " << rc << dendl;
+      ldpp_dout(dpp, 0) <<__func__<< ": ERROR: next_query_by_name failed, rc=" << rc << dendl;
       return rc;
     }
-    ldpp_dout(dpp, 20) << __func__ << ": items: " << rc << dendl;
+    ldpp_dout(dpp, 20) <<__func__<< ": items: " << rc << dendl;
     // Process the returned pairs to add into ListResults.
      for (int i = 0; i < rc; ++i) {
-      ldpp_dout(dpp, 70) << __func__ << ": key["<<i<<"] :"<<keys[i]<<dendl;
+      ldpp_dout(dpp, 70) <<__func__<< ": key["<<i<<"] :"<<keys[i]<<dendl;
       if(i == 0 && !next_key.empty()) {
-        ldpp_dout(dpp, 70) << __func__ << ": skipping previous next_key: " << next_key << dendl;
+        ldpp_dout(dpp, 70) <<__func__<< ": skipping previous next_key: " << next_key << dendl;
         continue;
       }
       if (vals[i].length() == 0) {
@@ -1293,16 +1293,16 @@ int MotrBucket::list(const DoutPrefixProvider *dpp, ListParams& params, int max,
           ldpp_dout(dpp, 70) << __func__ << ": skipping key "<<keys[i]<<dendl;
             continue;
         }
-        if ( params.list_versions || ent.is_visible()) {
+        if (params.list_versions || ent.is_visible()) {
           if (keycount < max) {
             results.objs.emplace_back(std::move(ent));
-            ldpp_dout(dpp, 70) << __func__ << ": adding key "<<keys[i]<<" to result"<<dendl;
+            ldpp_dout(dpp, 70) <<__func__<< ": adding key "<<keys[i]<<" to result"<<dendl;
           }
           if (keycount == max) {
             // One extra key is successfully fetched.
             results.next_marker = keys[i-1];
             results.is_truncated = true;
-            ldpp_dout(dpp, 20) << __func__ << ": adding key "<<keys[i-1]<<" to next_marker"<<dendl;
+            ldpp_dout(dpp, 20) <<__func__<< ": adding key "<<keys[i-1]<<" to next_marker"<<dendl;
             break;
           }
           keycount++;
@@ -1346,7 +1346,7 @@ int MotrBucket::list_multiparts(const DoutPrefixProvider *dpp,
   key_vec[0].assign(marker.begin(), marker.end());
   rc = store->next_query_by_name(bucket_multipart_iname, key_vec, val_vec, prefix, delim);
   if (rc < 0) {
-    ldpp_dout(dpp, 0) << __func__ << ": ERROR: next_query_by_name failed, rc = " << rc << dendl;
+    ldpp_dout(dpp, 0) <<__func__<< ": ERROR: next_query_by_name failed, rc=" << rc << dendl;
     return rc;
   }
 
@@ -1358,7 +1358,7 @@ int MotrBucket::list_multiparts(const DoutPrefixProvider *dpp,
   *is_truncated = false;
 
   for (const auto& bl: val_vec) {
-    
+
     if (bl.length() == 0)
       continue;
 
@@ -1374,7 +1374,7 @@ int MotrBucket::list_multiparts(const DoutPrefixProvider *dpp,
     rgw_obj_key key(ent.key);
     if (prefix.size() &&
         (0 != key.name.compare(0, prefix.size(), prefix))) {
-      ldpp_dout(dpp, 20) << __func__ <<
+      ldpp_dout(dpp, 20) <<__func__<<
         ": skippping \"" << ent.key <<
         "\" because doesn't match prefix" << dendl;
       continue;
@@ -1412,9 +1412,9 @@ uint64_t MotrStore::get_new_req_id()
   uint64_t req_id = ceph::util::generate_random_number<uint64_t>();
 
   addb_logger.set_id(req_id);
-  ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+  ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
        RGW_ADDB_FUNC_GET_NEW_REQ_ID, RGW_ADDB_PHASE_START);
-  
+
   return req_id;
 }
 
@@ -1525,10 +1525,11 @@ MotrObject::~MotrObject() {
 int MotrObject::fetch_obj_entry_and_key(const DoutPrefixProvider* dpp, rgw_bucket_dir_entry& ent, std::string& bname, std::string& key, rgw_obj* target_obj)
 {
   int rc = this->get_bucket_dir_ent(dpp, ent);
+
   if (rc < 0) {
       ldpp_dout(dpp, 0) <<__func__<< ": ERROR: failed to get object entry. rc=" << rc << dendl;
       return rc;
-    }
+  }
 
   read_bucket_info(dpp, bname, key, target_obj);
 
@@ -1541,10 +1542,10 @@ int MotrObject::fetch_obj_entry_and_key(const DoutPrefixProvider* dpp, rgw_bucke
     ldpp_dout(dpp, 20) <<__func__<< ": fetching null version key instance " << key << dendl;
   } else {
     key =  ent.key.name + "[" + ent.key.instance + "]";
-     ldpp_dout(dpp, 20) <<__func__<< ": fetching null version key instance for latest object " << key << dendl;
+    ldpp_dout(dpp, 20) <<__func__<< ": fetching null version key instance for latest object " << key << dendl;
   }
 
-   return 0;
+  return 0;
 }
 
 int MotrObject::set_obj_attrs(const DoutPrefixProvider* dpp, RGWObjectCtx* rctx, Attrs* setattrs, Attrs* delattrs, optional_yield y, rgw_obj* target_obj)
@@ -1559,7 +1560,7 @@ int MotrObject::set_obj_attrs(const DoutPrefixProvider* dpp, RGWObjectCtx* rctx,
 
   rc = fetch_obj_entry_and_key(dpp, ent, bname, key, target_obj);
   if (rc < 0) {
-      ldpp_dout(dpp, 0) <<__func__<< ": Failed to get key or object's entry from bucket index. rc= " << rc << dendl;
+      ldpp_dout(dpp, 0) <<__func__<< ": Failed to get key or object's entry from bucket index. rc=" << rc << dendl;
       return rc;
     }
   // set attributes present in setattrs
@@ -1612,7 +1613,7 @@ int MotrObject::get_obj_attrs(RGWObjectCtx* rctx, optional_yield y, const DoutPr
   string bname, key;
   rc = fetch_obj_entry_and_key(dpp, ent, bname, key, target_obj);
   if (rc < 0) {
-      ldpp_dout(dpp, 0) <<__func__<< ": Failed to get key or object's entry from bucket index. rc= " << rc << dendl;
+      ldpp_dout(dpp, 0) <<__func__<< ": Failed to get key or object's entry from bucket index. rc=" << rc << dendl;
       return rc;
     }
 
@@ -1628,7 +1629,7 @@ void MotrObject::read_bucket_info(const DoutPrefixProvider* dpp, std::string& bn
     bname = get_bucket_name(this->get_bucket()->get_tenant(), this->get_bucket()->get_name());
     key   = this->get_key().to_str();
   }
-  ldpp_dout(dpp, 20) << __func__ << ": for bucket " << bname << "/" << key << dendl;
+  ldpp_dout(dpp, 20) <<__func__<< ": for bucket " << bname << "/" << key << dendl;
 }
 
 int MotrObject::modify_obj_attrs(RGWObjectCtx* rctx, const char* attr_name, bufferlist& attr_val, optional_yield y, const DoutPrefixProvider* dpp)
@@ -1758,7 +1759,7 @@ std::unique_ptr<Object::ReadOp> MotrObject::get_read_op(RGWObjectCtx* ctx)
 MotrObject::MotrReadOp::MotrReadOp(MotrObject *_source, RGWObjectCtx *_rctx) :
   source(_source),
   rctx(_rctx)
-{ 
+{
   struct req_state* s = static_cast<req_state*>(_rctx->get_private());
   ADDB(RGW_ADDB_REQUEST_OPCODE_ID, addb_logger.get_id(), s->op_type);
 }
@@ -1809,7 +1810,7 @@ int MotrObject::MotrReadOp::prepare(optional_yield y, const DoutPrefixProvider* 
     // Check if-modified-since condition
     if (params.mod_ptr && !params.if_nomatch) {
       dest_weight.init(*params.mod_ptr, params.mod_zone_id, params.mod_pg_ver);
-      ldpp_dout(dpp, 10) << __func__ << ": If-Modified-Since: " << dest_weight << " & "
+      ldpp_dout(dpp, 10) <<__func__<< ": If-Modified-Since: " << dest_weight << " & "
                          << "Last-Modified: " << src_weight << dendl;
       if (!(dest_weight < src_weight)) {
         return -ERR_NOT_MODIFIED;
@@ -1819,7 +1820,7 @@ int MotrObject::MotrReadOp::prepare(optional_yield y, const DoutPrefixProvider* 
     // Check if-unmodified-since condition
     if (params.unmod_ptr && !params.if_match) {
       dest_weight.init(*params.unmod_ptr, params.mod_zone_id, params.mod_pg_ver);
-      ldpp_dout(dpp, 10) << __func__ << ": If-UnModified-Since: " << dest_weight << " & "
+      ldpp_dout(dpp, 10) <<__func__<< ": If-UnModified-Since: " << dest_weight << " & "
                          << "Last-Modified: " << src_weight << dendl;
       if (dest_weight < src_weight) {
         return -ERR_PRECONDITION_FAILED;
@@ -1829,8 +1830,8 @@ int MotrObject::MotrReadOp::prepare(optional_yield y, const DoutPrefixProvider* 
   // Check if-match condition
   if (params.if_match) {
     string if_match_str = rgw_string_unquote(params.if_match);
-    ldpp_dout(dpp, 10) << __func__ << ": ETag: " << etag << " & "
-                       << "If-Match: " << if_match_str << dendl;     
+    ldpp_dout(dpp, 10) <<__func__<< ": ETag: " << etag << " & "
+                       << "If-Match: " << if_match_str << dendl;
     if (if_match_str.compare(etag) != 0) {
       return -ERR_PRECONDITION_FAILED;
     }
@@ -1838,7 +1839,7 @@ int MotrObject::MotrReadOp::prepare(optional_yield y, const DoutPrefixProvider* 
   // Check if-none-match condition
   if (params.if_nomatch) {
     string if_nomatch_str = rgw_string_unquote(params.if_nomatch);
-    ldpp_dout(dpp, 10) << __func__ << ": ETag: " << etag << " & "
+    ldpp_dout(dpp, 10) <<__func__<< ": ETag: " << etag << " & "
                        << "If-NoMatch: " << if_nomatch_str << dendl;
     if (if_nomatch_str.compare(etag) == 0) {
       return -ERR_NOT_MODIFIED;
@@ -1849,7 +1850,7 @@ int MotrObject::MotrReadOp::prepare(optional_yield y, const DoutPrefixProvider* 
 
 int MotrObject::MotrReadOp::read(int64_t off, int64_t end, bufferlist& bl, optional_yield y, const DoutPrefixProvider* dpp)
 {
-  ldpp_dout(dpp, 20) <<  __func__ << ": sync read." << dendl;
+  ldpp_dout(dpp, 20) << __func__<< ": sync read." << dendl;
   return 0;
 }
 
@@ -1872,7 +1873,7 @@ int MotrObject::MotrReadOp::iterate(const DoutPrefixProvider* dpp, int64_t off, 
     rc = source->get_part_objs(dpp, this->part_objs)? :
          source->open_part_objs(dpp, this->part_objs);
     if (rc < 0) {
-      ldpp_dout(dpp, 10) << __func__ << ": ERROR: failed to open motr object: rc = " << rc << dendl;
+      ldpp_dout(dpp, 10) <<__func__<< ": ERROR: failed to open motr object: rc=" << rc << dendl;
       return rc;
     }
     rc = source->read_multipart_obj(dpp, off, end, cb, part_objs);
@@ -1881,7 +1882,7 @@ int MotrObject::MotrReadOp::iterate(const DoutPrefixProvider* dpp, int64_t off, 
     ldpp_dout(dpp, 20) <<__func__<< ": open object..." << dendl;
     rc = source->open_mobj(dpp);
     if (rc < 0) {
-      ldpp_dout(dpp, 10) << __func__ << ": ERROR: failed to open motr object: rc = " << rc << dendl;
+      ldpp_dout(dpp, 10) <<__func__<< ": ERROR: failed to open motr object: rc=" << rc << dendl;
       return rc;
     }
     rc = source->read_mobj(dpp, off, end, cb);
@@ -1910,7 +1911,7 @@ std::unique_ptr<Object::DeleteOp> MotrObject::get_delete_op(RGWObjectCtx* ctx)
 MotrObject::MotrDeleteOp::MotrDeleteOp(MotrObject *_source, RGWObjectCtx *_rctx) :
   source(_source),
   rctx(_rctx)
-{ 
+{
   addb_logger.set_id(rctx);
 }
 
@@ -1947,7 +1948,7 @@ int MotrObject::MotrDeleteOp::delete_obj(const DoutPrefixProvider* dpp, optional
       rc = source->fetch_null_obj_reference(dpp, delete_key);
       if (rc < 0)
         return rc;
-      ldpp_dout(dpp, 0)<<__func__<< ": instance is null -  delete_key "<< delete_key << dendl;
+      ldpp_dout(dpp, 0)<<__func__<< ": instance is null - delete_key "<< delete_key << dendl;
     }
     else
       delete_key = source->get_name() + "[" + source->get_instance() + "]";
@@ -1975,14 +1976,14 @@ int MotrObject::MotrDeleteOp::delete_obj(const DoutPrefixProvider* dpp, optional
       result.version_id = ent.key.instance;
       if (ent.is_delete_marker())
         result.delete_marker = true;
-      ldpp_dout(dpp, 20) <<  __func__ << "delete " << delete_key << " from "
+      ldpp_dout(dpp, 20) << __func__<< "delete " << delete_key << " from "
                             << tenant_bkt_name << dendl;
 
       rc = source->remove_mobj_and_index_entry(
           dpp, ent, delete_key, bucket_index_iname, tenant_bkt_name);
       if (rc < 0) {
-        ldpp_dout(dpp, 0) << __func__ << ":Failed to delete the object from Motr."
-	                          <<" key = " << delete_key << dendl;
+        ldpp_dout(dpp, 0) <<__func__<< ":Failed to delete the object from Motr."
+	                          <<" key=" << delete_key << dendl;
         return rc;
       }
       // if deleted object version is the latest version,
@@ -2027,7 +2028,7 @@ int MotrObject::MotrDeleteOp::delete_obj(const DoutPrefixProvider* dpp, optional
         }
       }
       // update is-latest=false for current version entry.
-      ldpp_dout(dpp, 20) << __func__ << " Updating previous version entries " << dendl;
+      ldpp_dout(dpp, 20) <<__func__<< " Updating previous version entries " << dendl;
       rc = source->update_version_entries(dpp);
       if (rc < 0)
         return rc;
@@ -2051,7 +2052,7 @@ int MotrObject::MotrDeleteOp::delete_obj(const DoutPrefixProvider* dpp, optional
 
       // key for delete marker - obj1[delete-markers's ver-id].
       std::string delete_marker_key = source->get_key().to_str();
-      ldpp_dout(dpp, 20)<<__func__<< "Add delete marker in bucket index, key=  " <<  delete_marker_key << dendl;
+      ldpp_dout(dpp, 20)<<__func__<< "Add delete marker in bucket index, key=" <<  delete_marker_key << dendl;
       rc = source->store->do_idx_op_by_name(bucket_index_iname,
                                             M0_IC_PUT, delete_marker_key, del_mark_bl);
       if(rc < 0) {
@@ -2120,15 +2121,15 @@ int MotrObject::remove_mobj_and_index_entry(
       rc = this->delete_mobj(dpp);
     }
     if (rc < 0) {
-      ldpp_dout(dpp, 0) << "Failed to delete the object " << delete_key  <<" from Motr. " << dendl;
+      ldpp_dout(dpp, 0) << "Failed to delete the object " << delete_key  <<" from Motr." << dendl;
       return rc;
     }
   }
   rc = this->store->do_idx_op_by_name(bucket_index_iname,
                                       M0_IC_DEL, delete_key, bl);
   if (rc < 0) {
-    ldpp_dout(dpp, 0) << "Failed to delete object's entry " << delete_key 
-                                      << " from bucket index. " << dendl;
+    ldpp_dout(dpp, 0) << "Failed to delete object's entry " << delete_key
+                                      << " from bucket index." << dendl;
     return rc;
   }
 
@@ -2138,14 +2139,14 @@ int MotrObject::remove_mobj_and_index_entry(
   rc = update_bucket_stats(dpp, this->store, ent.meta.owner, bucket_name,
                            ent.meta.size, size_rounded, 1, false);
   if (rc != 0) {
-    ldpp_dout(dpp, 20) << __func__ << ": Failed stats substraction for the "
-      << "bucket/obj = " << bucket_name << "/" << delete_key
-      << ", rc = " << rc << dendl;
+    ldpp_dout(dpp, 20) <<__func__<< ": Failed stats substraction for the "
+      << "bucket/obj=" << bucket_name << "/" << delete_key
+      << ", rc=" << rc << dendl;
     return rc;
   }
-  ldpp_dout(dpp, 70) << __func__ << ": Stats subtracted successfully for the "
-      << "bucket/obj = " << bucket_name << "/" << delete_key
-      << ", rc = " << rc << dendl;
+  ldpp_dout(dpp, 70) <<__func__<< ": Stats subtracted successfully for the "
+      << "bucket/obj=" << bucket_name << "/" << delete_key
+      << ", rc=" << rc << dendl;
 
   return rc;
 }
@@ -2170,8 +2171,8 @@ int MotrObject::delete_obj_aio(const DoutPrefixProvider* dpp, RGWObjState* astat
 int MotrCopyObj_CB::handle_data(bufferlist& bl, off_t bl_ofs, off_t bl_len)
 {
   int rc = 0;
-  ldpp_dout(m_dpp, 20) << "Offset = " << bl_ofs << " Length = "
-                       << " Write Offset = " << write_offset << bl_len << dendl;
+  ldpp_dout(m_dpp, 20) << "Offset=" << bl_ofs << " Length = "
+                       << " Write Offset=" << write_offset << bl_len << dendl;
 
 
   //offset is zero and bufferlength is equal to bl_len
@@ -2182,26 +2183,26 @@ int MotrCopyObj_CB::handle_data(bufferlist& bl, off_t bl_ofs, off_t bl_len)
     rc = m_dst_writer->process(std::move(blist), write_offset);
     if(rc < 0){
       ldpp_dout(m_dpp, 20) << "ERROR: writer process bl_ofs=0 && " <<
-                          "bl_len = " << bl.length() << " Write Offset = " <<
-                          write_offset << "failed rc = " << rc << dendl;
+                          "bl_len=" << bl.length() << " Write Offset=" <<
+                          write_offset << "failed rc=" << rc << dendl;
     }
     write_offset += bl_len;
     return rc;
   }
-  
+
   bufferptr bp(bl.c_str() + bl_ofs, bl_len);
   bufferlist new_bl;
   new_bl.push_back(bp);
 
   rc = m_dst_writer->process(std::move(new_bl), write_offset);
   if(rc < 0){
-    ldpp_dout(m_dpp, 20) << "ERROR: writer process failed rc = " << rc
-                         << " Write Offset = " << write_offset << dendl;
+    ldpp_dout(m_dpp, 20) << "ERROR: writer process failed rc=" << rc
+                         << " Write Offset=" << write_offset << dendl;
     return rc;
   }
   write_offset += bl_len;
 
-  ldpp_dout(m_dpp, 20) << "MotrCopyObj_CB handle_data called rc = " << rc << dendl;
+  ldpp_dout(m_dpp, 20) << "MotrCopyObj_CB handle_data called rc=" << rc << dendl;
   return rc;
 }
 
@@ -2253,7 +2254,7 @@ int MotrObject::copy_object_same_zone(RGWObjectCtx& obj_ctx,
 
   rc = read_op->prepare(y, dpp);
   if(rc < 0){
-    ldpp_dout(dpp, 20) << "ERROR: read op prepare failed rc = " << rc << dendl;
+    ldpp_dout(dpp, 20) << "ERROR: read op prepare failed rc=" << rc << dendl;
     return rc;
   }
 
@@ -2272,7 +2273,7 @@ int MotrObject::copy_object_same_zone(RGWObjectCtx& obj_ctx,
 
   rc = dst_writer->prepare(y);
   if(rc < 0){
-    ldpp_dout(dpp, 20) << "ERROR: writer prepare failed rc = " << rc << dendl;
+    ldpp_dout(dpp, 20) << "ERROR: writer prepare failed rc=" << rc << dendl;
     return rc;
   }
 
@@ -2284,14 +2285,14 @@ int MotrObject::copy_object_same_zone(RGWObjectCtx& obj_ctx,
   int64_t cur_ofs = 0, cur_end = obj_size;
   rc = this->range_to_ofs(obj_size, cur_ofs, cur_end);
   if (rc < 0){
-    ldpp_dout(dpp, 20) << "ERROR: read op range_to_ofs failed rc = " << rc << dendl;
+    ldpp_dout(dpp, 20) << "ERROR: read op range_to_ofs failed rc=" << rc << dendl;
     return rc;
   }
 
   // read::iterate -> handle_data() -> write::process
   rc = read_op->iterate(dpp, cur_ofs, cur_end, filter, y);
   if (rc < 0){
-    ldpp_dout(dpp, 20) << "ERROR: read op iterate failed rc = " << rc << dendl;
+    ldpp_dout(dpp, 20) << "ERROR: read op iterate failed rc=" << rc << dendl;
     return rc;
   }
 
@@ -2304,7 +2305,7 @@ int MotrObject::copy_object_same_zone(RGWObjectCtx& obj_ctx,
   bufferlist bl;
   rc = read_op->get_attr(dpp, RGW_ATTR_ETAG, bl, y);
   if (rc < 0){
-    ldpp_dout(dpp, 20) << "ERROR: read op iterate failed rc = " << rc << dendl;
+    ldpp_dout(dpp, 20) << "ERROR: read op iterate failed rc=" << rc << dendl;
     return rc;
   }
   string etag_str;
@@ -2328,7 +2329,7 @@ int MotrObject::copy_object_same_zone(RGWObjectCtx& obj_ctx,
                       nullptr,
                       y);
   if (rc < 0){
-    ldpp_dout(dpp, 20) << "ERROR: writer complete failed rc = " << rc << dendl;
+    ldpp_dout(dpp, 20) << "ERROR: writer complete failed rc=" << rc << dendl;
     return rc;
   }
 
@@ -2369,11 +2370,11 @@ int MotrObject::copy_object(RGWObjectCtx& obj_ctx,
   auto& dest_zonegrp = dest_bucket->get_info().zonegroup;
 
   if(src_zonegrp.compare(dest_zonegrp) != 0){
-    ldpp_dout(dpp, 0) << __func__ << "Unsupported Action Requested." << dendl;
+    ldpp_dout(dpp, 0) <<__func__<< "Unsupported Action Requested." << dendl;
     return -ERR_NOT_IMPLEMENTED;
   }
 
-  ldpp_dout(dpp, 20) << __func__ << "Src and Dest Zonegroups are same."
+  ldpp_dout(dpp, 20) <<__func__<< "Src and Dest Zonegroups are same."
                     << "src_zonegrp : " << src_zonegrp
                     << "dest_zonegrp : " << dest_zonegrp << dendl;
 
@@ -2418,11 +2419,11 @@ int MotrObject::copy_object(RGWObjectCtx& obj_ctx,
                             dpp,
                             y);
   if (rc < 0){
-    ldpp_dout(dpp, 20) << "ERROR: copy_object_same_zone failed rc = " << rc << dendl;
+    ldpp_dout(dpp, 20) << "ERROR: copy_object_same_zone failed rc=" << rc << dendl;
     return rc;
   }
 
-  ldpp_dout(dpp, 20) << "Copy op completed rc = " << rc << dendl;
+  ldpp_dout(dpp, 20) << "Copy op completed rc=" << rc << dendl;
   return rc;
 }
 
@@ -2486,20 +2487,20 @@ int MotrAtomicWriter::prepare(optional_yield y)
 
 int MotrObject::create_mobj(const DoutPrefixProvider *dpp, uint64_t sz)
 {
-  ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+  ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
        RGW_ADDB_FUNC_CREATE_MOBJ, RGW_ADDB_PHASE_START);
 
   if (mobj != nullptr) {
-    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
          RGW_ADDB_FUNC_CREATE_MOBJ, RGW_ADDB_PHASE_ERROR);
     ldpp_dout(dpp, 0) <<__func__<< "ERROR: object is already opened" << dendl;
-    
+
     return -EINVAL;
   }
 
   int rc = m0_ufid_next(&ufid_gr, 1, &meta.oid);
   if (rc != 0) {
-    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
          RGW_ADDB_FUNC_CREATE_MOBJ, RGW_ADDB_PHASE_ERROR);
     ldpp_dout(dpp, 0) <<__func__<< "ERROR: m0_ufid_next() failed: " << rc << dendl;
 
@@ -2507,7 +2508,7 @@ int MotrObject::create_mobj(const DoutPrefixProvider *dpp, uint64_t sz)
   }
   expected_obj_size = sz;
 
-  ldpp_dout(dpp, 20) << __func__ << ": key=" << this->get_key().to_str() << ", meta:oid=[0x" << std::hex
+  ldpp_dout(dpp, 20) <<__func__<< ": key=" << this->get_key().to_str() << ", meta:oid=[0x" << std::hex
                                  << meta.oid.u_hi << ":0x" << std::hex  << meta.oid.u_lo << "]" << dendl;
 
   int64_t lid = m0_layout_find_by_objsz(store->instance, nullptr, sz);
@@ -2524,14 +2525,14 @@ int MotrObject::create_mobj(const DoutPrefixProvider *dpp, uint64_t sz)
   mobj->ob_entity.en_flags |= M0_ENF_META;
   rc = m0_entity_create(nullptr, &mobj->ob_entity, &op);
   if (rc != 0) {
-    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
          RGW_ADDB_FUNC_CREATE_MOBJ, RGW_ADDB_PHASE_ERROR);
     this->close_mobj();
-    ldpp_dout(dpp, 0) << __func__ << ": ERROR: m0_entity_create() failed, rc = " << rc << dendl;
+    ldpp_dout(dpp, 0) <<__func__<< ": ERROR: m0_entity_create() failed, rc=" << rc << dendl;
     return rc;
   }
   ldpp_dout(dpp, 20) <<__func__<< ": call m0_op_launch()..." << dendl;
-  ADDB(RGW_ADDB_REQUEST_TO_MOTR_ID, addb_logger.get_id(), 
+  ADDB(RGW_ADDB_REQUEST_TO_MOTR_ID, addb_logger.get_id(),
        m0_sm_id_get(&op->op_sm));
   m0_op_launch(&op, 1);
   rc = m0_op_wait(op, M0_BITS(M0_OS_FAILED, M0_OS_STABLE), M0_TIME_NEVER) ?:
@@ -2540,21 +2541,21 @@ int MotrObject::create_mobj(const DoutPrefixProvider *dpp, uint64_t sz)
   m0_op_free(op);
 
   if (rc != 0) {
-    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
          RGW_ADDB_FUNC_CREATE_MOBJ, RGW_ADDB_PHASE_ERROR);
     this->close_mobj();
-    ldpp_dout(dpp, 0) << __func__ << ": ERROR: failed to create motr object. rc = " << rc << dendl;
+    ldpp_dout(dpp, 0) <<__func__<< ": ERROR: failed to create motr object. rc=" << rc << dendl;
     return rc;
   }
 
   meta.layout_id = mobj->ob_attr.oa_layout_id;
   meta.pver      = mobj->ob_attr.oa_pver;
-  ldpp_dout(dpp, 20) << __func__ << ": key=" << this->get_key() << ", meta:oid=[0x" << std::hex << meta.oid.u_hi
+  ldpp_dout(dpp, 20) <<__func__<< ": key=" << this->get_key() << ", meta:oid=[0x" << std::hex << meta.oid.u_hi
                                   << ":0x" << std::hex << meta.oid.u_lo << "], meta:pvid=[0x" << std::hex
                                   << meta.pver.f_container << ":0x" << std::hex << meta.pver.f_key
                                   << "], meta:layout_id=0x" << std::hex << meta.layout_id << dendl;
 
-  ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+  ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
        RGW_ADDB_FUNC_CREATE_MOBJ, RGW_ADDB_PHASE_DONE);
   // TODO: add key:user+bucket+key+obj.meta.oid value:timestamp to
   // gc.queue.index. See more at github.com/Seagate/cortx-rgw/issues/7.
@@ -2564,10 +2565,10 @@ int MotrObject::create_mobj(const DoutPrefixProvider *dpp, uint64_t sz)
 
 int MotrObject::open_mobj(const DoutPrefixProvider *dpp)
 {
-  ldpp_dout(dpp, 20) << __func__ << ": key=" << this->get_key().to_str() << ", meta:oid=[0x" << std::hex
+  ldpp_dout(dpp, 20) <<__func__<< ": key=" << this->get_key().to_str() << ", meta:oid=[0x" << std::hex
                                  << meta.oid.u_hi  << ":0x" << std::hex  << meta.oid.u_lo << "]" << dendl;
 
-  ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+  ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
        RGW_ADDB_FUNC_OPEN_MOBJ, RGW_ADDB_PHASE_START);
 
   int rc;
@@ -2575,17 +2576,17 @@ int MotrObject::open_mobj(const DoutPrefixProvider *dpp)
     rgw_bucket_dir_entry ent;
     rc = this->get_bucket_dir_ent(dpp, ent);
     if (rc < 0) {
-      ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+      ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
            RGW_ADDB_FUNC_OPEN_MOBJ, RGW_ADDB_PHASE_ERROR);
-      ldpp_dout(dpp, 0) << __func__ << ": ERROR: get_bucket_dir_ent failed: rc = " << rc << dendl;
+      ldpp_dout(dpp, 0) <<__func__<< ": ERROR: get_bucket_dir_ent failed: rc=" << rc << dendl;
       return rc;
     }
   }
 
   if (meta.layout_id == 0) {
-    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
          RGW_ADDB_FUNC_OPEN_MOBJ, RGW_ADDB_PHASE_DONE);
-    ldpp_dout(dpp, 0) << __func__ << ": ERROR: did not find motr obj details." << dendl;
+    ldpp_dout(dpp, 0) <<__func__<< ": ERROR: did not find motr obj details." << dendl;
     return -ENOENT;
   }
 
@@ -2598,14 +2599,14 @@ int MotrObject::open_mobj(const DoutPrefixProvider *dpp)
   mobj->ob_attr.oa_layout_id = meta.layout_id;
   mobj->ob_attr.oa_pver      = meta.pver;
   mobj->ob_entity.en_flags  |= M0_ENF_META;
-  ldpp_dout(dpp, 20) << __func__ << ": key=" << this->get_key().to_str() << ", meta:oid=[0x" << std::hex << meta.oid.u_hi
+  ldpp_dout(dpp, 20) <<__func__<< ": key=" << this->get_key().to_str() << ", meta:oid=[0x" << std::hex << meta.oid.u_hi
                                  << ":0x" << meta.oid.u_lo << "], meta:pvid=[0x" << std::hex << meta.pver.f_container
                                  << ":0x" << meta.pver.f_key << "], meta:layout_id=0x" << std::hex << meta.layout_id << dendl;
   rc = m0_entity_open(&mobj->ob_entity, &op);
   if (rc != 0) {
-    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
          RGW_ADDB_FUNC_OPEN_MOBJ, RGW_ADDB_PHASE_ERROR);
-    ldpp_dout(dpp, 0) << __func__ << ": ERROR: m0_entity_open() failed: rc =" << rc << dendl;
+    ldpp_dout(dpp, 0) <<__func__<< ": ERROR: m0_entity_open() failed: rc=" << rc << dendl;
     this->close_mobj();
     return rc;
   }
@@ -2618,16 +2619,16 @@ int MotrObject::open_mobj(const DoutPrefixProvider *dpp)
   m0_op_free(op);
 
   if (rc < 0) {
-    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
          RGW_ADDB_FUNC_OPEN_MOBJ, RGW_ADDB_PHASE_ERROR);
-    ldpp_dout(dpp, 10) << __func__ << ": ERROR: failed to open motr object: rc =" << rc << dendl;
+    ldpp_dout(dpp, 10) <<__func__<< ": ERROR: failed to open motr object: rc=" << rc << dendl;
     this->close_mobj();
     return rc;
   }
 
-  ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+  ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
        RGW_ADDB_FUNC_OPEN_MOBJ, RGW_ADDB_PHASE_DONE);
-  ldpp_dout(dpp, 20) <<__func__<< ": exit. rc =" << rc << dendl;
+  ldpp_dout(dpp, 20) <<__func__<< ": exit. rc=" << rc << dendl;
 
   return 0;
 }
@@ -2638,22 +2639,22 @@ int MotrObject::delete_mobj(const DoutPrefixProvider *dpp)
   char fid_str[M0_FID_STR_LEN];
   snprintf(fid_str, ARRAY_SIZE(fid_str), U128X_F, U128_P(&meta.oid));
 
-  ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+  ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
        RGW_ADDB_FUNC_DELETE_MOBJ, RGW_ADDB_PHASE_START);
 
   if (!meta.oid.u_hi || !meta.oid.u_lo) {
-    ldpp_dout(dpp, 20) << __func__ << ": invalid motr object oid=" << fid_str << dendl;
-    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+    ldpp_dout(dpp, 20) <<__func__<< ": invalid motr object oid=" << fid_str << dendl;
+    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
          RGW_ADDB_FUNC_DELETE_MOBJ, RGW_ADDB_PHASE_ERROR);
     return -EINVAL;
   }
-  ldpp_dout(dpp, 20) << __func__ << ": deleting motr object oid=" << fid_str << dendl;
+  ldpp_dout(dpp, 20) <<__func__<< ": deleting motr object oid=" << fid_str << dendl;
 
   // Open the object.
   if (mobj == nullptr) {
     rc = this->open_mobj(dpp);
     if (rc < 0) {
-      ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+      ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
            RGW_ADDB_FUNC_DELETE_MOBJ, RGW_ADDB_PHASE_ERROR);
       return rc;
     }
@@ -2664,8 +2665,8 @@ int MotrObject::delete_mobj(const DoutPrefixProvider *dpp)
   mobj->ob_entity.en_flags |= M0_ENF_META;
   rc = m0_entity_delete(&mobj->ob_entity, &op);
   if (rc != 0) {
-    ldpp_dout(dpp, 0) << __func__ << ": ERROR: m0_entity_delete() failed. rc = " << rc << dendl;
-    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+    ldpp_dout(dpp, 0) <<__func__<< ": ERROR: m0_entity_delete() failed. rc=" << rc << dendl;
+    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
          RGW_ADDB_FUNC_DELETE_MOBJ, RGW_ADDB_PHASE_ERROR);
     return rc;
   }
@@ -2678,13 +2679,13 @@ int MotrObject::delete_mobj(const DoutPrefixProvider *dpp)
   m0_op_free(op);
 
   if (rc < 0) {
-    ldpp_dout(dpp, 0) << __func__ << ": ERROR: failed to open motr object. rc = " << rc << dendl;
-    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+    ldpp_dout(dpp, 0) <<__func__<< ": ERROR: failed to open motr object. rc=" << rc << dendl;
+    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
          RGW_ADDB_FUNC_DELETE_MOBJ, RGW_ADDB_PHASE_ERROR);
     return rc;
   }
 
-  ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+  ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
        RGW_ADDB_FUNC_DELETE_MOBJ, RGW_ADDB_PHASE_DONE);
 
   this->close_mobj();
@@ -2713,14 +2714,14 @@ int MotrObject::write_mobj(const DoutPrefixProvider *dpp, bufferlist&& in_buffer
 
   bufferlist data = std::move(in_buffer);
 
-  ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+  ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
        RGW_ADDB_FUNC_WRITE_MOBJ, RGW_ADDB_PHASE_START);
 
   left = data.length();
   if (left == 0) {
-    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
          RGW_ADDB_FUNC_WRITE_MOBJ, RGW_ADDB_PHASE_DONE);
-    
+
     return 0;
   }
 
@@ -2767,8 +2768,8 @@ int MotrObject::write_mobj(const DoutPrefixProvider *dpp, bufferlist&& in_buffer
        m0_bufvec_alloc(&attr, 1, 1) ?:
        m0_indexvec_alloc(&ext, 1);
   if (rc != 0) {
-    ldpp_dout(dpp, 0) <<__func__<< ": buffer allocation failed, rc =" << rc << dendl;
-    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+    ldpp_dout(dpp, 0) <<__func__<< ": buffer allocation failed, rc=" << rc << dendl;
+    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
          RGW_ADDB_FUNC_WRITE_MOBJ, RGW_ADDB_PHASE_ERROR);
     goto out;
   }
@@ -2811,7 +2812,7 @@ int MotrObject::write_mobj(const DoutPrefixProvider *dpp, bufferlist&& in_buffer
     rc = m0_obj_op(this->mobj, M0_OC_WRITE, &ext, &buf, &attr, 0, flags, &op);
     if (rc != 0) {
       ldpp_dout(dpp, 0) <<__func__<< ": write failed, m0_obj_op rc="<< rc << dendl;
-      ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+      ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
            RGW_ADDB_FUNC_WRITE_MOBJ, RGW_ADDB_PHASE_ERROR);
       goto out;
     }
@@ -2823,13 +2824,13 @@ int MotrObject::write_mobj(const DoutPrefixProvider *dpp, bufferlist&& in_buffer
     m0_op_free(op);
     if (rc != 0) {
       ldpp_dout(dpp, 0) <<__func__<< ": write failed, m0_op_wait rc="<< rc << dendl;
-      ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+      ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
            RGW_ADDB_FUNC_WRITE_MOBJ, RGW_ADDB_PHASE_ERROR);
       goto out;
     }
   }
 
-  ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+  ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
        RGW_ADDB_FUNC_WRITE_MOBJ, RGW_ADDB_PHASE_DONE);
 out:
   m0_indexvec_free(&ext);
@@ -2854,7 +2855,7 @@ int MotrObject::read_mobj(const DoutPrefixProvider* dpp, int64_t start, int64_t 
   struct m0_indexvec ext;
 
   req_id = addb_logger.get_id();
-  ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+  ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
        RGW_ADDB_FUNC_READ_MOBJ, RGW_ADDB_PHASE_START);
 
   ldpp_dout(dpp, 20) <<__func__<< ": start=" << start << " end=" << end << dendl;
@@ -2864,7 +2865,7 @@ int MotrObject::read_mobj(const DoutPrefixProvider* dpp, int64_t start, int64_t 
        m0_indexvec_alloc(&ext, 1);
   if (rc < 0) {
     ldpp_dout(dpp, 0) <<__func__<< ": vecs alloc failed: rc="<< rc << dendl;
-    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
          RGW_ADDB_FUNC_READ_MOBJ, RGW_ADDB_PHASE_ERROR);
     goto out;
   }
@@ -2912,7 +2913,7 @@ int MotrObject::read_mobj(const DoutPrefixProvider* dpp, int64_t start, int64_t 
     rc = m0_obj_op(this->mobj, M0_OC_READ, &ext, &buf, &attr, 0, flags, &op);
     if (rc != 0) {
       ldpp_dout(dpp, 0) <<__func__<< ": motr op failed: rc=" << rc << dendl;
-      ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+      ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
            RGW_ADDB_FUNC_READ_MOBJ, RGW_ADDB_PHASE_ERROR);
       goto out;
     }
@@ -2925,7 +2926,7 @@ int MotrObject::read_mobj(const DoutPrefixProvider* dpp, int64_t start, int64_t 
     m0_op_free(op);
     if (rc != 0) {
       ldpp_dout(dpp, 0) <<__func__<< ": m0_op_wait failed: rc=" << rc << dendl;
-      ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+      ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
            RGW_ADDB_FUNC_READ_MOBJ, RGW_ADDB_PHASE_ERROR);
       goto out;
     }
@@ -2947,7 +2948,7 @@ int MotrObject::read_mobj(const DoutPrefixProvider* dpp, int64_t start, int64_t 
     addb_logger.set_id(req_id);
   }
 
-  ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+  ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
        RGW_ADDB_FUNC_READ_MOBJ, RGW_ADDB_PHASE_DONE);
 out:
   m0_indexvec_free(&ext);
@@ -2989,8 +2990,8 @@ int MotrObject::fetch_null_obj_reference(const DoutPrefixProvider *dpp, std::str
     ent_null_ref.decode(iter);
   }
   prev_null_obj_key = ent_null_ref.key.name + '[' + ent_null_ref.key.instance + ']';
-  return rc;
-}
+      return rc;
+  }
 
 int MotrObject::fetch_null_obj(const DoutPrefixProvider *dpp, bufferlist& bl, bool raise_error)
 {
@@ -3059,8 +3060,8 @@ int MotrObject::get_bucket_dir_ent(const DoutPrefixProvider *dpp, rgw_bucket_dir
     // Cache miss.
     rc = this->store->do_idx_op_by_name(bucket_index_iname,
                         M0_IC_GET, this->get_key().to_str(), bl);
-    if(rc < 0) {
-      ldpp_dout(dpp, 0) << __func__ << " ERROR: do_idx_op_by_name failed to get object's entry: rc="
+    if (rc < 0) {
+      ldpp_dout(dpp, 0) <<__func__<< " ERROR: do_idx_op_by_name failed to get object's entry: rc="
                         << rc << dendl;
       return rc;
     }
@@ -3083,12 +3084,12 @@ int MotrObject::get_bucket_dir_ent(const DoutPrefixProvider *dpp, rgw_bucket_dir
     if (rc < 0) {
       ldpp_dout(dpp, 0) << __func__ << "ERROR: NEXT query failed. " << rc << dendl;
       return rc;
-      } 
+    }
     // No key found
-    if(rc == 0){
+    if (rc == 0) {
       ldpp_dout(dpp, 0) << __func__ << "ERROR: Key does not exist. " << rc << dendl;
       return -ENOENT;
-      }
+    }
 
     ldpp_dout(dpp, 20) <<__func__<< ": found current version!" << dendl;
     rc=0;
@@ -3106,9 +3107,9 @@ out:
 
     char fid_str[M0_FID_STR_LEN];
     snprintf(fid_str, ARRAY_SIZE(fid_str), U128X_F, U128_P(&meta.oid));
-    ldpp_dout(dpp, 70) << __func__ << ": oid=" << fid_str << dendl;
+    ldpp_dout(dpp, 70) <<__func__<< ": oid=" << fid_str << dendl;
   } else
-    ldpp_dout(dpp, 0) <<__func__<< ": rc = " << rc << dendl;
+    ldpp_dout(dpp, 0) <<__func__<< ": rc=" << rc << dendl;
 
   return rc;
 }
@@ -3123,16 +3124,16 @@ int MotrObject::update_version_entries(const DoutPrefixProvider *dpp, bool set_i
 
   keys[0] = this->get_name() + "[";
   int rc = store->next_query_by_name(bucket_index_iname, keys, vals);
-  ldpp_dout(dpp, 20) << "get all versions, name = " << this->get_name() << "rc = " << rc << dendl;
+  ldpp_dout(dpp, 20) << "get all versions, name=" << this->get_name() << "rc=" << rc << dendl;
   if (rc < 0) {
-    ldpp_dout(dpp, 0) << __func__ << ": ERROR: NEXT query failed. rc = " << rc << dendl;
+    ldpp_dout(dpp, 0) <<__func__<< ": ERROR: NEXT query failed. rc=" << rc << dendl;
     return rc;
   }
 
   // no entries returned.
   if (rc == 0)
   {
-    ldpp_dout(dpp, 0) <<__func__<<": No entries found, rc = " << rc << dendl;
+    ldpp_dout(dpp, 0) <<__func__<<": No entries found, rc=" << rc << dendl;
     return 0;
   }
   rgw_bucket_dir_entry ent;
@@ -3140,7 +3141,7 @@ int MotrObject::update_version_entries(const DoutPrefixProvider *dpp, bool set_i
   for (; i < rc; ++i) {
     if (vals[i].length() == 0)
       break;
-  
+
     auto iter = vals[i].cbegin();
     ent.decode(iter);
 
@@ -3166,7 +3167,7 @@ int MotrObject::update_version_entries(const DoutPrefixProvider *dpp, bool set_i
     decode(attrs, iter);
     MotrObject::Meta meta;
     meta.decode(iter);
-    
+
     if(set_is_latest)
     {
       // delete-object flow
@@ -3186,9 +3187,9 @@ int MotrObject::update_version_entries(const DoutPrefixProvider *dpp, bool set_i
     string key;
     if (ent.key.instance.empty())
       key = ent.key.name;
-    else 
+    else
       key = keys[i];
-    ldpp_dout(dpp, 20) << "update one version, key = " << key << dendl;
+    ldpp_dout(dpp, 20) << "update one version, key=" << key << dendl;
     bufferlist ent_bl;
     ent.encode(ent_bl);
     encode(attrs, ent_bl);
@@ -3198,6 +3199,7 @@ int MotrObject::update_version_entries(const DoutPrefixProvider *dpp, bool set_i
     if (rc < 0)
       break;
   }
+
   return rc;
 }
 
@@ -3240,7 +3242,7 @@ int MotrObject::get_part_objs(const DoutPrefixProvider* dpp,
       obj = this->bucket->get_object(rgw_obj_key(part_obj_name));
       std::unique_ptr<rgw::sal::MotrObject> mobj(static_cast<rgw::sal::MotrObject *>(obj.release()));
 
-      ldpp_dout(dpp, 20) << __func__ << ": off = " << off << ", size = " << part_size << dendl;
+      ldpp_dout(dpp, 20) <<__func__<< ": off=" << off << ", size=" << part_size << dendl;
       mobj->part_off = off;
       mobj->part_size = part_size;
       mobj->set_obj_size(part_size);
@@ -3262,7 +3264,7 @@ int MotrObject::open_part_objs(const DoutPrefixProvider* dpp,
   //for (auto& iter: part_objs) {
   for (auto iter = part_objs.begin(); iter != part_objs.end(); ++iter) {
     MotrObject* obj = static_cast<MotrObject *>(iter->second.get());
-    ldpp_dout(dpp, 20) << __func__ << ": name = " << obj->get_name() << dendl;
+    ldpp_dout(dpp, 20) <<__func__<< ": name=" << obj->get_name() << dendl;
     int rc = obj->open_mobj(dpp);
     if (rc < 0)
       return rc;
@@ -3286,7 +3288,7 @@ int MotrObject::read_multipart_obj(const DoutPrefixProvider* dpp,
 {
   int64_t cursor = off;
 
-  ldpp_dout(dpp, 20) << __func__ << ": off=" << off << " end=" << end << dendl;
+  ldpp_dout(dpp, 20) <<__func__<< ": off=" << off << " end=" << end << dendl;
 
   // Find the parts which are in the (off, end) range and
   // read data from it. Note: `end` argument is inclusive.
@@ -3295,14 +3297,14 @@ int MotrObject::read_multipart_obj(const DoutPrefixProvider* dpp,
     int64_t part_off = obj->part_off;
     int64_t part_size = obj->part_size;
     int64_t part_end = obj->part_off + obj->part_size - 1;
-    ldpp_dout(dpp, 20) << __func__ << ": part_off=" << part_off
+    ldpp_dout(dpp, 20) <<__func__<< ": part_off=" << part_off
                                           << " part_end=" << part_end << dendl;
     if (part_end < off)
       continue;
 
     int64_t local_off = cursor - obj->part_off;
     int64_t local_end = part_end < end? part_size - 1 : end - part_off;
-    ldpp_dout(dpp, 20) << __func__ << ": name=" << obj->get_name()
+    ldpp_dout(dpp, 20) <<__func__<< ": name=" << obj->get_name()
                                           << " local_off=" << local_off
                                           << " local_end=" << local_end << dendl;
     int rc = obj->read_mobj(dpp, local_off, local_end, cb);
@@ -3403,9 +3405,9 @@ int MotrAtomicWriter::write(bool last)
 
   addb_logger.set_id(req_id);
 
-  ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+  ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
        RGW_ADDB_FUNC_WRITE, RGW_ADDB_PHASE_START);
-  
+
   if (!obj.is_opened()) {
     rc = obj.create_mobj(dpp, left);
     if (rc == -EEXIST)
@@ -3413,9 +3415,9 @@ int MotrAtomicWriter::write(bool last)
     if (rc != 0) {
       char fid_str[M0_FID_STR_LEN];
       snprintf(fid_str, ARRAY_SIZE(fid_str), U128X_F, U128_P(&obj.meta.oid));
-      ldpp_dout(dpp, 0) << __func__ << ": ERROR: failed to create/open motr object "
+      ldpp_dout(dpp, 0) <<__func__<< ": ERROR: failed to create/open motr object "
                         << fid_str << " (" << obj.get_bucket()->get_name()
-                        << "/" << obj.get_key().to_str() << "): rc = " << rc
+                        << "/" << obj.get_key().to_str() << "): rc=" << rc
                         << dendl;
       goto err;
     }
@@ -3451,7 +3453,7 @@ int MotrAtomicWriter::write(bool last)
     rc = m0_obj_op(obj.mobj, M0_OC_WRITE, &ext, &buf, &attr, 0, flags, &op);
     if (rc != 0) {
       ldpp_dout(dpp, 0) <<__func__<< ": write failed, m0_obj_op rc="<< rc << dendl;
-      ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+      ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
            RGW_ADDB_FUNC_WRITE, RGW_ADDB_PHASE_ERROR);
       goto err;
     }
@@ -3486,12 +3488,12 @@ int MotrAtomicWriter::write(bool last)
     acc_data.append(std::move(tmp));
   }
 
-  ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+  ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
        RGW_ADDB_FUNC_WRITE, RGW_ADDB_PHASE_DONE);
   return 0;
 
 err:
-  ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+  ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
        RGW_ADDB_FUNC_WRITE, RGW_ADDB_PHASE_ERROR);
   this->cleanup();
   return rc;
@@ -3574,26 +3576,27 @@ int MotrObject::overwrite_null_obj(const DoutPrefixProvider *dpp)
   }
 
   if (rc == 0 && old_check_bl.length() > 0) {
-      auto ent_iter = old_check_bl.cbegin();
-      old_ent.decode(ent_iter);
-      rgw::sal::Attrs attrs;
-      decode(attrs, ent_iter);
-      this->meta.decode(ent_iter);
-      this->set_instance(std::move(old_ent.key.instance));
-      if (old_ent.meta.category == RGWObjCategory::MultiMeta)
-          obj_type = "multipart object";
-      ldpp_dout(dpp, 20) <<__func__<< ": Old " << obj_type << " exists" << dendl;
+    auto ent_iter = old_check_bl.cbegin();
+    old_ent.decode(ent_iter);
+    rgw::sal::Attrs attrs;
+    decode(attrs, ent_iter);
+    this->meta.decode(ent_iter);
+    this->set_instance(std::move(old_ent.key.instance));
+    if (old_ent.meta.category == RGWObjCategory::MultiMeta)
+      obj_type = "multipart object";
+    ldpp_dout(dpp, 20) <<__func__<< ": Old " << obj_type << " exists" << dendl;
       rc = this->remove_mobj_and_index_entry(
           dpp, old_ent, null_obj_key, bucket_index_iname, tenant_bkt_name);
-      if (rc == 0) {
-          ldpp_dout(dpp, 20) <<__func__<< ": Old " << obj_type << " ["
-            << this->get_name() <<  "] deleted succesfully" << dendl;
-      } else {
-          ldpp_dout(dpp, 0) << __func__<<": Failed to delete old " << obj_type << " ["
-            << this->get_name() <<  "]. Error = " << rc << dendl;
-          // TODO: This will be handled during GC
-      }
+    if (rc == 0) {
+      ldpp_dout(dpp, 20) <<__func__<< ": Old " << obj_type << " ["
+        << this->get_name() <<  "] deleted succesfully" << dendl;
+    } else {
+      ldpp_dout(dpp, 0) << __func__<<": Failed to delete old " << obj_type << " ["
+        << this->get_name() <<  "]. Error=" << rc << dendl;
+      // TODO: This will be handled during GC
     }
+  }
+
   return rc;
 }
 
@@ -3654,7 +3657,7 @@ int MotrAtomicWriter::complete(size_t accounted_size, const std::string& etag,
   if (info.versioned())
     ent.flags = rgw_bucket_dir_entry::FLAG_VER | rgw_bucket_dir_entry::FLAG_CURRENT;
 
-  ldpp_dout(dpp, 20) << __func__ << ": key=" << obj.get_key().to_str() << ", meta:oid=[0x" << std::hex << obj.meta.oid.u_hi
+  ldpp_dout(dpp, 20) <<__func__<< ": key=" << obj.get_key().to_str() << ", meta:oid=[0x" << std::hex << obj.meta.oid.u_hi
                                  << ":0x" << obj.meta.oid.u_lo << "], meta:pvid=[0x" << std::hex << obj.meta.pver.f_container
                                  << ":0x" << obj.meta.pver.f_key << "], meta:layout_id=0x" << std::hex << obj.meta.layout_id
                                  << " etag=" << etag << " user_data=" << user_data << dendl;
@@ -3722,8 +3725,8 @@ int MotrAtomicWriter::complete(size_t accounted_size, const std::string& etag,
   rc = store->do_idx_op_by_name(bucket_index_iname,
                                M0_IC_PUT, obj.get_key().to_str(), bl);
   if (rc != 0) {
-    // TODO: handle this object leak via gc.  
-    ldpp_dout(dpp, 0) << __func__ << ": index operation failed, rc = "<< rc << dendl;
+    // TODO: handle this object leak via gc.
+    ldpp_dout(dpp, 0) <<__func__<< ": index operation failed, rc="<< rc << dendl;
     return rc;
   }
   store->get_obj_meta_cache()->put(dpp, obj.get_key().to_str(), bl);
@@ -3733,12 +3736,12 @@ int MotrAtomicWriter::complete(size_t accounted_size, const std::string& etag,
   rc = update_bucket_stats(dpp, store, owner.to_str(), tenant_bkt_name,
                            total_data_size, size_rounded);
   if (rc != 0) {
-    ldpp_dout(dpp, 20) << __func__ << ": Failed stats additon for the bucket/obj = "
-      << tenant_bkt_name << "/" << obj.get_name() << ", rc = " << rc << dendl;
+    ldpp_dout(dpp, 20) <<__func__<< ": Failed stats additon for the bucket/obj = "
+      << tenant_bkt_name << "/" << obj.get_name() << ", rc=" << rc << dendl;
     return rc;
   }
-  ldpp_dout(dpp, 70) << __func__ << ": Stats added successfully for the bucket/obj = "
-    << tenant_bkt_name << "/" << obj.get_name() << ", rc = " << rc << dendl;
+  ldpp_dout(dpp, 70) <<__func__<< ": Stats added successfully for the bucket/obj = "
+    << tenant_bkt_name << "/" << obj.get_name() << ", rc=" << rc << dendl;
 
   // TODO: We need to handle the object leak caused by parallel object upload by
   // making use of background gc, which is currently not enabled for motr.
@@ -3787,7 +3790,7 @@ int MotrMultipartUpload::delete_parts(const DoutPrefixProvider *dpp, std::string
       mobj->meta = mmpart->meta;
       rc = mobj->delete_mobj(dpp);
       if (rc < 0) {
-        ldpp_dout(dpp, 0) << __func__ << ": failed to delete object from Motr. rc = " << rc << dendl;
+        ldpp_dout(dpp, 0) <<__func__<< ": failed to delete object from Motr. rc=" << rc << dendl;
         return rc;
       }
     }
@@ -3797,7 +3800,7 @@ int MotrMultipartUpload::delete_parts(const DoutPrefixProvider *dpp, std::string
   string upload_id = get_upload_id();
   string key_name;
 
-  if (upload_id.length() == 0){
+  if (upload_id.length() == 0) {
     std::unique_ptr<rgw::sal::Object> obj_ver = this->bucket->get_object(rgw_obj_key(this->get_key()));
     rgw::sal::MotrObject *mobj_ver = static_cast<rgw::sal::MotrObject *>(obj_ver.get());
     RGWBucketInfo &info = this->bucket->get_info();
@@ -3816,7 +3819,7 @@ int MotrMultipartUpload::delete_parts(const DoutPrefixProvider *dpp, std::string
 
     rc = store->get_upload_id(tenant_bkt_name, key_name, upload_id);
     if (rc < 0) {
-      ldpp_dout(dpp, 0) << __func__ << ": ERROR: get_upload_id failed. rc = " << rc << dendl;
+      ldpp_dout(dpp, 0) <<__func__<< ": ERROR: get_upload_id failed. rc=" << rc << dendl;
       return rc;
     }
   }
@@ -3829,18 +3832,18 @@ int MotrMultipartUpload::delete_parts(const DoutPrefixProvider *dpp, std::string
                              bucket->get_owner()->get_id().to_str(), tenant_bkt_name,
                              total_size, total_size_rounded, total_parts_fetched, false);
     if (rc != 0) {
-      ldpp_dout(dpp, 20) << __func__ << ": Failed stats substraction for the "
-        << "bucket/obj = " << tenant_bkt_name << "/" << mp_obj.get_key()
-        << ", rc = " << rc << dendl;
+      ldpp_dout(dpp, 20) <<__func__<< ": Failed stats substraction for the "
+        << "bucket/obj=" << tenant_bkt_name << "/" << mp_obj.get_key()
+        << ", rc=" << rc << dendl;
       return rc;
     }
-    ldpp_dout(dpp, 70) << __func__ << ": Stats subtracted successfully for the "
-        << "bucket/obj = " << tenant_bkt_name << "/" << mp_obj.get_key()
-        << ", rc = " << rc << dendl;
+    ldpp_dout(dpp, 70) <<__func__<< ": Stats subtracted successfully for the "
+        << "bucket/obj=" << tenant_bkt_name << "/" << mp_obj.get_key()
+        << ", rc=" << rc << dendl;
   }
 
   // Delete object part index.
-  string obj_part_iname = "motr.rgw.object." + tenant_bkt_name + "." + mp_obj.get_key() + 
+  string obj_part_iname = "motr.rgw.object." + tenant_bkt_name + "." + mp_obj.get_key() +
                           "." + upload_id + ".parts";
   return store->delete_motr_idx_by_name(obj_part_iname);
 }
@@ -3859,7 +3862,7 @@ int MotrMultipartUpload::abort(const DoutPrefixProvider *dpp, CephContext *cct,
   rc = store->do_idx_op_by_name(bucket_multipart_iname,
                                   M0_IC_GET, meta_obj->get_key().to_str(), bl);
   if (rc < 0) {
-    ldpp_dout(dpp, 0) << __func__ << ": failed to get multipart upload. rc = " << rc << dendl;
+    ldpp_dout(dpp, 0) <<__func__<< ": failed to get multipart upload. rc=" << rc << dendl;
     return rc == -ENOENT ? -ERR_NO_SUCH_UPLOAD : rc;
   }
 
@@ -3873,7 +3876,7 @@ int MotrMultipartUpload::abort(const DoutPrefixProvider *dpp, CephContext *cct,
   rc = store->do_idx_op_by_name(bucket_multipart_iname,
                                   M0_IC_DEL, meta_obj->get_key().to_str(), bl);
   if (rc != 0) {
-    ldpp_dout(dpp, 0) <<__func__<< ": WARNING:  index opration failed, M0_IC_DEL rc = "<< rc << dendl;
+    ldpp_dout(dpp, 0) <<__func__<< ": WARNING:  index opration failed, M0_IC_DEL rc="<< rc << dendl;
   }
   return rc;
 }
@@ -3980,7 +3983,7 @@ int MotrMultipartUpload::init(const DoutPrefixProvider *dpp, optional_yield y,
   } while (rc == -EEXIST);
 
   if (rc < 0) {
-    ldpp_dout(dpp, 0) <<__func__<< ": index opration failed, M0_IC_PUT rc = "<< rc << dendl;
+    ldpp_dout(dpp, 0) <<__func__<< ": index opration failed, M0_IC_PUT rc="<< rc << dendl;
     return rc;
   }
   string tenant_bkt_name = get_bucket_name(bucket->get_tenant(), bucket->get_name());
@@ -3990,7 +3993,7 @@ int MotrMultipartUpload::init(const DoutPrefixProvider *dpp, optional_yield y,
   // Create object part index.
   string obj_part_iname = "motr.rgw.object." + tenant_bkt_name + "." + mp_obj.get_key() +
                           "." + upload_id + ".parts";
-  ldpp_dout(dpp, 20) << __func__ << ": object part index=" << obj_part_iname << dendl;
+  ldpp_dout(dpp, 20) <<__func__<< ": object part index=" << obj_part_iname << dendl;
   rc = store->create_motr_idx_by_name(obj_part_iname);
   if (rc == -EEXIST)
     rc = 0;
@@ -4035,21 +4038,21 @@ int MotrMultipartUpload::list_parts(const DoutPrefixProvider *dpp, CephContext *
       if(ent.key.instance == "null") {
         ret_rc = mobj_ver->fetch_null_obj_reference(dpp, key_name);
         if(ret_rc < 0) {
-          ldpp_dout(dpp, 0) << __func__ << " : failed to get null object reference, ret_rc : "<< ret_rc << dendl;
+          ldpp_dout(dpp, 0) <<__func__<< " : failed to get null object reference, ret_rc : "<< ret_rc << dendl;
           return ret_rc;
         }
       }
       rc = store->get_upload_id(tenant_bkt_name, key_name, upload_id);
       if (rc < 0) {
-        ldpp_dout(dpp, 0) << __func__ << ": ERROR: get_upload_id failed. rc = " << rc << dendl;
+        ldpp_dout(dpp, 0) <<__func__<< ": ERROR: get_upload_id failed. rc=" << rc << dendl;
         return rc;
       }
     }
   }
 
-  string obj_part_iname = "motr.rgw.object." + tenant_bkt_name + "." + mp_obj.get_key() + 
+  string obj_part_iname = "motr.rgw.object." + tenant_bkt_name + "." + mp_obj.get_key() +
                           "." + upload_id + ".parts";
-  ldpp_dout(dpp, 20) << __func__ << ": object part index = " << obj_part_iname << dendl;
+  ldpp_dout(dpp, 20) <<__func__<< ": object part index=" << obj_part_iname << dendl;
   key_vec[0].clear();
   key_vec[0] = "part.";
   char buf[32];
@@ -4057,13 +4060,13 @@ int MotrMultipartUpload::list_parts(const DoutPrefixProvider *dpp, CephContext *
   key_vec[0].append(buf);
   rc = store->next_query_by_name(obj_part_iname, key_vec, val_vec);
   if (rc < 0) {
-    ldpp_dout(dpp, 0) << __func__ << ": ERROR: NEXT query failed. rc = " << rc << dendl;
+    ldpp_dout(dpp, 0) <<__func__<< ": ERROR: NEXT query failed. rc=" << rc << dendl;
     return rc;
   }
 
   int last_num = 0;
   int part_cnt = 0;
-  ldpp_dout(dpp, 20) << __func__ << ": marker = " << marker << dendl;
+  ldpp_dout(dpp, 20) <<__func__<< ": marker=" << marker << dendl;
   parts.clear();
 
   for (const auto& bl: val_vec) {
@@ -4078,9 +4081,9 @@ int MotrMultipartUpload::list_parts(const DoutPrefixProvider *dpp, CephContext *
     MotrObject::Meta meta;
     meta.decode(iter);
 
-    ldpp_dout(dpp, 20) << __func__ << ": part_num=" << info.num
+    ldpp_dout(dpp, 20) <<__func__<< ": part_num=" << info.num
                                              << " part_size=" << info.size << dendl;
-    ldpp_dout(dpp, 20) << __func__ << ": key=" << mp_obj.get_key() << ", meta:oid=[0x" << std::hex << meta.oid.u_hi
+    ldpp_dout(dpp, 20) <<__func__<< ": key=" << mp_obj.get_key() << ", meta:oid=[0x" << std::hex << meta.oid.u_hi
                                    << ":0x" << std::hex << meta.oid.u_lo << "], meta:pvid=[0x" << std::hex
                                    << meta.pver.f_container << ":0x" << std::hex << meta.pver.f_key
                                    << "], meta:layout_id=0x" << std::hex << meta.layout_id << dendl;
@@ -4096,7 +4099,7 @@ int MotrMultipartUpload::list_parts(const DoutPrefixProvider *dpp, CephContext *
   // Does it have more parts?
   if (truncated)
     *truncated = part_cnt < num_parts? false : true;
-  ldpp_dout(dpp, 20) << __func__ << ": truncated=" << *truncated << dendl;
+  ldpp_dout(dpp, 20) <<__func__<< ": truncated=" << *truncated << dendl;
 
   if (next_marker)
     *next_marker = last_num;
@@ -4126,7 +4129,7 @@ int MotrMultipartUpload::complete(const DoutPrefixProvider *dpp,
   bool truncated;
   int rc;
 
-  ldpp_dout(dpp, 20) << __func__ << ": enter" << dendl;
+  ldpp_dout(dpp, 20) <<__func__<< ": enter" << dendl;
   int total_parts = 0;
   int handled_parts = 0;
   int max_parts = 1000;
@@ -4136,7 +4139,7 @@ int MotrMultipartUpload::complete(const DoutPrefixProvider *dpp,
   rgw::sal::Attrs &attrs = target_obj->get_attrs();
 
   do {
-    ldpp_dout(dpp, 20) <<  __func__ << ": list_parts()" << dendl;
+    ldpp_dout(dpp, 20) << __func__<< ": list_parts()" << dendl;
     rc = list_parts(dpp, cct, max_parts, marker, &marker, &truncated);
     if (rc == -ENOENT) {
       rc = -ERR_NO_SUCH_UPLOAD;
@@ -4146,12 +4149,12 @@ int MotrMultipartUpload::complete(const DoutPrefixProvider *dpp,
 
     total_parts += parts.size();
     if (!truncated && total_parts != (int)part_etags.size()) {
-      ldpp_dout(dpp, 0) << __func__ << ": ERROR: total parts mismatch: have: " << total_parts
+      ldpp_dout(dpp, 0) <<__func__<< ": ERROR: total parts mismatch: have: " << total_parts
                         << " expected: " << part_etags.size() << dendl;
       rc = -ERR_INVALID_PART;
       return rc;
     }
-    ldpp_dout(dpp, 20) <<  __func__ << ": parts.size()=" << parts.size() << dendl;
+    ldpp_dout(dpp, 20) << __func__<< ": parts.size()=" << parts.size() << dendl;
 
     for (auto obj_iter = parts.begin();
         etags_iter != part_etags.end() && obj_iter != parts.end();
@@ -4161,7 +4164,7 @@ int MotrMultipartUpload::complete(const DoutPrefixProvider *dpp,
       RGWUploadPartInfo *part = &mmpart->info;
 
       uint64_t part_size = part->accounted_size;
-      ldpp_dout(dpp, 20) << __func__ << ":  part_size=" << part_size << dendl;
+      ldpp_dout(dpp, 20) <<__func__<< ":  part_size=" << part_size << dendl;
       if (handled_parts < (int)part_etags.size() - 1 &&
           part_size < min_part_size) {
         rc = -ERR_TOO_SMALL;
@@ -4170,7 +4173,7 @@ int MotrMultipartUpload::complete(const DoutPrefixProvider *dpp,
 
       char petag[CEPH_CRYPTO_MD5_DIGESTSIZE];
       if (etags_iter->first != (int)obj_iter->first) {
-        ldpp_dout(dpp, 0) << __func__ << ": ERROR: parts num mismatch: next requested: "
+        ldpp_dout(dpp, 0) <<__func__<< ": ERROR: parts num mismatch: next requested: "
                           << etags_iter->first << " next uploaded: "
                           << obj_iter->first << dendl;
         rc = -ERR_INVALID_PART;
@@ -4178,7 +4181,7 @@ int MotrMultipartUpload::complete(const DoutPrefixProvider *dpp,
       }
       string part_etag = rgw_string_unquote(etags_iter->second);
       if (part_etag.compare(part->etag) != 0) {
-        ldpp_dout(dpp, 0) << __func__ << ": ERROR: etag mismatch: part: " << etags_iter->first
+        ldpp_dout(dpp, 0) <<__func__<< ": ERROR: etag mismatch: part: " << etags_iter->first
                           << " etag: " << etags_iter->second << dendl;
         rc = -ERR_INVALID_PART;
         return rc;
@@ -4186,7 +4189,7 @@ int MotrMultipartUpload::complete(const DoutPrefixProvider *dpp,
 
       hex_to_buf(part->etag.c_str(), petag, CEPH_CRYPTO_MD5_DIGESTSIZE);
       hash.Update((const unsigned char *)petag, sizeof(petag));
-      ldpp_dout(dpp, 20) << __func__ << ": calc etag " << dendl;
+      ldpp_dout(dpp, 20) <<__func__<< ": calc etag " << dendl;
 
       string oid = mp_obj.get_part(part->num);
       rgw_obj src_obj;
@@ -4195,27 +4198,27 @@ int MotrMultipartUpload::complete(const DoutPrefixProvider *dpp,
 #if 0 // does Motr backend need it?
       /* update manifest for part */
       if (part->manifest.empty()) {
-        ldpp_dout(dpp, 0) << __func__ << ": ERROR: empty manifest for object part: obj="
+        ldpp_dout(dpp, 0) <<__func__<< ": ERROR: empty manifest for object part: obj="
 			 << src_obj << dendl;
         rc = -ERR_INVALID_PART;
         return rc;
       } else {
         manifest.append(dpp, part->manifest, store->get_zone());
       }
-      ldpp_dout(dpp, 0) << __func__ << ": manifest " << dendl;
+      ldpp_dout(dpp, 0) <<__func__<< ": manifest " << dendl;
 #endif
 
       bool part_compressed = (part->cs_info.compression_type != "none");
       if ((handled_parts > 0) &&
           ((part_compressed != compressed) ||
             (cs_info.compression_type != part->cs_info.compression_type))) {
-          ldpp_dout(dpp, 0) << __func__ << ": ERROR: compression type was changed during multipart upload ("
+          ldpp_dout(dpp, 0) <<__func__<< ": ERROR: compression type was changed during multipart upload ("
                            << cs_info.compression_type << ">>" << part->cs_info.compression_type << ")" << dendl;
           rc = -ERR_INVALID_PART;
           return rc;
       }
 
-      ldpp_dout(dpp, 20) << __func__ << ": part compression" << dendl;
+      ldpp_dout(dpp, 20) <<__func__<< ": part compression" << dendl;
       if (part_compressed) {
         int64_t new_ofs; // offset in compression data for new part
         if (cs_info.blocks.size() > 0)
@@ -4246,7 +4249,7 @@ int MotrMultipartUpload::complete(const DoutPrefixProvider *dpp,
 
       off += part_size;
       accounted_size += part->accounted_size;
-      ldpp_dout(dpp, 20) << __func__ << ": off=" << off << ", accounted_size = " << accounted_size << dendl;
+      ldpp_dout(dpp, 20) <<__func__<< ": off=" << off << ", accounted_size=" << accounted_size << dendl;
     }
   } while (truncated);
   hash.Final((unsigned char *)final_etag);
@@ -4256,7 +4259,7 @@ int MotrMultipartUpload::complete(const DoutPrefixProvider *dpp,
 	   sizeof(final_etag_str) - CEPH_CRYPTO_MD5_DIGESTSIZE * 2,
            "-%lld", (long long)part_etags.size());
   etag = final_etag_str;
-  ldpp_dout(dpp, 20) << __func__ << ": calculated etag: " << etag << dendl;
+  ldpp_dout(dpp, 20) <<__func__<< ": calculated etag: " << etag << dendl;
   etag_bl.append(etag);
   attrs[RGW_ATTR_ETAG] = etag_bl;
 
@@ -4278,7 +4281,7 @@ int MotrMultipartUpload::complete(const DoutPrefixProvider *dpp,
       "motr.rgw.bucket." + tenant_bkt_name + ".multiparts";
   rc = this->store->do_idx_op_by_name(bucket_multipart_iname,
                                       M0_IC_GET, meta_obj->get_key().to_str(), bl);
-  ldpp_dout(dpp, 20) << __func__ << ": read entry from bucket multipart index rc = " << rc << dendl;
+  ldpp_dout(dpp, 20) <<__func__<< ": read entry from bucket multipart index rc=" << rc << dendl;
   if (rc < 0) {
     return rc == -ENOENT ? -ERR_NO_SUCH_UPLOAD : rc;
   }
@@ -4299,7 +4302,7 @@ int MotrMultipartUpload::complete(const DoutPrefixProvider *dpp,
   target_obj->get_key().get_index_key(&ent.key);  // Change to offical name :)
   ent.meta.size = off;
   ent.meta.accounted_size = accounted_size;
-  ldpp_dout(dpp, 20) << __func__ << ": obj size=" << ent.meta.size
+  ldpp_dout(dpp, 20) <<__func__<< ": obj size=" << ent.meta.size
                            << " obj accounted size=" << ent.meta.accounted_size << dendl;
   ent.meta.mtime = ceph::real_clock::now();
   ent.meta.etag = etag;
@@ -4317,12 +4320,12 @@ int MotrMultipartUpload::complete(const DoutPrefixProvider *dpp,
   meta_dummy.encode(update_bl);
 
   string bucket_index_iname = "motr.rgw.bucket.index." + tenant_bkt_name;
-  ldpp_dout(dpp, 20) << __func__ << ": target_obj name=" << target_obj->get_name()
+  ldpp_dout(dpp, 20) <<__func__<< ": target_obj name=" << target_obj->get_name()
                                   << " target_obj oid=" << target_obj->get_oid() << dendl;
 
   std::unique_ptr<rgw::sal::Object> obj_ver = target_obj->get_bucket()->get_object(rgw_obj_key(target_obj->get_name()));
   rgw::sal::MotrObject *mobj_ver = static_cast<rgw::sal::MotrObject *>(obj_ver.get());
-  
+
   // Check for bucket versioning
   // Update existing object version entries in a bucket,
   // in case of both versioning enabled and suspended.
@@ -4331,7 +4334,7 @@ int MotrMultipartUpload::complete(const DoutPrefixProvider *dpp,
     string bucket_index_iname = "motr.rgw.bucket.index." + tenant_bkt_name;
 
     rc = mobj_ver->update_version_entries(dpp);
-    ldpp_dout(dpp, 20) << __func__ << ": update_version_entries, rc = " << rc << dendl;
+    ldpp_dout(dpp, 20) <<__func__<< ": update_version_entries, rc=" << rc << dendl;
     if (rc < 0)
       return rc;
   }
@@ -4355,28 +4358,28 @@ int MotrMultipartUpload::complete(const DoutPrefixProvider *dpp,
   rc = store->do_idx_op_by_name(bucket_index_iname, M0_IC_PUT,
                                 target_obj->get_key().to_str(), update_bl);
   if (rc < 0) {
-    ldpp_dout(dpp, 0) << __func__ << ": index operation failed, M0_IC_PUT rc = " << rc << dendl;
+    ldpp_dout(dpp, 0) <<__func__<< ": index operation failed, M0_IC_PUT rc=" << rc << dendl;
     return rc;
   }
-  
+
   // Increment size & count for new multipart obj in bucket stats entry.
   std::string bkt_owner = target_obj->get_bucket()->get_owner()->get_id().to_str();
   rc = update_bucket_stats(dpp, store, bkt_owner, tenant_bkt_name,
                            0, 0, total_parts - 1, false);
   if (rc != 0) {
-    ldpp_dout(dpp, 20) << __func__ << ": Failed stats update for the "
-      << "bucket/obj = " << tenant_bkt_name << "/" << target_obj->get_key().to_str()
-      << ", rc = " << rc << dendl;
+    ldpp_dout(dpp, 20) <<__func__<< ": Failed stats update for the "
+      << "bucket/obj=" << tenant_bkt_name << "/" << target_obj->get_key().to_str()
+      << ", rc=" << rc << dendl;
     return rc;
   }
-  ldpp_dout(dpp, 70) << __func__ << ": Updated stats successfully for the "
-      << "bucket/obj = " << tenant_bkt_name << "/" << target_obj->get_key().to_str()
-      << ", rc = " << rc << dendl;
+  ldpp_dout(dpp, 70) <<__func__<< ": Updated stats successfully for the "
+      << "bucket/obj=" << tenant_bkt_name << "/" << target_obj->get_key().to_str()
+      << ", rc=" << rc << dendl;
 
   // Put into metadata cache.
   store->get_obj_meta_cache()->put(dpp, target_obj->get_key().to_str(), update_bl);
 
-  ldpp_dout(dpp, 20) << __func__ << ": remove from bucket multipart index " << dendl;
+  ldpp_dout(dpp, 20) <<__func__<< ": remove from bucket multipart index " << dendl;
   return store->do_idx_op_by_name(bucket_multipart_iname,
                                   M0_IC_DEL, meta_obj->get_key().to_str(), bl);
 }
@@ -4411,7 +4414,7 @@ int MotrMultipartUpload::get_info(const DoutPrefixProvider *dpp, optional_yield 
   int rc = this->store->do_idx_op_by_name(bucket_multipart_iname,
                                           M0_IC_GET, meta_obj->get_key().to_str(), bl);
   if (rc < 0) {
-    ldpp_dout(dpp, 0) << __func__ << ": Failed to get multipart info. rc = " << rc << dendl;
+    ldpp_dout(dpp, 0) <<__func__<< ": Failed to get multipart info. rc=" << rc << dendl;
     return rc == -ENOENT ? -ERR_NO_SUCH_UPLOAD : rc;
   }
 
@@ -4423,7 +4426,7 @@ int MotrMultipartUpload::get_info(const DoutPrefixProvider *dpp, optional_yield 
   if (attrs) {
     bufferlist etag_bl;
     string& etag = ent.meta.etag;
-    ldpp_dout(dpp, 20) << __func__ << ": object's etag:  " << ent.meta.etag << dendl;
+    ldpp_dout(dpp, 20) <<__func__<< ": object's etag:  " << ent.meta.etag << dendl;
     etag_bl.append(etag.c_str(), etag.size());
     attrs->emplace(std::move(RGW_ATTR_ETAG), std::move(etag_bl));
     if (!rule || *rule != nullptr) {
@@ -4463,7 +4466,7 @@ int MotrMultipartWriter::prepare(optional_yield y)
   string part_obj_name = head_obj->get_bucket()->get_name() + "." +
                          head_obj->get_key().to_str() +
                          ".part." + std::to_string(part_num);
-  ldpp_dout(dpp, 20) << __func__ << ": bucket=" << head_obj->get_bucket()->get_name()
+  ldpp_dout(dpp, 20) <<__func__<< ": bucket=" << head_obj->get_bucket()->get_name()
                      << "part_obj_name=" << part_obj_name << dendl;
   part_obj = std::make_unique<MotrObject>(this->store, rgw_obj_key(part_obj_name), head_obj->get_bucket());
   if (part_obj == nullptr)
@@ -4471,7 +4474,7 @@ int MotrMultipartWriter::prepare(optional_yield y)
 
   // s3 client may retry uploading part, so the part may have already
   // been created.
-  ldpp_dout(dpp, 20) << __func__ << ": creating object for size =" << expected_part_size << dendl;
+  ldpp_dout(dpp, 20) <<__func__<< ": creating object for size=" << expected_part_size << dendl;
   int rc = part_obj->create_mobj(dpp, expected_part_size);
   if (rc == -EEXIST) {
     rc = part_obj->open_mobj(dpp);
@@ -4486,7 +4489,7 @@ int MotrMultipartWriter::process(bufferlist&& data, uint64_t offset)
   int rc = part_obj->write_mobj(dpp, std::move(data), offset);
   if (rc == 0) {
     actual_part_size = part_obj->get_processed_bytes();
-    ldpp_dout(dpp, 20) << __func__ << ": actual_part_size=" << actual_part_size << dendl;
+    ldpp_dout(dpp, 20) <<__func__<< ": actual_part_size=" << actual_part_size << dendl;
   }
   return rc;
 }
@@ -4503,7 +4506,7 @@ int MotrMultipartWriter::complete(size_t accounted_size, const std::string& etag
   // Should the dir entry(object metadata) be updated? For example
   // mtime.
 
-  ldpp_dout(dpp, 20) << __func__ << ": enter" << dendl;
+  ldpp_dout(dpp, 20) <<__func__<< ": enter" << dendl;
   // Add an entry into object_nnn_part_index.
   bufferlist bl;
   RGWUploadPartInfo info;
@@ -4511,7 +4514,7 @@ int MotrMultipartWriter::complete(size_t accounted_size, const std::string& etag
   info.etag = etag;
   info.size = actual_part_size;
   uint64_t size_rounded = 0;
-  //For 0kb Object layout_id will not be available. 
+  //For 0kb Object layout_id will not be available.
   if(info.size != 0)
   {
     uint64_t lid = M0_OBJ_LAYOUT_ID(part_obj->meta.layout_id);
@@ -4526,9 +4529,9 @@ int MotrMultipartWriter::complete(size_t accounted_size, const std::string& etag
 
   bool compressed;
   int rc = rgw_compression_info_from_attrset(attrs, compressed, info.cs_info);
-  ldpp_dout(dpp, 20) << __func__ << ": compression rc = " << rc << dendl;
+  ldpp_dout(dpp, 20) <<__func__<< ": compression rc=" << rc << dendl;
   if (rc < 0) {
-    ldpp_dout(dpp, 1) << __func__ <<": cannot get compression info" << dendl;
+    ldpp_dout(dpp, 1) <<__func__<<": cannot get compression info" << dendl;
     return rc;
   }
   encode(info, bl);
@@ -4544,7 +4547,7 @@ int MotrMultipartWriter::complete(size_t accounted_size, const std::string& etag
   string upload_id_str = upload_id;
   string obj_part_iname = "motr.rgw.object." + tenant_bkt_name + "." +
 	                  head_obj->get_key().to_str() + "." + upload_id_str + ".parts";
-  ldpp_dout(dpp, 20) << __func__ << ": object part index = " << obj_part_iname << dendl;
+  ldpp_dout(dpp, 20) <<__func__<< ": object part index=" << obj_part_iname << dendl;
 
   // Before updating object part index with entry for new part, check if
   // old part exists. Perform M0_IC_GET operation on object part index.
@@ -4569,23 +4572,23 @@ int MotrMultipartWriter::complete(size_t accounted_size, const std::string& etag
     char oid_str[M0_FID_STR_LEN];
     snprintf(oid_str, ARRAY_SIZE(oid_str), U128X_F, U128_P(&old_part_obj->meta.oid));
     rgw::sal::MotrObject *old_mobj = static_cast<rgw::sal::MotrObject *>(old_part_obj.get());
-    ldpp_dout(dpp, 20) << __func__ << ": Old part with oid [" << oid_str << "] exists" << dendl;
+    ldpp_dout(dpp, 20) <<__func__<< ": Old part with oid [" << oid_str << "] exists" << dendl;
     old_part_size = old_part_info.accounted_size;
     old_part_size_rounded = old_part_info.size_rounded;
     old_part_exist = true;
     // Delete old object
     rc = old_mobj->delete_mobj(dpp);
     if (rc == 0) {
-      ldpp_dout(dpp, 20) << __func__ << ": Old part [" << p <<  "] deleted succesfully" << dendl;
+      ldpp_dout(dpp, 20) <<__func__<< ": Old part [" << p <<  "] deleted succesfully" << dendl;
     } else {
-      ldpp_dout(dpp, 0) << __func__ << ": Failed to delete old part [" << p <<  "]. Error = " << rc << dendl;
+      ldpp_dout(dpp, 0) <<__func__<< ": Failed to delete old part [" << p <<  "]. Error=" << rc << dendl;
       return rc;
     }
   }
 
   rc = store->do_idx_op_by_name(obj_part_iname, M0_IC_PUT, p, bl);
   if (rc < 0) {
-    ldpp_dout(dpp, 0) << __func__ << ": failed to add part obj in part index, rc = " << rc << dendl;
+    ldpp_dout(dpp, 0) <<__func__<< ": failed to add part obj in part index, rc=" << rc << dendl;
     return rc == -ENOENT ? -ERR_NO_SUCH_UPLOAD : rc;
   }
 
@@ -4596,14 +4599,14 @@ int MotrMultipartWriter::complete(size_t accounted_size, const std::string& etag
                            size_rounded - old_part_size_rounded,
                            1 - old_part_exist);
   if (rc != 0) {
-    ldpp_dout(dpp, 20) << __func__ << ": Failed stats update for the "
-      << "obj/part = " << head_obj->get_key().to_str() << "/" << part_num
-      << ", rc = " << rc << dendl;
+    ldpp_dout(dpp, 20) <<__func__<< ": Failed stats update for the "
+      << "obj/part=" << head_obj->get_key().to_str() << "/" << part_num
+      << ", rc=" << rc << dendl;
     return rc;
   }
-  ldpp_dout(dpp, 70) << __func__ << ": Updated stats successfully for the "
-      << "obj/part = " << head_obj->get_key().to_str() << "/" << part_num
-      << ", rc = " << rc << dendl;
+  ldpp_dout(dpp, 70) <<__func__<< ": Updated stats successfully for the "
+      << "obj/part=" << head_obj->get_key().to_str() << "/" << part_num
+      << ", rc=" << rc << dendl;
 
   return 0;
 }
@@ -4617,7 +4620,7 @@ int MotrStore::get_upload_id(string tenant_bkt_name, string key_name, string& up
   rc = this->do_idx_op_by_name(index_name,
                               M0_IC_GET, key_name, bl);
   if (rc < 0) {
-    //ldpp_dout(cctx, 0) << "ERROR: NEXT query failed. " << rc << dendl;
+    //ldpp_dout(cctx, 0) << "ERROR: NEXT query failed." << rc << dendl;
     return rc;
   }
 
@@ -4709,7 +4712,7 @@ std::unique_ptr<Writer> MotrStore::get_atomic_writer(const DoutPrefixProvider *d
 
 std::unique_ptr<User> MotrStore::get_user(const rgw_user &u)
 {
-  ldout(cctx, 20) << __func__ << ": bucket's user:  " << u.to_str() << dendl;
+  ldout(cctx, 20) <<__func__<< ": bucket's user:  " << u.to_str() << dendl;
   return std::make_unique<MotrUser>(this, u);
 }
 
@@ -4724,7 +4727,7 @@ int MotrStore::get_user_by_access_key(const DoutPrefixProvider *dpp, const std::
   rc = do_idx_op_by_name(RGW_IAM_MOTR_ACCESS_KEY,
                            M0_IC_GET, key, bl);
   if (rc < 0){
-    ldout(cctx, 0) << __func__ << ": access key not found: rc = " << rc << dendl;
+    ldout(cctx, 0) <<__func__<< ": access key not found: rc=" << rc << dendl;
     return rc;
   }
 
@@ -4733,10 +4736,10 @@ int MotrStore::get_user_by_access_key(const DoutPrefixProvider *dpp, const std::
   access_key.decode(iter);
 
   uinfo.user_id.from_str(access_key.user_id);
-  ldout(cctx, 0) << __func__ << ": loading user: " << uinfo.user_id.id << dendl;
+  ldout(cctx, 0) <<__func__<< ": loading user: " << uinfo.user_id.id << dendl;
   rc = MotrUser().load_user_from_idx(dpp, this, uinfo, nullptr, nullptr);
   if (rc < 0){
-    ldout(cctx, 0) << __func__ << ": failed to load user: rc = " << rc << dendl;
+    ldout(cctx, 0) <<__func__<< ": failed to load user: rc=" << rc << dendl;
     return rc;
   }
   u = new MotrUser(this, uinfo);
@@ -4753,27 +4756,27 @@ int MotrStore::get_user_by_email(const DoutPrefixProvider *dpp, const std::strin
   User *u;
   bufferlist bl;
   RGWUserInfo uinfo;
-  MotrEmailInfo email_info; 
+  MotrEmailInfo email_info;
   rc = do_idx_op_by_name(RGW_IAM_MOTR_EMAIL_KEY,
                            M0_IC_GET, email, bl);
   if (rc < 0){
-    ldout(cctx, 0) << __func__ << ": email Id not found: rc = " << rc << dendl;
+    ldout(cctx, 0) <<__func__<< ": email Id not found: rc=" << rc << dendl;
     return rc;
   }
   auto iter = bl.cbegin();
   email_info.decode(iter);
-  ldout(cctx, 0) << __func__ << ": loading user: " << email_info.user_id << dendl;
+  ldout(cctx, 0) <<__func__<< ": loading user: " << email_info.user_id << dendl;
   uinfo.user_id.from_str(email_info.user_id);
   rc = MotrUser().load_user_from_idx(dpp, this, uinfo, nullptr, nullptr);
   if (rc < 0){
-    ldout(cctx, 0) << __func__ << ": failed to load user: rc = " << rc << dendl;
+    ldout(cctx, 0) <<__func__<< ": failed to load user: rc=" << rc << dendl;
     return rc;
   }
   u = new MotrUser(this, uinfo);
   if (!u)
     return -ENOMEM;
 
-  user->reset(u);  
+  user->reset(u);
   return 0;
 }
 
@@ -4791,7 +4794,7 @@ int MotrStore::store_access_key(const DoutPrefixProvider *dpp, optional_yield y,
   rc = do_idx_op_by_name(RGW_IAM_MOTR_ACCESS_KEY,
                                 M0_IC_PUT, access_key.id, bl);
   if (rc < 0){
-    ldout(cctx, 0) << __func__ << ": failed to store key: rc = " << rc << dendl;
+    ldout(cctx, 0) <<__func__<< ": failed to store key: rc=" << rc << dendl;
     return rc;
   }
   return rc;
@@ -4804,7 +4807,7 @@ int MotrStore::delete_access_key(const DoutPrefixProvider *dpp, optional_yield y
   rc = do_idx_op_by_name(RGW_IAM_MOTR_ACCESS_KEY,
                                 M0_IC_DEL, access_key, bl);
   if (rc < 0){
-    ldout(cctx, 0) << __func__ << ": failed to delete key: rc = " << rc << dendl;
+    ldout(cctx, 0) <<__func__<< ": failed to delete key: rc=" << rc << dendl;
   }
   return rc;
 }
@@ -4817,8 +4820,8 @@ int MotrStore::store_email_info(const DoutPrefixProvider *dpp, optional_yield y,
   rc = do_idx_op_by_name(RGW_IAM_MOTR_EMAIL_KEY,
                                 M0_IC_PUT, email_info.email_id, bl);
   if (rc < 0) {
-    ldout(cctx, 0) << __func__ << ": failed to store the user by email as key: rc = " << rc << dendl;
-  } 
+    ldout(cctx, 0) <<__func__<< ": failed to store the user by email as key: rc=" << rc << dendl;
+  }
   return rc;
 }
 
@@ -5013,16 +5016,16 @@ int MotrStore::list_users(const DoutPrefixProvider* dpp, const std::string& meta
   int rc;
   bufferlist bl;
   if (max_entries <= 0 or max_entries > 1000) {
-    max_entries = 1000; 
+    max_entries = 1000;
   }
   vector<string> keys(max_entries + 1);
   vector<bufferlist> vals(max_entries + 1);
-  
+
   if(!(marker.empty())){
     rc = do_idx_op_by_name(RGW_MOTR_USERS_IDX_NAME,
                                   M0_IC_GET, marker, bl);
     if (rc < 0) {
-      ldpp_dout(dpp, 0) << "ERROR: Invalid marker. " << rc << dendl;
+      ldpp_dout(dpp, 0) << "ERROR: Invalid marker." << rc << dendl;
       return rc;
     }
     else {
@@ -5032,12 +5035,12 @@ int MotrStore::list_users(const DoutPrefixProvider* dpp, const std::string& meta
 
   rc = next_query_by_name(RGW_MOTR_USERS_IDX_NAME, keys, vals);
   if (rc < 0) {
-    ldpp_dout(dpp, 0) << __func__ <<": ERROR: NEXT query failed. rc = " << rc << dendl;
+    ldpp_dout(dpp, 0) <<__func__<<": ERROR: NEXT query failed. rc=" << rc << dendl;
     return rc;
   }
   if (!(keys.back()).empty()) {
     *truncated = true;
-    marker = keys.back(); 
+    marker = keys.back();
   }
   for (int i = 0; i < int(keys.size()) - 1; i++) {
     if (keys[i].empty()) {
@@ -5063,12 +5066,12 @@ int MotrStore::do_idx_op(struct m0_idx *idx, enum m0_idx_opcode opcode,
   uint32_t flags = 0;
   struct m0_op *op = nullptr;
 
-  ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+  ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
        RGW_ADDB_FUNC_DO_IDX_OP, RGW_ADDB_PHASE_START);
   rc = m0_bufvec_empty_alloc(&k, 1);
   if (rc != 0) {
-    ldout(cctx, 0) << __func__ <<": ERROR: failed to allocate key bufvec. rc =" << rc << dendl;
-    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+    ldout(cctx, 0) <<__func__<<": ERROR: failed to allocate key bufvec. rc=" << rc << dendl;
+    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
 	 RGW_ADDB_FUNC_DO_IDX_OP,
 	 RGW_ADDB_PHASE_ERROR);
     return -ENOMEM;
@@ -5077,9 +5080,9 @@ int MotrStore::do_idx_op(struct m0_idx *idx, enum m0_idx_opcode opcode,
   if (opcode == M0_IC_PUT || opcode == M0_IC_GET) {
     rc = m0_bufvec_empty_alloc(&v, 1);
     if (rc != 0) {
-      ldout(cctx, 0) << __func__ << ": ERROR: failed to allocate value bufvec, rc = " << rc << dendl;
+      ldout(cctx, 0) <<__func__<< ": ERROR: failed to allocate value bufvec, rc=" << rc << dendl;
       rc = -ENOMEM;
-      ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+      ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
            RGW_ADDB_FUNC_DO_IDX_OP, RGW_ADDB_PHASE_ERROR);
       goto out;
     }
@@ -5097,8 +5100,8 @@ int MotrStore::do_idx_op(struct m0_idx *idx, enum m0_idx_opcode opcode,
 
   rc = m0_idx_op(idx, opcode, &k, vp, &rc_i, flags, &op);
   if (rc != 0) {
-    ldout(cctx, 0) << __func__ << ": ERROR: failed to init index op: " << rc << dendl;
-    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+    ldout(cctx, 0) <<__func__<< ": ERROR: failed to init index op: " << rc << dendl;
+    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
          RGW_ADDB_FUNC_DO_IDX_OP, RGW_ADDB_PHASE_ERROR);
     goto out;
   }
@@ -5111,16 +5114,16 @@ int MotrStore::do_idx_op(struct m0_idx *idx, enum m0_idx_opcode opcode,
   m0_op_free(op);
 
   if (rc != 0) {
-    ldout(cctx, 0) << __func__ << ": ERROR: op failed: " << rc << dendl;
-    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+    ldout(cctx, 0) <<__func__<< ": ERROR: op failed: " << rc << dendl;
+    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
          RGW_ADDB_FUNC_DO_IDX_OP, RGW_ADDB_PHASE_ERROR);
     goto out;
   }
 
   if (rc_i != 0) {
-    ldout(cctx, 0) << __func__ << ": ERROR: idx op failed: " << rc_i << dendl;
+    ldout(cctx, 0) <<__func__<< ": ERROR: idx op failed: " << rc_i << dendl;
     rc = rc_i;
-    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
          RGW_ADDB_FUNC_DO_IDX_OP, RGW_ADDB_PHASE_ERROR);
     goto out;
   }
@@ -5130,7 +5133,7 @@ int MotrStore::do_idx_op(struct m0_idx *idx, enum m0_idx_opcode opcode,
     memcpy(reinterpret_cast<char*>(val.data()), *v.ov_buf, *v.ov_vec.v_count);
   }
 
-  ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+  ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
        RGW_ADDB_FUNC_DO_IDX_OP, RGW_ADDB_PHASE_DONE);
 out:
   m0_bufvec_free2(&k);
@@ -5154,14 +5157,14 @@ int MotrStore::do_idx_next_op(struct m0_idx *idx,
   struct m0_bufvec k, v;
   struct m0_op *op = nullptr;
 
-  ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+  ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
        RGW_ADDB_FUNC_DO_IDX_NEXT_OP, RGW_ADDB_PHASE_START);
 
   rc = m0_bufvec_empty_alloc(&k, nr_kvp)?:
        m0_bufvec_empty_alloc(&v, nr_kvp);
   if (rc != 0) {
-    ldout(cctx, 0) << __func__ << ": ERROR: failed to allocate kv bufvecs" << dendl;
-    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+    ldout(cctx, 0) <<__func__<< ": ERROR: failed to allocate kv bufvecs" << dendl;
+    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
          RGW_ADDB_FUNC_DO_IDX_NEXT_OP, RGW_ADDB_PHASE_ERROR);
     return rc;
   }
@@ -5170,8 +5173,8 @@ int MotrStore::do_idx_next_op(struct m0_idx *idx,
 
   rc = m0_idx_op(idx, M0_IC_NEXT, &k, &v, rcs, 0, &op);
   if (rc != 0) {
-    ldout(cctx, 0) << __func__ << ": ERROR: failed to init index op: " << rc << dendl;
-    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+    ldout(cctx, 0) <<__func__<< ": ERROR: failed to init index op: " << rc << dendl;
+    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
          RGW_ADDB_FUNC_DO_IDX_NEXT_OP, RGW_ADDB_PHASE_ERROR);
     goto out;
   }
@@ -5184,8 +5187,8 @@ int MotrStore::do_idx_next_op(struct m0_idx *idx,
   m0_op_free(op);
 
   if (rc != 0) {
-    ldout(cctx, 0) << __func__ << ": ERROR: op failed: " << rc << dendl;
-    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+    ldout(cctx, 0) <<__func__<< ": ERROR: op failed: " << rc << dendl;
+    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
          RGW_ADDB_FUNC_DO_IDX_NEXT_OP, RGW_ADDB_PHASE_ERROR);
     goto out;
   }
@@ -5202,7 +5205,7 @@ int MotrStore::do_idx_next_op(struct m0_idx *idx,
     memcpy(reinterpret_cast<char*>(val.data()), v.ov_buf[i], v.ov_vec.v_count[i]);
   }
 
-  ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+  ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
        RGW_ADDB_FUNC_DO_IDX_NEXT_OP, RGW_ADDB_PHASE_DONE);
 out:
   k.ov_vec.v_nr = i;
@@ -5231,7 +5234,7 @@ int MotrStore::next_query_by_name(string idx_name,
   index_name_to_motr_fid(idx_name, &idx_id);
   int rc = open_motr_idx(&idx_id, &idx);
   if (rc != 0) {
-    ldout(cctx, 0) << __func__ << ": ERROR: failed to open index: rc = "
+    ldout(cctx, 0) <<__func__<< ": ERROR: failed to open index: rc="
                    << rc << dendl;
     goto out;
   }
@@ -5243,12 +5246,12 @@ int MotrStore::next_query_by_name(string idx_name,
   keys[0].assign(key_out[0].begin(), key_out[0].end());
   for (i = 0; i < (int)val_out.size(); i += k, k = 0) {
     rc = do_idx_next_op(&idx, keys, vals);
-    ldout(cctx, 20) << __func__ << ": do_idx_next_op() = " << rc << dendl;
+    ldout(cctx, 20) <<__func__<< ": do_idx_next_op()=" << rc << dendl;
     if (rc < 0) {
-      ldout(cctx, 0) << __func__ << ": ERROR: NEXT query failed. " << rc << dendl;
+      ldout(cctx, 0) <<__func__<< ": ERROR: NEXT query failed." << rc << dendl;
       goto out;
     } else if (rc == 0) {
-      ldout(cctx, 20) << __func__ << ": No more entries in the table." << dendl;
+      ldout(cctx, 20) <<__func__<< ": No more entries in the table." << dendl;
       goto out;
     }
 
@@ -5283,7 +5286,7 @@ int MotrStore::next_query_by_name(string idx_name,
       next_key = dir + "\xff"; // skip all dir content in 1 step
     else
       next_key = key_out[i + k - 1] + " ";
-    ldout(cctx, 0) << __func__ << ": do_idx_next_op(): next_key=" << next_key << dendl;
+    ldout(cctx, 0) <<__func__<< ": do_idx_next_op(): next_key=" << next_key << dendl;
     keys[0].assign(next_key.begin(), next_key.end());
 
     int keys_left = val_out.size() - (i + k);  // i + k gives next index.
@@ -5305,9 +5308,9 @@ int MotrStore::delete_motr_idx_by_name(string iname)
   struct m0_uint128 idx_id;
   struct m0_op *op = nullptr;
 
-  ldout(cctx, 20) << __func__ << ": iname=" << iname << dendl;
+  ldout(cctx, 20) <<__func__<< ": iname=" << iname << dendl;
 
-  ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+  ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
        RGW_ADDB_FUNC_DELETE_IDX_BY_NAME, RGW_ADDB_PHASE_START);
 
   index_name_to_motr_fid(iname, &idx_id);
@@ -5315,8 +5318,8 @@ int MotrStore::delete_motr_idx_by_name(string iname)
   m0_entity_open(&idx.in_entity, &op);
   int rc = m0_entity_delete(&idx.in_entity, &op);
   if (rc < 0) {
-    ldout(cctx, 0) << __func__ <<": m0_entity_delete failed, rc = " << rc << dendl;
-    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+    ldout(cctx, 0) <<__func__<<": m0_entity_delete failed, rc=" << rc << dendl;
+    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
          RGW_ADDB_FUNC_DELETE_IDX_BY_NAME, RGW_ADDB_PHASE_ERROR);
     goto out;
   }
@@ -5324,7 +5327,7 @@ int MotrStore::delete_motr_idx_by_name(string iname)
   ADDB(RGW_ADDB_REQUEST_TO_MOTR_ID, addb_logger.get_id(), m0_sm_id_get(&op->op_sm));
   m0_op_launch(&op, 1);
 
-  ldout(cctx, 70) << __func__ << ": waiting for op completion" << dendl;
+  ldout(cctx, 70) <<__func__<< ": waiting for op completion" << dendl;
 
   rc = m0_op_wait(op, M0_BITS(M0_OS_FAILED, M0_OS_STABLE), M0_TIME_NEVER) ?:
        m0_rc(op);
@@ -5334,15 +5337,14 @@ int MotrStore::delete_motr_idx_by_name(string iname)
   if (rc == -ENOENT) // race deletion??
     rc = 0;
   else if (rc < 0) {
-    ldout(cctx, 0) << __func__ << ": ERROR: index create failed. rc = " << rc << dendl;
-    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+    ldout(cctx, 0) <<__func__<< ": ERROR: index create failed. rc=" << rc << dendl;
+    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
          RGW_ADDB_FUNC_DELETE_IDX_BY_NAME, RGW_ADDB_PHASE_ERROR);
     goto out;
   }
 
-  ldout(cctx, 20) << __func__ << ": delete_motr_idx_by_name rc =" << rc << dendl;
-
-  ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+  ldout(cctx, 20) <<__func__<< ": delete_motr_idx_by_name rc=" << rc << dendl;
+  ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
        RGW_ADDB_FUNC_DELETE_IDX_BY_NAME, RGW_ADDB_PHASE_DONE);
 out:
   ldout(cctx, 20) << "delete_motr_idx_by_name rc=" << rc << dendl;
@@ -5377,12 +5379,12 @@ void MotrStore::index_name_to_motr_fid(string iname, struct m0_uint128 *id)
 
   memcpy(&id->u_hi, md5, 8);
   memcpy(&id->u_lo, md5 + 8, 8);
-  ldout(cctx, 20) << __func__ << ": id = 0x" << std::hex << id->u_hi << ":0x" << std::hex << id->u_lo  << dendl;
+  ldout(cctx, 20) <<__func__<< ": id = 0x" << std::hex << id->u_hi << ":0x" << std::hex << id->u_lo  << dendl;
 
   struct m0_fid *fid = (struct m0_fid*)id;
   m0_fid_tset(fid, m0_dix_fid_type.ft_id,
               fid->f_container & M0_DIX_FID_DIX_CONTAINER_MASK, fid->f_key);
-  ldout(cctx, 20) << __func__ << ": converted id = 0x" << std::hex << id->u_hi << ":0x" << std::hex << id->u_lo  << dendl;
+  ldout(cctx, 20) <<__func__<< ": converted id = 0x" << std::hex << id->u_hi << ":0x" << std::hex << id->u_lo  << dendl;
 }
 
 int MotrStore::do_idx_op_by_name(string idx_name, enum m0_idx_opcode opcode,
@@ -5396,7 +5398,7 @@ int MotrStore::do_idx_op_by_name(string idx_name, enum m0_idx_opcode opcode,
   index_name_to_motr_fid(idx_name, &idx_id);
   int rc = open_motr_idx(&idx_id, &idx);
   if (rc != 0) {
-    ldout(cctx, 0) << __func__ << ": ERROR: failed to open index rc = " << rc << dendl;
+    ldout(cctx, 0) <<__func__<< ": ERROR: failed to open index rc=" << rc << dendl;
     goto out;
   }
 
@@ -5410,7 +5412,7 @@ int MotrStore::do_idx_op_by_name(string idx_name, enum m0_idx_opcode opcode,
     // Append the returned value (blob) to the bufferlist.
     bl.append(reinterpret_cast<char*>(val.data()), val.size());
   if (rc < 0) {
-    ldout(cctx, 0) << __func__ << ": ERROR: index operation "<< opcode << " failed, rc = " << rc << dendl;
+    ldout(cctx, 0) <<__func__<< ": ERROR: index operation "<< opcode << " failed, rc=" << rc << dendl;
   }
 out:
   m0_idx_fini(&idx);
@@ -5422,7 +5424,7 @@ int MotrStore::create_motr_idx_by_name(string iname)
   struct m0_idx idx = {};
   struct m0_uint128 id;
 
-  ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+  ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
        RGW_ADDB_FUNC_CREATE_IDX_BY_NAME, RGW_ADDB_PHASE_START);
 
   index_name_to_motr_fid(iname, &id);
@@ -5432,8 +5434,8 @@ int MotrStore::create_motr_idx_by_name(string iname)
   struct m0_op *op = nullptr;
   int rc = m0_entity_create(nullptr, &idx.in_entity, &op);
   if (rc != 0) {
-    ldout(cctx, 0) << __func__ << ": ERROR: m0_entity_create() failed, rc= " << rc << dendl;
-    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+    ldout(cctx, 0) <<__func__<< ": ERROR: m0_entity_create() failed, rc=" << rc << dendl;
+    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
          RGW_ADDB_FUNC_CREATE_IDX_BY_NAME, RGW_ADDB_PHASE_ERROR);
     goto out;
   }
@@ -5446,13 +5448,13 @@ int MotrStore::create_motr_idx_by_name(string iname)
   m0_op_free(op);
 
   if (rc != 0 && rc != -EEXIST) {
-    ldout(cctx, 0) << __func__ << ": ERROR: index create failed, rc = " << rc << dendl;
-    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+    ldout(cctx, 0) <<__func__<< ": ERROR: index create failed, rc=" << rc << dendl;
+    ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
          RGW_ADDB_FUNC_CREATE_IDX_BY_NAME, RGW_ADDB_PHASE_ERROR);
     goto out;
   }
 
-  ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(), 
+  ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
        RGW_ADDB_FUNC_CREATE_IDX_BY_NAME, RGW_ADDB_PHASE_DONE);
 out:
   m0_idx_fini(&idx);
@@ -5570,7 +5572,7 @@ void *newMotrStore(CephContext *cct)
     store->instance = nullptr;
     rc = m0_client_init(&store->instance, &store->conf, true);
     if (rc != 0) {
-      ldout(cct, 0) << __func__ << ": ERROR: m0_client_init() failed: " << rc << dendl;
+      ldout(cct, 0) <<__func__<< ": ERROR: m0_client_init() failed: " << rc << dendl;
       goto out;
     }
     rgw::sal::MotrADDBLogger::set_m0_instance(store->instance->m0c_motr);
@@ -5578,20 +5580,20 @@ void *newMotrStore(CephContext *cct)
     m0_container_init(&store->container, nullptr, &M0_UBER_REALM, store->instance);
     rc = store->container.co_realm.re_entity.en_sm.sm_rc;
     if (rc != 0) {
-      ldout(cct, 0) << __func__ << ": ERROR: m0_container_init() failed: " << rc << dendl;
+      ldout(cct, 0) <<__func__<< ": ERROR: m0_container_init() failed: " << rc << dendl;
       goto out;
     }
 
     rc = m0_ufid_init(store->instance, &ufid_gr);
     if (rc != 0) {
-      ldout(cct, 0) << __func__ << ": ERROR: m0_ufid_init() failed: " << rc << dendl;
+      ldout(cct, 0) <<__func__<< ": ERROR: m0_ufid_init() failed: " << rc << dendl;
       goto out;
     }
 
     // Create global indices if not yet.
     rc = store->check_n_create_global_indices();
     if (rc != 0) {
-      ldout(cct, 0) << __func__ << ": ERROR: check_n_create_global_indices() failed: " << rc << dendl;
+      ldout(cct, 0) <<__func__<< ": ERROR: check_n_create_global_indices() failed: " << rc << dendl;
       goto out;
     }
 

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -733,12 +733,10 @@ class MotrObject : public Object {
     int delete_part_objs(const DoutPrefixProvider* dpp, uint64_t* size_rounded);
     void set_category(RGWObjCategory _category) {category = _category;}
     int get_bucket_dir_ent(const DoutPrefixProvider *dpp, rgw_bucket_dir_entry& ent);
-    int fetch_null_obj(const DoutPrefixProvider *dpp, bufferlist& bl, bool raise_error=true);
-    int fetch_null_obj_reference(
-      const DoutPrefixProvider *dpp, std::string& prev_null_obj_key, bool raise_error=true);
-    int update_null_reference(const DoutPrefixProvider *dpp, rgw_bucket_dir_entry& ent);
+    int fetch_latest_obj(const DoutPrefixProvider *dpp, bufferlist& bl);
     int update_version_entries(const DoutPrefixProvider *dpp, bool set_is_latest=false);
-    int overwrite_null_obj(const DoutPrefixProvider *dpp);
+    int fetch_null_obj(const DoutPrefixProvider *dpp, std::string& key, bufferlist *bl=NULL);
+    int remove_null_obj(const DoutPrefixProvider *dpp);
     int remove_mobj_and_index_entry(const DoutPrefixProvider* dpp, rgw_bucket_dir_entry& ent,
                                     std::string delete_key, std::string bucket_index_iname,
                                     std::string bucket_name);


### PR DESCRIPTION
When writing an object we are getting object's metadata
several times: sometimes two, sometimes even three times,
when there is no real need. This generates a lot of
redundant fops in the network and redundant load on the
servers.

The need of sending several GET requests comes from the
concept of using null-reference entry, which references
the real null entry in the metadata records: we get the
null reference entry first, read the reference key from
it (the key-instance hash), and then we get the real null
entry by using the key name and its instance hash.

Solution: refactor & simplify the code: 1) don't store
the key instance hash for the null entries, there is no
real need for this; this allows to 2) get rid of the null
reference entry concept entirely.

Testing: tested put, get, delete simple and multipart
objects on unversioned, versioned and suspended buckets.

Closes #311.



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
