### PR TITLE
rgw_sal_motr : [CORTX-32424] Fix for delete previous object using version-id

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -3657,6 +3657,7 @@ int MotrMultipartUpload::delete_parts(const DoutPrefixProvider *dpp, std::string
   int marker = 0;
   bool truncated = false;
 
+  this->set_version_id(version_id);
   // Scan all parts and delete the corresponding motr objects.
   do {
     rc = this->list_parts(dpp, store->ctx(), max_parts, marker, &marker, &truncated);
@@ -3912,6 +3913,7 @@ int MotrMultipartUpload::list_parts(const DoutPrefixProvider *dpp, CephContext *
     std::string key_name;
 
     // Get the object entry
+    mobj_ver->set_instance(this->get_version_id());
     int ret_rc = mobj_ver->get_bucket_dir_ent(dpp, ent);
     if(ret_rc < 0)
       return ret_rc;

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -3915,7 +3915,7 @@ int MotrMultipartUpload::list_parts(const DoutPrefixProvider *dpp, CephContext *
     // Get the object entry
     mobj_ver->set_instance(this->get_version_id());
     int ret_rc = mobj_ver->get_bucket_dir_ent(dpp, ent);
-    if(ret_rc < 0)
+    if (ret_rc < 0)
       return ret_rc;
 
     if (!ent.is_delete_marker()) {

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -913,7 +913,7 @@ class MotrMultipartUpload : public MultipartUpload {
   ceph::real_time mtime;
   rgw_placement_rule placement;
   RGWObjManifest manifest;
-  std::string _version_id;
+  std::string version_id;
 
 public:
   MotrMultipartUpload(MotrStore* _store, Bucket* _bucket, const std::string& oid,
@@ -922,8 +922,8 @@ public:
        }
   virtual ~MotrMultipartUpload() = default;
 
-  void set_version_id(std::string version_id) { _version_id = version_id; };
-  std::string get_version_id() { return _version_id; };
+  void set_version_id(std::string _version_id) { version_id = _version_id; };
+  std::string get_version_id() { return version_id; };
   virtual const std::string& get_meta() const { return mp_obj.get_meta(); }
   virtual const std::string& get_key() const { return mp_obj.get_key(); }
   virtual const std::string& get_upload_id() const { return mp_obj.get_upload_id(); }

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -913,6 +913,7 @@ class MotrMultipartUpload : public MultipartUpload {
   ceph::real_time mtime;
   rgw_placement_rule placement;
   RGWObjManifest manifest;
+  std::string _version_id;
 
 public:
   MotrMultipartUpload(MotrStore* _store, Bucket* _bucket, const std::string& oid,
@@ -921,6 +922,8 @@ public:
        }
   virtual ~MotrMultipartUpload() = default;
 
+  void set_version_id(std::string version_id) { _version_id = version_id; };
+  std::string get_version_id() { return _version_id; };
   virtual const std::string& get_meta() const { return mp_obj.get_meta(); }
   virtual const std::string& get_key() const { return mp_obj.get_key(); }
   virtual const std::string& get_upload_id() const { return mp_obj.get_upload_id(); }


### PR DESCRIPTION
Problem Statement:
- For multipart object, observed a crash when user tries to delete the previous (non-latest)  object version with version-id parameter.
- Root cause is, in the `MotrMultipartUpload `class we are not storing the version-id for an object. When user tries to delete a specific multipart object version (non-latest) by specifying the version-id parameter, it always tries to fetch latest object entry instead of specified object version (`list_parts() -> get_bucket_dir_ent()`)

Solution:

- In the `MotrMultipartUpload `class added a new variable `version_id` to store the specific version-id for multipart object, along with getter and setter methods.
- Now, this version_id variable will store the version-id passed by user, hence in the `get_bucket_dir_ent()` function, it fetches the specified object version entry, instead of latest entry.

Signed-off-by: Priyanka Salunke <priyanka.s.salunke@seagate.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
