### PR TITLE
rgw_sal_motr: [CORTX-32233]: realm configuration [WIP]

### DIFF
--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -48,6 +48,7 @@ set(librgw_common_srcs
   services/svc_user_rados.cc
   services/svc_zone.cc
   services/svc_zone_utils.cc
+  services/motr_service.cc
   rgw_service.cc
   rgw_acl.cc
   rgw_acl_s3.cc

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -5451,6 +5451,12 @@ void *newMotrStore(CephContext *cct)
       goto out;
     }
 
+    int ret = store->svc()->init_svc(true);
+    if (ret < 0) {
+      ldout(cct, 0) << "ERROR: failed to init services" << dendl;
+      delete store; store = nullptr;
+      return store;
+    }
   }
 
 out:

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -33,6 +33,8 @@ extern "C" {
 #include "rgw_multi.h"
 #include "rgw_putobj_processor.h"
 
+#include "services/motr_service.h"
+
 namespace rgw::sal {
 
 class MotrStore;
@@ -963,6 +965,7 @@ class MotrStore : public Store {
     MotrMetaCache* obj_meta_cache;
     MotrMetaCache* user_cache;
     MotrMetaCache* bucket_inst_cache;
+    MOTRServices motr_svc;
 
   public:
     CephContext *cctx;
@@ -981,6 +984,10 @@ class MotrStore : public Store {
 
     virtual const char* get_name() const override {
       return "motr";
+    }
+
+    virtual MOTRServices* svc() {
+      return &motr_svc;
     }
 
     virtual int list_users(const DoutPrefixProvider* dpp, const std::string& metadata_key,

--- a/src/rgw/rgw_service.h
+++ b/src/rgw/rgw_service.h
@@ -106,9 +106,9 @@ struct RGWServices_Def
   std::unique_ptr<RGWDataChangesLog> datalog_rados;
 
   RGWServices_Def();
-  ~RGWServices_Def();
+  virtual ~RGWServices_Def();
 
-  int init(CephContext *cct, bool have_cache, bool raw_storage, bool run_sync, optional_yield y, const DoutPrefixProvider *dpp);
+  virtual int init(CephContext *cct, bool have_cache, bool raw_storage, bool run_sync, optional_yield y, const DoutPrefixProvider *dpp);
   void shutdown();
 };
 
@@ -147,7 +147,7 @@ struct RGWServices
   RGWSI_SysObj_Core *core{nullptr};
   RGWSI_User *user{nullptr};
 
-  int do_init(CephContext *cct, bool have_cache, bool raw_storage, bool run_sync, optional_yield y, const DoutPrefixProvider *dpp);
+  virtual int do_init(CephContext *cct, bool have_cache, bool raw_storage, bool run_sync, optional_yield y, const DoutPrefixProvider *dpp);
 
   int init(CephContext *cct, bool have_cache, bool run_sync, optional_yield y, const DoutPrefixProvider *dpp) {
     return do_init(cct, have_cache, false, run_sync, y, dpp);
@@ -156,9 +156,11 @@ struct RGWServices
   int init_raw(CephContext *cct, bool have_cache, optional_yield y, const DoutPrefixProvider *dpp) {
     return do_init(cct, have_cache, true, false, y, dpp);
   }
-  void shutdown() {
+  virtual void shutdown() {
     _svc.shutdown();
   }
+
+  virtual ~RGWServices() {}
 };
 
 class RGWMetadataManager;

--- a/src/rgw/services/motr_service.cc
+++ b/src/rgw/services/motr_service.cc
@@ -1,0 +1,213 @@
+#include "motr_service.h"
+
+int MOTRServices_Def::init(CephContext *cct, bool have_cache, bool raw, bool run_sync, optional_yield y, const DoutPrefixProvider *dpp)
+{
+  finisher = std::make_unique<RGWSI_Finisher>(cct);
+  cls = std::make_unique<RGWSI_Cls>(cct);
+  config_key_rados = std::make_unique<RGWSI_ConfigKey_RADOS>(cct);
+  mdlog = std::make_unique<RGWSI_MDLog>(cct, run_sync);
+  meta = std::make_unique<RGWSI_Meta>(cct);
+  meta_be_sobj = std::make_unique<RGWSI_MetaBackend_SObj>(cct);
+  meta_be_otp = std::make_unique<RGWSI_MetaBackend_OTP>(cct);
+  notify = std::make_unique<RGWSI_Notify>(cct);
+  otp = std::make_unique<RGWSI_OTP>(cct);
+  rados = std::make_unique<RGWSI_RADOS>(cct);
+  zone = std::make_unique<RGWSI_Zone>(cct);
+  zone_utils = std::make_unique<RGWSI_ZoneUtils>(cct);
+  quota = std::make_unique<RGWSI_Quota>(cct);
+  sync_modules = std::make_unique<RGWSI_SyncModules>(cct);
+  sysobj = std::make_unique<RGWSI_SysObj>(cct);
+  sysobj_core = std::make_unique<MOTRSI_SysObj_Core>(cct);
+  user_rados = std::make_unique<RGWSI_User_RADOS>(cct);
+
+  if (have_cache) {
+    sysobj_cache = std::make_unique<RGWSI_SysObj_Cache>(dpp, cct);
+  }
+
+  // bucket_sobj = std::make_unique<RGWSI_Bucket_SObj>(cct);
+  // bucket_sync_sobj = std::make_unique<RGWSI_Bucket_Sync_SObj>(cct);
+  // bi_rados = std::make_unique<RGWSI_BucketIndex_RADOS>(cct);
+  // bilog_rados = std::make_unique<RGWSI_BILog_RADOS>(cct);
+  // datalog_rados = std::make_unique<RGWDataChangesLog>(cct);
+
+  finisher->init();
+  // bi_rados->init(zone.get(), rados.get(), bilog_rados.get(), datalog_rados.get());
+  // bilog_rados->init(bi_rados.get());
+  // bucket_sobj->init(zone.get(), sysobj.get(), sysobj_cache.get(),
+  //                   bi_rados.get(), meta.get(), meta_be_sobj.get(),
+  //                   sync_modules.get(), bucket_sync_sobj.get());
+  // bucket_sync_sobj->init(zone.get(),
+  //                        sysobj.get(),
+  //                        sysobj_cache.get(),
+  //                        bucket_sobj.get());
+  cls->init(zone.get(), rados.get());
+  config_key_rados->init(rados.get());
+  mdlog->init(rados.get(), zone.get(), sysobj.get(), cls.get());
+  // meta->init(sysobj.get(), mdlog.get(), meta_bes);
+  meta_be_sobj->init(sysobj.get(), mdlog.get());
+  meta_be_otp->init(sysobj.get(), mdlog.get(), cls.get());
+  notify->init(zone.get(), rados.get(), finisher.get());
+  otp->init(zone.get(), meta.get(), meta_be_otp.get());
+  rados->init();
+  zone->init(sysobj.get(), rados.get(), sync_modules.get(), bucket_sync_sobj.get());
+  zone_utils->init(rados.get(), zone.get());
+  quota->init(zone.get());
+  sync_modules->init(zone.get());
+  sysobj_core->core_init(rados.get(), zone.get());
+  if (have_cache) {
+    // sysobj_cache->init(rados.get(), zone.get(), notify.get());
+    sysobj->init(rados.get(), sysobj_cache.get());
+  } else {
+    sysobj->init(rados.get(), sysobj_core.get());
+  }
+  user_rados->init(rados.get(), zone.get(), sysobj.get(), sysobj_cache.get(),
+                   meta.get(), meta_be_sobj.get(), sync_modules.get());
+
+  can_shutdown = true;
+
+  int r = finisher->start(y, dpp);
+  if (r < 0) {
+    // ldpp_dout(dpp, 0) << "ERROR: failed to start finisher service (" << cpp_strerror(-r) << dendl;
+    return r;
+  }
+
+  if (!raw) {
+    r = notify->start(y, dpp);
+    if (r < 0) {
+      // ldpp_dout(dpp, 0) << "ERROR: failed to start notify service (" << cpp_strerror(-r) << dendl;
+      return r;
+    }
+  }
+
+  r = rados->start(y, dpp);
+  if (r < 0) {
+    // ldpp_dout(dpp, 0) << "ERROR: failed to start rados service (" << cpp_strerror(-r) << dendl;
+    return r;
+  }
+
+  if (!raw) {
+    r = zone->start(y, dpp);
+    if (r < 0) {
+      // ldpp_dout(dpp, 0) << "ERROR: failed to start zone service (" << cpp_strerror(-r) << dendl;
+      return r;
+    }
+
+    // r = datalog_rados->start(dpp, &zone->get_zone(),
+		// 	     zone->get_zone_params(),
+		// 	     rados->get_rados_handle());
+    // if (r < 0) {
+    //   // ldpp_dout(dpp, 0) << "ERROR: failed to start datalog_rados service (" << cpp_strerror(-r) << dendl;
+    //   return r;
+    // }
+
+    r = mdlog->start(y, dpp);
+    if (r < 0) {
+      // ldpp_dout(dpp, 0) << "ERROR: failed to start mdlog service (" << cpp_strerror(-r) << dendl;
+      return r;
+    }
+
+    r = sync_modules->start(y, dpp);
+    if (r < 0) {
+      // ldpp_dout(dpp, 0) << "ERROR: failed to start sync modules service (" << cpp_strerror(-r) << dendl;
+      return r;
+    }
+  }
+
+  r = cls->start(y, dpp);
+  if (r < 0) {
+    // ldpp_dout(dpp, 0) << "ERROR: failed to start cls service (" << cpp_strerror(-r) << dendl;
+    return r;
+  }
+
+  r = config_key_rados->start(y, dpp);
+  if (r < 0) {
+    // ldpp_dout(dpp, 0) << "ERROR: failed to start config_key service (" << cpp_strerror(-r) << dendl;
+    return r;
+  }
+
+  r = zone_utils->start(y, dpp);
+  if (r < 0) {
+    // ldpp_dout(dpp, 0) << "ERROR: failed to start zone_utils service (" << cpp_strerror(-r) << dendl;
+    return r;
+  }
+
+  r = quota->start(y, dpp);
+  if (r < 0) {
+    // ldpp_dout(dpp, 0) << "ERROR: failed to start quota service (" << cpp_strerror(-r) << dendl;
+    return r;
+  }
+
+  r = sysobj_core->start(y, dpp);
+  if (r < 0) {
+    // ldpp_dout(dpp, 0) << "ERROR: failed to start sysobj_core service (" << cpp_strerror(-r) << dendl;
+    return r;
+  }
+
+  if (have_cache) {
+    r = sysobj_cache->start(y, dpp);
+    if (r < 0) {
+      // ldpp_dout(dpp, 0) << "ERROR: failed to start sysobj_cache service (" << cpp_strerror(-r) << dendl;
+      return r;
+    }
+  }
+
+  r = sysobj->start(y, dpp);
+  if (r < 0) {
+    // ldpp_dout(dpp, 0) << "ERROR: failed to start sysobj service (" << cpp_strerror(-r) << dendl;
+    return r;
+  }
+
+  if (!raw) {
+    r = meta_be_sobj->start(y, dpp);
+    if (r < 0) {
+      // ldpp_dout(dpp, 0) << "ERROR: failed to start meta_be_sobj service (" << cpp_strerror(-r) << dendl;
+      return r;
+    }
+
+    r = meta->start(y, dpp);
+    if (r < 0) {
+      // ldpp_dout(dpp, 0) << "ERROR: failed to start meta service (" << cpp_strerror(-r) << dendl;
+      return r;
+    }
+
+    r = bucket_sobj->start(y, dpp);
+    if (r < 0) {
+      // ldpp_dout(dpp, 0) << "ERROR: failed to start bucket service (" << cpp_strerror(-r) << dendl;
+      return r;
+    }
+
+    r = bucket_sync_sobj->start(y, dpp);
+    if (r < 0) {
+      // ldpp_dout(dpp, 0) << "ERROR: failed to start bucket_sync service (" << cpp_strerror(-r) << dendl;
+      return r;
+    }
+
+    r = user_rados->start(y, dpp);
+    if (r < 0) {
+      // ldpp_dout(dpp, 0) << "ERROR: failed to start user_rados service (" << cpp_strerror(-r) << dendl;
+      return r;
+    }
+
+    r = otp->start(y, dpp);
+    if (r < 0) {
+      // ldpp_dout(dpp, 0) << "ERROR: failed to start otp service (" << cpp_strerror(-r) << dendl;
+      return r;
+    }
+  }
+
+  /* cache or core services will be started by sysobj */
+
+  return  0;
+}
+
+int MOTRServices::do_init(CephContext *_cct, bool have_cache, bool raw, bool run_sync, optional_yield y, const DoutPrefixProvider* dpp)
+{
+  cct = _cct;
+
+  int r = motr_svc.init(cct, have_cache, raw, run_sync, y, nullptr);
+  if (r < 0) {
+    return r;
+  }
+
+  return 0;
+}

--- a/src/rgw/services/motr_service.h
+++ b/src/rgw/services/motr_service.h
@@ -1,0 +1,61 @@
+#ifndef CEPH_MOTR_SERVICE_H
+#define CEPH_MOTR_SERVICE_H
+
+#pragma once
+
+#include "rgw/rgw_service.h"
+
+#include "svc_sys_obj_core.h"
+#include "svc_rados.h"
+#include "svc_sync_modules.h"
+#include "svc_sys_obj.h"
+#include "svc_sys_obj_cache.h"
+#include "svc_sys_obj_core_types.h"
+#include "svc_finisher.h"
+#include "svc_bucket_sync_sobj.h"
+#include "svc_bucket_sobj.h"
+#include "svc_bilog_rados.h"
+#include "svc_cls.h"
+#include "svc_config_key_rados.h"
+#include "svc_mdlog.h"
+#include "svc_meta.h"
+#include "svc_meta_be_sobj.h"
+#include "svc_meta_be_otp.h"
+#include "svc_notify.h"
+#include "svc_otp.h"
+#include "svc_zone.h"
+#include "svc_zone_utils.h"
+#include "svc_quota.h"
+#include "svc_user_rados.h"
+
+class MOTRSI_SysObj_Core : public RGWSI_SysObj_Core {
+  public: 
+    MOTRSI_SysObj_Core(CephContext* cct) : RGWSI_SysObj_Core(cct) {}
+};
+
+struct MOTRServices_Def : public RGWServices_Def {
+  int init(CephContext *cct, bool have_cache, bool raw_storage, bool run_sync, optional_yield y, const DoutPrefixProvider *dpp) override;
+  ~MOTRServices_Def() {}
+};
+
+struct MOTRServices : public RGWServices
+{
+  MOTRServices_Def motr_svc;
+
+  int do_init(CephContext *cct, bool have_cache, bool raw_storage, bool run_sync, optional_yield y, const DoutPrefixProvider* dpp) override;
+
+  int init_svc(bool raw) { 
+    if (raw)
+      return init_raw(cct, false, null_yield, nullptr);
+      
+    return init(cct, false, false, null_yield, nullptr);
+  }
+
+  void shutdown() override {
+    motr_svc.shutdown();
+  }
+
+  ~MOTRServices() {}
+};
+
+#endif

--- a/src/rgw/services/svc_finisher.h
+++ b/src/rgw/services/svc_finisher.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "rgw/rgw_service.h"
+#include "motr_service.h"
 
 class Context;
 class Finisher;
@@ -11,6 +12,7 @@ class Finisher;
 class RGWSI_Finisher : public RGWServiceInstance
 {
   friend struct RGWServices_Def;
+  friend struct MOTRServices_Def;
 public:
   class ShutdownCB;
 

--- a/src/rgw/services/svc_notify.h
+++ b/src/rgw/services/svc_notify.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "rgw/rgw_service.h"
+#include "motr_service.h"
 
 #include "svc_rados.h"
 
@@ -22,6 +23,7 @@ class RGWSI_Notify : public RGWServiceInstance
   friend class RGWWatcher;
   friend class RGWSI_Notify_ShutdownCB;
   friend class RGWServices_Def;
+  friend class MOTRServices_Def;
 
 public:
   class CB;

--- a/src/rgw/services/svc_sys_obj.h
+++ b/src/rgw/services/svc_sys_obj.h
@@ -17,10 +17,12 @@ class RGWSI_SysObj;
 class RGWSysObjectCtx;
 
 struct rgw_cache_entry_info;
+struct MOTRServices_Def;
 
 class RGWSI_SysObj : public RGWServiceInstance
 {
   friend struct RGWServices_Def;
+  friend struct MOTRServices_Def;
 
 public:
   class Obj {

--- a/src/rgw/services/svc_sys_obj_core.h
+++ b/src/rgw/services/svc_sys_obj_core.h
@@ -13,11 +13,13 @@
 class RGWSI_Zone;
 
 struct rgw_cache_entry_info;
+struct MOTRServices_Def;
 
 class RGWSI_SysObj_Core : public RGWServiceInstance
 {
   friend class RGWServices_Def;
   friend class RGWSI_SysObj;
+  friend class MOTRServices_Def;
 
 protected:
   RGWSI_RADOS *rados_svc{nullptr};

--- a/src/rgw/services/svc_zone.h
+++ b/src/rgw/services/svc_zone.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "rgw/rgw_service.h"
+#include "motr_service.h"
 
 
 class RGWSI_RADOS;
@@ -27,6 +28,7 @@ struct rgw_sync_policy_info;
 class RGWSI_Zone : public RGWServiceInstance
 {
   friend struct RGWServices_Def;
+  friend struct MOTRServices_Def;
 
   RGWSI_SysObj *sysobj_svc{nullptr};
   RGWSI_RADOS *rados_svc{nullptr};

--- a/src/rgw/services/svc_zone_utils.h
+++ b/src/rgw/services/svc_zone_utils.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "rgw/rgw_service.h"
+#include "motr_service.h"
 
 
 class RGWSI_RADOS;
@@ -12,6 +13,7 @@ class RGWSI_Zone;
 class RGWSI_ZoneUtils : public RGWServiceInstance
 {
   friend struct RGWServices_Def;
+  friend struct MOTRServices_Def;
 
   RGWSI_RADOS *rados_svc{nullptr};
   RGWSI_Zone *zone_svc{nullptr};


### PR DESCRIPTION
Signed-off-by: Mayank Srivastava <mayank.srivastava@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Problem
Realm is not working with motr as BE
## Solution
Realm/Zone Configuration uses service classes for storing/retriving from rados which directly calls libRados.
So creating derived classes such that it works with motr
## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
