### PR TITLE
rgw: [CORTX-29924] Uncommented IPPolicyTest unittests

### DIFF
--- a/src/test/rgw/test_rgw_iam_policy.cc
+++ b/src/test/rgw/test_rgw_iam_policy.cc
@@ -919,34 +919,34 @@ TEST_F(IPPolicyTest, IPEnvironment) {
   ASSERT_NE(ip, rgw_req_state.env.end());
   EXPECT_EQ(ip->second, "192.168.1.1");
 
-  // ASSERT_EQ(cct.get()->_conf.set_val("rgw_remote_addr_param", "SOME_VAR"), 0);
-  // EXPECT_EQ(cct.get()->_conf->rgw_remote_addr_param, "SOME_VAR");
-  // rgw_req_state.env.clear();
-  // rgw_build_iam_environment(&store, &rgw_req_state);
-  // ip = rgw_req_state.env.find("aws:SourceIp");
-  // EXPECT_EQ(ip, rgw_req_state.env.end());
+  ASSERT_EQ(cct.get()->_conf.set_val("rgw_remote_addr_param", "SOME_VAR"), 0);
+  EXPECT_EQ(cct.get()->_conf->rgw_remote_addr_param, "SOME_VAR");
+  rgw_req_state.env.clear();
+  rgw_build_iam_environment(&store, &rgw_req_state);
+  ip = rgw_req_state.env.find("aws:SourceIp");
+  EXPECT_EQ(ip, rgw_req_state.env.end());
 
-  // rgw_env.set("SOME_VAR", "192.168.1.2");
-  // rgw_req_state.env.clear();
-  // rgw_build_iam_environment(&store, &rgw_req_state);
-  // ip = rgw_req_state.env.find("aws:SourceIp");
-  // ASSERT_NE(ip, rgw_req_state.env.end());
-  // EXPECT_EQ(ip->second, "192.168.1.2");
+  rgw_env.set("SOME_VAR", "192.168.1.2");
+  rgw_req_state.env.clear();
+  rgw_build_iam_environment(&store, &rgw_req_state);
+  ip = rgw_req_state.env.find("aws:SourceIp");
+  ASSERT_NE(ip, rgw_req_state.env.end());
+  EXPECT_EQ(ip->second, "192.168.1.2");
 
-  // ASSERT_EQ(cct.get()->_conf.set_val("rgw_remote_addr_param", "HTTP_X_FORWARDED_FOR"), 0);
-  // rgw_env.set("HTTP_X_FORWARDED_FOR", "192.168.1.3");
-  // rgw_req_state.env.clear();
-  // rgw_build_iam_environment(&store, &rgw_req_state);
-  // ip = rgw_req_state.env.find("aws:SourceIp");
-  // ASSERT_NE(ip, rgw_req_state.env.end());
-  // EXPECT_EQ(ip->second, "192.168.1.3");
+  ASSERT_EQ(cct.get()->_conf.set_val("rgw_remote_addr_param", "HTTP_X_FORWARDED_FOR"), 0);
+  rgw_env.set("HTTP_X_FORWARDED_FOR", "192.168.1.3");
+  rgw_req_state.env.clear();
+  rgw_build_iam_environment(&store, &rgw_req_state);
+  ip = rgw_req_state.env.find("aws:SourceIp");
+  ASSERT_NE(ip, rgw_req_state.env.end());
+  EXPECT_EQ(ip->second, "192.168.1.3");
 
-  // rgw_env.set("HTTP_X_FORWARDED_FOR", "192.168.1.4, 4.3.2.1, 2001:db8:85a3:8d3:1319:8a2e:370:7348");
-  // rgw_req_state.env.clear();
-  // rgw_build_iam_environment(&store, &rgw_req_state);
-  // ip = rgw_req_state.env.find("aws:SourceIp");
-  // ASSERT_NE(ip, rgw_req_state.env.end());
-  // EXPECT_EQ(ip->second, "192.168.1.4");
+  rgw_env.set("HTTP_X_FORWARDED_FOR", "192.168.1.4, 4.3.2.1, 2001:db8:85a3:8d3:1319:8a2e:370:7348");
+  rgw_req_state.env.clear();
+  rgw_build_iam_environment(&store, &rgw_req_state);
+  ip = rgw_req_state.env.find("aws:SourceIp");
+  ASSERT_NE(ip, rgw_req_state.env.end());
+  EXPECT_EQ(ip->second, "192.168.1.4");
 }
 
 TEST_F(IPPolicyTest, ParseIPAddress) {


### PR DESCRIPTION
Problem:
	In PR #316 we commented IPPolicyTest unittest as IPPolicyTest
	unittests were crashing.
Solution:
	Uncommented IPPolicyTest unittests. A new story will be
	creating for fixing this crash.

Signed-off-by: Parayya Vastrad <parayya.vastrad@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
