### PR TITLE
rgw_sal_motr:[CORTX-31978] Refactoring delete marker code.

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1991,36 +1991,14 @@ int MotrObject::MotrDeleteOp::delete_obj(const DoutPrefixProvider* dpp, optional
       rc = source->update_version_entries(dpp);
       if (rc < 0)
         return rc;
-      // creating a delete marker
-      bufferlist del_mark_bl;
-      rgw_bucket_dir_entry ent_del_marker;
-      ent_del_marker.key.name = source->get_name();
-      ent_del_marker.key.instance = result.version_id;
-      ent_del_marker.meta.owner = params.obj_owner.get_id().to_str();
-      ent_del_marker.meta.owner_display_name = params.obj_owner.get_display_name();
-      ent_del_marker.flags = rgw_bucket_dir_entry::FLAG_DELETE_MARKER | rgw_bucket_dir_entry::FLAG_CURRENT;
-      if (real_clock::is_zero(params.mtime))
-        ent_del_marker.meta.mtime = real_clock::now();
-      else
-        ent_del_marker.meta.mtime = params.mtime;
-
-      rgw::sal::Attrs attrs;
-      ent_del_marker.encode(del_mark_bl);
-      encode(attrs, del_mark_bl);
-      ent_del_marker.meta.encode(del_mark_bl);
-
-      // key for delete marker - obj1[delete-markers's ver-id].
-      std::string delete_marker_key = source->get_key().to_str();
-      ldpp_dout(dpp, 20) << "Add delete marker in bucket index, key=" <<  delete_marker_key << dendl;
-      rc = source->store->do_idx_op_by_name(bucket_index_iname,
-                                            M0_IC_PUT, delete_marker_key, del_mark_bl);
-      if(rc < 0) {
-        ldpp_dout(dpp, 0) << "Failed to add delete marker in bucket." << dendl;
+      rc = this->create_delete_marker(dpp, ent);
+      if (rc < 0) {
+        ldpp_dout(dpp, 0) <<__func__<< " ERROR: Failed to create delete marker." << dendl;
         return rc;
       }
-      // Update in the cache.
-      source->store->get_obj_meta_cache()->put(dpp, delete_marker_key, del_mark_bl);
     }
+    if (result.version_id == "")
+      result.version_id = "null"; // show it as "null" in the reply
   } else {
     // Unversioned flow
     // handling empty size object case
@@ -2033,10 +2011,42 @@ int MotrObject::MotrDeleteOp::delete_obj(const DoutPrefixProvider* dpp, optional
     }
   }
 
-  if (result.version_id == "")
-    result.version_id = "null"; // show it as "null" in the reply
-
   return 0;
+}
+
+int MotrObject::MotrDeleteOp::create_delete_marker(const DoutPrefixProvider* dpp, rgw_bucket_dir_entry& ent)
+{
+  // creating a delete marker
+  string tenant_bkt_name = get_bucket_name(source->get_bucket()->get_tenant(), source->get_bucket()->get_name());
+  string bucket_index_iname = "motr.rgw.bucket.index." + tenant_bkt_name;
+  bufferlist del_mark_bl;
+  rgw_bucket_dir_entry ent_del_marker;
+  ent_del_marker.key.name = source->get_name();
+  ent_del_marker.key.instance = result.version_id;
+  ent_del_marker.meta.owner = params.obj_owner.get_id().to_str();
+  ent_del_marker.meta.owner_display_name = params.obj_owner.get_display_name();
+  ent_del_marker.flags = rgw_bucket_dir_entry::FLAG_DELETE_MARKER | rgw_bucket_dir_entry::FLAG_CURRENT;
+  if (real_clock::is_zero(params.mtime))
+    ent_del_marker.meta.mtime = real_clock::now();
+  else
+    ent_del_marker.meta.mtime = params.mtime;
+
+  rgw::sal::Attrs attrs;
+  ent_del_marker.encode(del_mark_bl);
+  encode(attrs, del_mark_bl);
+  ent_del_marker.meta.encode(del_mark_bl);
+  // key for delete marker - obj1[delete-markers's ver-id].
+  std::string delete_marker_key = source->get_key().to_str();
+  ldpp_dout(dpp, 20) <<__func__<< ": Add delete marker in bucket index, key=  " <<  delete_marker_key << dendl;
+  int rc = source->store->do_idx_op_by_name(bucket_index_iname,
+                                        M0_IC_PUT, delete_marker_key, del_mark_bl);
+  if (rc < 0) {
+    ldpp_dout(dpp, 0) <<__func__ << " ERROR : Failed to add delete marker in bucket." << dendl;
+    return rc;
+  }
+  // Update in the cache.
+  source->store->get_obj_meta_cache()->put(dpp, delete_marker_key, del_mark_bl);
+  return rc;
 }
 
 int MotrObject::remove_mobj_and_index_entry(

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1992,10 +1992,8 @@ int MotrObject::MotrDeleteOp::delete_obj(const DoutPrefixProvider* dpp, optional
       if (rc < 0)
         return rc;
       rc = this->create_delete_marker(dpp, ent);
-      if (rc < 0) {
-        ldpp_dout(dpp, 0) <<__func__<< " ERROR: Failed to create delete marker." << dendl;
+      if (rc < 0)
         return rc;
-      }
     }
     if (result.version_id == "")
       result.version_id = "null"; // show it as "null" in the reply

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -608,6 +608,7 @@ class MotrObject : public Object {
         MotrDeleteOp(MotrObject* _source, RGWObjectCtx* _rctx);
 
         virtual int delete_obj(const DoutPrefixProvider* dpp, optional_yield y) override;
+        int create_delete_marker(const DoutPrefixProvider* dpp, rgw_bucket_dir_entry& ent);
     };
 
     MotrObject() = default;


### PR DESCRIPTION
 Problem:
 - delete_obj() function became bulk due to the addition of delete marker code.
 - VersionId response header is returned in DELETE Object response in an unversioned bucket

 Solution:
 - Create a separate function for delete-marker creation.
 - Assign a value to the 'result.version_id' only in case of version enabled and suspended case.

Signed-off-by: Shriya Deshmukh <shriya.deshmukh@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
