### PR TITLE
rgw_sal_motr: [CORTX-32383] fix null-version in list-object-versions

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1227,6 +1227,25 @@ std::unique_ptr<Object> MotrBucket::get_object(const rgw_obj_key& k)
   return std::make_unique<MotrObject>(this->store, k, this);
 }
 
+// List object versions in such a way that the null-version object is
+// positioned in the right place among the other versions ordered by mtime.
+// (AWS S3 spec says that the object versions should be ordered by mtime.)
+//
+// Note: all versioned objects have "key[instance]" format of the key in
+// motr index, and the instance hash is generated reverse-ordered by mtime
+// (see MotrObject::gen_rand_obj_instance_name()), so versions are ordered
+// as needed just as we fetch from them motr, but null-version objects do
+// not have any [instance] suffix key in their name, that's why we have to
+// position it correctly among the other object versions, that's why the
+// code is a bit tricky here.
+//
+// The basic algorithm is this: save null-version in null_ent and put it
+// to the result only if the next version is older than it. If marker is
+// provided (from which version to give the result), put null-version to
+// the result only if it's older than the marker. If the number of objects
+// is bigger than max and the result is_truncated, make sure we put the
+// correct next_marker, which can be the null-version too. If the marker
+// is the null-version, put it and only the older versions to the result.
 int MotrBucket::list(const DoutPrefixProvider *dpp, ListParams& params, int max, ListResults& results, optional_yield y)
 {
   int rc;
@@ -1250,19 +1269,19 @@ int MotrBucket::list(const DoutPrefixProvider *dpp, ListParams& params, int max,
   // Modify the marker based on its type
   keys[0] = params.prefix;
   if (!params.marker.empty()) {
-    keys[0] = params.marker.to_str();
+    keys[0] = params.marker.name;
     // Get the position of delimiter string
-    int delim_pos = keys[0].find(params.delim, params.prefix.length());
-    // If delimiter is present at the very end, append "\xff" to skip all
-    // the dir entries, else append " " to skip the maker key.
-    if (delim_pos == (int)(keys[0].length() - params.delim.length()))
-      keys[0].append("\xff");
-    else
-      keys[0].append(" ");
+    if (params.delim != "") {
+      int delim_pos = keys[0].find(params.delim, params.prefix.length());
+      // If delimiter is present at the very end, append "\xff" to skip all
+      // the dir entries.
+      if (delim_pos == (int)(keys[0].length() - params.delim.length()))
+        keys[0].append("\xff");
+    }
   }
 
   results.is_truncated = false;
-  int keycount=0;
+  int keycount=0; // how many keys we've put to the results so far
   std::string next_key;
   while (keycount <= max) {
     if (!next_key.empty())
@@ -1288,11 +1307,22 @@ int MotrBucket::list(const DoutPrefixProvider *dpp, ListParams& params, int max,
         auto iter = vals[i].cbegin();
         ent.decode(iter);
         if (params.list_versions || ent.is_visible()) {
+          if (ent.key.name == params.marker.name &&
+              // filter out versions which go before marker.instance
+              ((!null_ent.key.empty() && params.marker.instance == "null" &&
+                 null_ent.meta.mtime < ent.meta.mtime) ||
+               (ent.key.instance != "" &&
+                ent.key.instance < params.marker.instance)))
+            continue;
+check_keycount:
           if (keycount >= max) {
-            // One extra key is successfully fetched.
-            results.next_marker = keys[i];
+            if (!null_ent.key.empty() &&
+                (null_ent.key.name != ent.key.name ||
+                 null_ent.meta.mtime > ent.meta.mtime))
+              results.next_marker = rgw_obj_key(ent.key.name, "null");
+            else
+              results.next_marker = rgw_obj_key(ent.key.name, ent.key.instance);
             results.is_truncated = true;
-            ldpp_dout(dpp, 20) <<__func__<< ": adding key "<< keys[i] <<" to next_marker"<<dendl;
             break;
           }
           // Put null-entry ordered by mtime.
@@ -1301,21 +1331,27 @@ int MotrBucket::list(const DoutPrefixProvider *dpp, ListParams& params, int max,
           if (!null_ent.key.empty() &&
               (null_ent.key.name != ent.key.name ||
                null_ent.meta.mtime > ent.meta.mtime)) {
-            results.objs.emplace_back(std::move(null_ent));
-            null_ent.key = {};
+            if (ent.key.instance == params.marker.instance)
+              null_ent.key = {}; // filtered out by the marker
+            else {
+              results.objs.emplace_back(std::move(null_ent));
+              keycount++;
+              goto check_keycount;
+            }
           }
           if (ent.key.instance == "")
             null_ent = std::move(ent);
           else {
             results.objs.emplace_back(std::move(ent));
+            keycount++;
           }
-          keycount++;
         }
       }
     }
-    if (rc == 0 || rc < batch_size || results.is_truncated) {
+
+    if (rc == 0 || rc < batch_size || results.is_truncated)
       break;
-    }
+
     next_key = keys[rc-1]; // next marker key
     keys.clear();
     vals.clear();
@@ -1323,8 +1359,14 @@ int MotrBucket::list(const DoutPrefixProvider *dpp, ListParams& params, int max,
     vals.resize(batch_size);
   }
 
-  if (!null_ent.key.empty())
-    results.objs.emplace_back(std::move(null_ent));
+  if (!null_ent.key.empty() && !results.is_truncated) {
+    if (keycount < max)
+      results.objs.emplace_back(std::move(null_ent));
+    else { // there was no more records in the bucket
+      results.next_marker = rgw_obj_key(null_ent.key.name, "null");
+      results.is_truncated = true;
+    }
+  }
 
   return 0;
 }


### PR DESCRIPTION
Currently, null-version record always appears in the result of
the list-object-versions command for the specified object, even
when --max-keys limit is specified and there are more recent
objects in the bucket than the null-version. For example, in
case when --max-keys=1, null-version always will be returned in
the result regardless of its modification time (mtime) to the
other versions of this object.

AWS S3 specifies that the order of the object version returned
in the list-object-versions should be the same in which the
objects were put, i.e. the latest ones should be at the top.
This should work also when --max-keys limit is set by the user.

Solution: fix the code at MotrBucket::list() to return the
object versions in the correct way when the null-version is
present and --max-keys limit is given. Also, fix the return of
NextKeyMarker and NextVersionIdMarker, and the usage of these
markers with key-marker and version-id-marker parameters.







<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
