### PR TITLE
rgw_sal_motr:[CORTX-32128] Restricted adding tags to delete marker metadata

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -2935,10 +2935,11 @@ int MotrObject::read_mobj(const DoutPrefixProvider* dpp, int64_t start, int64_t 
     if (start > off)
       skip = start - off;
     if(cb){
-      ldpp_dout(dpp, 20) << __func__  << " call cb to process data" << dendl;
+      ldpp_dout(dpp, 20) <<__func__<< ": return data, skip=" << skip
+                         << " bs=" << bs << " left=" << left << dendl;
       cb->handle_data(bl, skip, (left < bs ? left : bs) - skip);
       if (rc != 0){
-        ldpp_dout(dpp, 0) << __func__ << " handle_data failed rc =" << rc << dendl;
+        ldpp_dout(dpp, 0) <<__func__<< ": handle_data failed rc=" << rc << dendl;
         goto out;
       }
     }
@@ -3439,11 +3440,9 @@ int MotrAtomicWriter::write(bool last)
       acc_data.clear();
       acc_data.append(tmp.c_str(), bs); // make it a single buf
       bi = acc_data.begin();
-      left = bs;
     }
     ldpp_dout(dpp, 20) <<__func__<< ": left=" << left << " bs=" << bs << dendl;
     done = this->populate_bvec(bs, bi);
-    left -= done;
 
     if (last)
       flags |= M0_OOF_LAST;
@@ -3469,7 +3468,8 @@ int MotrAtomicWriter::write(bool last)
       goto err;
     }
 
-    total_data_size += done;
+    total_data_size += left < done ? left : done;
+    left            -= left < done ? left : done;
   }
 
   if (last) {

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -5259,7 +5259,7 @@ int MotrStore::next_query_by_name(string idx_name,
       if (!delim.empty())
         pos = key.find(delim, prefix.length());
       if (pos != std::string::npos) { // DIR entry
-        dir.assign(key, 0, pos + 1);
+        dir.assign(key, 0, pos + delim.length());
         if (dir.compare(0, prefix.length(), prefix) != 0)
           goto out;
         if (i + k == 0 || dir != key_out[i + k - 1]) // a new one

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1528,7 +1528,11 @@ int MotrObject::fetch_obj_entry_and_key(const DoutPrefixProvider* dpp, rgw_bucke
   if (rc < 0) {
       ldpp_dout(dpp, 0) <<__func__<< ": ERROR: failed to get object entry. rc=" << rc << dendl;
       return rc;
-    }
+  }
+  if(ent.is_delete_marker()){
+    ldpp_dout(dpp, 0) <<__func__<< ": ERROR: delete marker is not an object." << dendl;
+    return -ENOENT;
+  }
 
   read_bucket_info(dpp, bname, key, target_obj);
 

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1538,7 +1538,7 @@ int MotrObject::fetch_obj_entry_and_key(const DoutPrefixProvider* dpp, rgw_bucke
       ldpp_dout(dpp, 0) <<__func__<< ": ERROR: failed to get object entry. rc=" << rc << dendl;
       return rc;
   }
-  if(ent.is_delete_marker()){
+  if (ent.is_delete_marker()) {
     ldpp_dout(dpp, 0) <<__func__<< ": ERROR: delete marker is not an object." << dendl;
     return -ENOENT;
   }


### PR DESCRIPTION
Problem:
In a versioning Enabled/Suspended bucket, where DeleteMarker exists, GET Object Tagging API without versionId and with DeleteMarker's versionid is returning an empty tagset. Instead, it should return a 'NoSuchKey' error.

Solution
Handled and restricted adding tags to delete marker metadata at get_object method, when some one try to get/ add tags to delete marker it will raise validation error.

Signed-off-by: suryakumar.kumaravelan <suryakumar.kumaravelan@seagate.com>




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
