### PR TITLE
rgw_sal_motr: [CORTX-32423] fix listing of same-prefix objs

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1586,11 +1586,14 @@ int MotrObject::fetch_obj_entry_and_key(const DoutPrefixProvider* dpp, rgw_bucke
     return -ENOENT;
   }
 
-  read_bucket_info(dpp, bname, key, target_obj);
+  if (target_obj)
+    bname = get_bucket_name(target_obj->bucket.tenant, target_obj->bucket.name);
+  else
+    bname = get_bucket_name(this->get_bucket()->get_tenant(), this->get_bucket()->get_name());
 
-  key = ent.key.name;
-  if (ent.key.instance != "")
-    key += "[" + ent.key.instance + "]";
+  key = ent.key.name + '\a' + ent.key.instance;
+
+  ldpp_dout(dpp, 20) <<__func__<< ": bucket=" << bname << " key=" << key << dendl;
 
   return 0;
 }
@@ -1665,18 +1668,6 @@ int MotrObject::get_obj_attrs(RGWObjectCtx* rctx, optional_yield y, const DoutPr
     }
 
   return 0;
-}
-
-void MotrObject::read_bucket_info(const DoutPrefixProvider* dpp, std::string& bname, std::string& key, rgw_obj* target_obj)
-{
-  if (target_obj) {
-    bname = get_bucket_name(target_obj->bucket.tenant, target_obj->bucket.name);
-    key   = target_obj->key.to_str();
-  } else {
-    bname = get_bucket_name(this->get_bucket()->get_tenant(), this->get_bucket()->get_name());
-    key   = this->get_key().to_str();
-  }
-  ldpp_dout(dpp, 20) <<__func__<< ": for bucket " << bname << "/" << key << dendl;
 }
 
 int MotrObject::modify_obj_attrs(RGWObjectCtx* rctx, const char* attr_name, bufferlist& attr_val, optional_yield y, const DoutPrefixProvider* dpp)
@@ -1961,17 +1952,16 @@ int MotrObject::MotrDeleteOp::delete_obj(const DoutPrefixProvider* dpp, optional
   bufferlist bl;
   string tenant_bkt_name = get_bucket_name(source->get_bucket()->get_tenant(), source->get_bucket()->get_name());
   string bucket_index_iname = "motr.rgw.bucket.index." + tenant_bkt_name;
-  std::string delete_key = source->get_key().to_str();
   rgw_bucket_dir_entry ent;
   RGWBucketInfo &info = source->get_bucket()->get_info();
+
   rc = source->get_bucket_dir_ent(dpp, ent);
   if (rc < 0) {
     ldpp_dout(dpp, 0) << "Failed to get object's entry from bucket index. rc="<< rc << dendl;
     return rc;
   }
 
-  if (source->get_key().have_null_instance())
-    delete_key = source->get_name();
+  string delete_key = source->get_key_str();
 
   //TODO: When integrating with background GC for object deletion,
   // we should consider adding object entry to GC before deleting the metadata.
@@ -2081,16 +2071,17 @@ int MotrObject::MotrDeleteOp::create_delete_marker(const DoutPrefixProvider* dpp
   encode(attrs, del_mark_bl);
   ent_del_marker.meta.encode(del_mark_bl);
   // key for delete marker - obj1[delete-markers's ver-id].
-  std::string delete_marker_key = source->get_key().to_str();
-  ldpp_dout(dpp, 20) <<__func__<< ": Add delete marker in bucket index, key=  " <<  delete_marker_key << dendl;
+  std::string delete_marker_key = source->get_key_str();
+  ldpp_dout(dpp, 20) <<__func__<< ": Add delete marker in bucket index, key=" << delete_marker_key << dendl;
   int rc = source->store->do_idx_op_by_name(bucket_index_iname,
                                         M0_IC_PUT, delete_marker_key, del_mark_bl);
   if (rc < 0) {
-    ldpp_dout(dpp, 0) <<__func__ << " ERROR : Failed to add delete marker in bucket." << dendl;
+    ldpp_dout(dpp, 0) <<__func__<< " ERROR : Failed to add delete marker in bucket." << dendl;
     return rc;
   }
   // Update in the cache.
   source->store->get_obj_meta_cache()->put(dpp, delete_marker_key, del_mark_bl);
+
   return rc;
 }
 
@@ -2119,10 +2110,7 @@ int MotrObject::remove_mobj_and_index_entry(
           return rc;
         }
       }
-      uint64_t lid = M0_OBJ_LAYOUT_ID(mobj->ob_attr.oa_layout_id);
-      uint64_t unit_sz = m0_obj_layout_id_to_unit_size(lid);
-      size_rounded = roundup(ent.meta.size, unit_sz);
-
+      size_rounded = roundup(ent.meta.size, get_unit_sz());
       rc = this->delete_mobj(dpp);
     }
     if (rc < 0) {
@@ -2524,8 +2512,9 @@ int MotrObject::create_mobj(const DoutPrefixProvider *dpp, uint64_t sz)
   }
   expected_obj_size = sz;
 
-  ldpp_dout(dpp, 20) <<__func__<< ": key=" << this->get_key().to_str() << ", meta:oid=[0x" << std::hex
-                                 << meta.oid.u_hi << ":0x" << std::hex  << meta.oid.u_lo << "]" << dendl;
+  ldpp_dout(dpp, 20) <<__func__<< ": key=" << this->get_key().to_str()
+                     << " size=" << sz << " meta:oid=[0x" << std::hex
+                     << meta.oid.u_hi << ":0x" << meta.oid.u_lo << "]" << dendl;
 
   int64_t lid = m0_layout_find_by_objsz(store->instance, nullptr, sz);
   if (lid <= 0) {
@@ -2981,33 +2970,40 @@ int MotrObject::fetch_null_obj(const DoutPrefixProvider *dpp, std::string& key, 
   // Read the null index entry
   string tenant_bkt_name = get_bucket_name(this->get_bucket()->get_tenant(), this->get_bucket()->get_name());
   string bucket_index_iname = "motr.rgw.bucket.index." + tenant_bkt_name;
-  std::string null_key = this->get_name();
   bufferlist bl;
   rgw_bucket_dir_entry ent_null;
 
+  key = this->get_name() + '\a';
+
   // Check entry in the cache
-  if (this->store->get_obj_meta_cache()->get(dpp, null_key, bl)) {
-    rc = this->store->do_idx_op_by_name(bucket_index_iname,
-                                        M0_IC_GET, null_key, bl);
-    ldpp_dout(dpp, 20) <<__func__<< ": key="<< null_key <<", rc="<< rc << dendl;
+  if (this->store->get_obj_meta_cache()->get(dpp, key, bl)) {
+    rc = this->store->do_idx_op_by_name(bucket_index_iname, M0_IC_GET, key, bl);
     if (rc < 0)
       return rc;
 
-    this->store->get_obj_meta_cache()->put(dpp, null_key, bl);
+    this->store->get_obj_meta_cache()->put(dpp, key, bl);
   }
 
   bufferlist& blr = bl;
   auto iter = blr.cbegin();
   ent_null.decode(iter);
 
-  key = ent_null.key.name;
   if (bl_out != NULL) {
     bl_out->clear();
     bl_out->append(bl);
   }
 
-  ldpp_dout(dpp, 20) <<__func__<< ": key="<< null_key <<", rc="<< rc << dendl;
+  ldpp_dout(dpp, 20) <<__func__<< ": key="<< key <<", rc="<< rc << dendl;
   return rc;
+}
+
+std::string MotrObject::get_key_str()
+{
+  if (!this->get_key().have_instance() ||
+       this->get_key().have_null_instance())
+    return this->get_name() + '\a';
+  else
+    return this->get_key().name + '\a' + this->get_key().instance;
 }
 
 // Find the latest one among the two first records. Versioned records are
@@ -3022,8 +3018,8 @@ int MotrObject::fetch_latest_obj(const DoutPrefixProvider *dpp, bufferlist& bl_o
   string tenant_bkt_name = get_bucket_name(bucket->get_tenant(), bucket->get_name());
   string bucket_index_iname = "motr.rgw.bucket.index." + tenant_bkt_name;
 
-  ldpp_dout(dpp, 20) <<__func__<< ": name=" << this->get_name() << dendl;
-  keys[0] = this->get_name();
+  keys[0] = this->get_name() + '\a';
+  ldpp_dout(dpp, 20) <<__func__<< ": name=" << keys[0] << dendl;
   int rc = store->next_query_by_name(bucket_index_iname, keys, vals);
   if (rc < 0) {
     ldpp_dout(dpp, 0) <<__func__<< ": ERROR: NEXT query failed. rc=" << rc << dendl;
@@ -3068,10 +3064,7 @@ int MotrObject::get_bucket_dir_ent(const DoutPrefixProvider *dpp, rgw_bucket_dir
   string bucket_index_iname = "motr.rgw.bucket.index." + tenant_bkt_name;
   bufferlist bl;
   bufferlist::const_iterator iter;
-  std::string obj_key = this->get_key().to_str();
-
-  if (this->get_key().have_null_instance())
-    obj_key = this->get_name(); // drop "null" suffix
+  std::string obj_key = this->get_key_str();
 
   if (this->have_instance()) {
     // Check entry in the cache
@@ -3099,9 +3092,7 @@ int MotrObject::get_bucket_dir_ent(const DoutPrefixProvider *dpp, rgw_bucket_dir
   iter = bl.cbegin();
   ent.decode(iter);
 
-  obj_key = ent.key.name;
-  if (!ent.key.instance.empty())
-    obj_key += "[" + ent.key.instance + "]";
+  obj_key = ent.key.name + '\a' + ent.key.instance;
 
   // Put into the cache
   this->store->get_obj_meta_cache()->put(dpp, obj_key, bl);
@@ -3131,6 +3122,7 @@ int MotrObject::update_version_entries(const DoutPrefixProvider *dpp, bool set_i
                      << " set_is_latest=" << set_is_latest << dendl;
   rgw_bucket_dir_entry ent;
   bufferlist bl;
+
   int rc = this->fetch_latest_obj(dpp, bl);
   // no entries returned.
   if (rc == -ENOENT) {
@@ -3172,9 +3164,7 @@ int MotrObject::update_version_entries(const DoutPrefixProvider *dpp, bool set_i
       ent.flags = rgw_bucket_dir_entry::FLAG_VER;
   }
 
-  string key = ent.key.name;
-  if (!ent.key.instance.empty())
-    key += "[" + ent.key.instance + "]";
+  string key = ent.key.name + '\a' + ent.key.instance;
 
   // Remove from the cache.
   store->get_obj_meta_cache()->remove(dpp, key);
@@ -3204,10 +3194,7 @@ int MotrObject::get_part_objs(const DoutPrefixProvider* dpp,
 
   string tenant_bkt_name = get_bucket_name(bucket->get_tenant(), bucket->get_name());
   string upload_id;
-  string key_name = this->get_name();
-  if (this->have_instance())
-    key_name += "[" + this->get_instance() + "]";
-  rc = store->get_upload_id(tenant_bkt_name, key_name, upload_id);
+  rc = store->get_upload_id(tenant_bkt_name, this->get_key_str(), upload_id);
   if (rc < 0) {
     ldpp_dout(dpp, 0) <<__func__<< ": ERROR: get_upload_id failed. rc=" << rc << dendl;
     return rc;
@@ -3605,11 +3592,9 @@ int MotrAtomicWriter::complete(size_t accounted_size, const std::string& etag,
   ent.meta.owner_display_name = obj.get_bucket()->get_owner()->get_display_name();
   uint64_t size_rounded = 0;
   // For 0kb Object layout_id will not be available.
-  if (ent.meta.size != 0) {
-    uint64_t lid = M0_OBJ_LAYOUT_ID(obj.meta.layout_id);
-    uint64_t unit_sz = m0_obj_layout_id_to_unit_size(lid);
-    size_rounded = roundup(ent.meta.size, unit_sz);
-  }
+  if (ent.meta.size != 0)
+    size_rounded = roundup(ent.meta.size, obj.get_unit_sz());
+
   RGWBucketInfo &info = obj.get_bucket()->get_info();
 
   // Set version and current flag in case of both versioning enabled and suspended case.
@@ -3676,15 +3661,14 @@ int MotrAtomicWriter::complete(size_t accounted_size, const std::string& etag,
     }
   }
 
-  rc = store->do_idx_op_by_name(bucket_index_iname,
-                               M0_IC_PUT, obj.get_key().to_str(), bl);
+  string obj_key = obj.get_key_str();
+  rc = store->do_idx_op_by_name(bucket_index_iname, M0_IC_PUT, obj_key, bl);
   if (rc != 0) {
     // TODO: handle this object leak via gc.
     ldpp_dout(dpp, 0) <<__func__<< ": index operation failed, rc="<< rc << dendl;
     return rc;
   }
-  store->get_obj_meta_cache()->put(dpp, obj.get_key().to_str(), bl);
-
+  store->get_obj_meta_cache()->put(dpp, obj_key, bl);
 
   // Add object size and count in bucket stats entry.
   rc = update_bucket_stats(dpp, store, owner.to_str(), tenant_bkt_name,
@@ -3756,9 +3740,9 @@ int MotrMultipartUpload::delete_parts(const DoutPrefixProvider *dpp, std::string
   string key_name;
 
   if (upload_id.length() == 0) {
-    key_name = this->get_key();
-    if (version_id != "" && version_id != "null")
-      key_name += "[" + version_id + "]";
+    key_name = this->get_key() + '\a';
+    if (version_id != "null")
+      key_name += version_id;
     rc = store->get_upload_id(tenant_bkt_name, key_name, upload_id);
     if (rc < 0) {
       ldpp_dout(dpp, 0) <<__func__<< ": ERROR: get_upload_id failed. rc=" << rc << dendl;
@@ -3973,9 +3957,7 @@ int MotrMultipartUpload::list_parts(const DoutPrefixProvider *dpp, CephContext *
       return ret_rc;
 
     if (!ent.is_delete_marker()) {
-      key_name = ent.key.name;
-      if (ent.key.instance != "")
-        key_name += "[" + ent.key.instance + "]";
+      key_name = ent.key.name + '\a' + ent.key.instance;
       rc = store->get_upload_id(tenant_bkt_name, key_name, upload_id);
       if (rc < 0) {
         ldpp_dout(dpp, 0) <<__func__<< ": ERROR: get_upload_id failed. rc=" << rc << dendl;
@@ -4248,7 +4230,6 @@ int MotrMultipartUpload::complete(const DoutPrefixProvider *dpp,
   MotrObject::Meta meta_dummy;
   meta_dummy.encode(update_bl);
 
-  string bucket_index_iname = "motr.rgw.bucket.index." + tenant_bkt_name;
   ldpp_dout(dpp, 20) <<__func__<< ": target_obj name=" << target_obj->get_name()
                                   << " target_obj oid=" << target_obj->get_oid() << dendl;
 
@@ -4259,7 +4240,6 @@ int MotrMultipartUpload::complete(const DoutPrefixProvider *dpp,
   // Update existing object version entries in a bucket,
   // in case of both versioning enabled and suspended.
   if (info.versioned()) {
-    string bucket_index_iname = "motr.rgw.bucket.index." + tenant_bkt_name;
     rc = mobj_ver->update_version_entries(dpp);
     ldpp_dout(dpp, 20) <<__func__<< ": update_version_entries, rc=" << rc << dendl;
     if (rc < 0)
@@ -4277,12 +4257,15 @@ int MotrMultipartUpload::complete(const DoutPrefixProvider *dpp,
     mobj_ver->set_instance(ent.key.instance);
   }
 
-  rc = store->do_idx_op_by_name(bucket_index_iname, M0_IC_PUT,
-                                target_obj->get_key().to_str(), update_bl);
+  string bucket_index_iname = "motr.rgw.bucket.index." + tenant_bkt_name;
+  rgw::sal::MotrObject *tmo = static_cast<rgw::sal::MotrObject *>(target_obj);
+  string tobj_key = tmo->get_key_str();
+  rc = store->do_idx_op_by_name(bucket_index_iname, M0_IC_PUT, tobj_key, update_bl);
   if (rc < 0) {
     ldpp_dout(dpp, 0) <<__func__<< ": index operation failed, M0_IC_PUT rc=" << rc << dendl;
     return rc;
   }
+  store->get_obj_meta_cache()->put(dpp, tobj_key, update_bl);
 
   // Increment size & count for new multipart obj in bucket stats entry.
   std::string bkt_owner = target_obj->get_bucket()->get_owner()->get_id().to_str();
@@ -4297,9 +4280,6 @@ int MotrMultipartUpload::complete(const DoutPrefixProvider *dpp,
   ldpp_dout(dpp, 70) <<__func__<< ": Updated stats successfully for the "
       << "bucket/obj=" << tenant_bkt_name << "/" << target_obj->get_key().to_str()
       << ", rc=" << rc << dendl;
-
-  // Put into metadata cache.
-  store->get_obj_meta_cache()->put(dpp, target_obj->get_key().to_str(), update_bl);
 
   ldpp_dout(dpp, 20) <<__func__<< ": remove from bucket multipart index " << dendl;
   return store->do_idx_op_by_name(bucket_multipart_iname,
@@ -4539,8 +4519,7 @@ int MotrStore::get_upload_id(string tenant_bkt_name, string key_name, string& up
 
   string index_name = "motr.rgw.bucket.index." + tenant_bkt_name;
 
-  rc = this->do_idx_op_by_name(index_name,
-                              M0_IC_GET, key_name, bl);
+  rc = this->do_idx_op_by_name(index_name, M0_IC_GET, key_name, bl);
   if (rc < 0) {
     //ldpp_dout(cctx, 0) << "ERROR: NEXT query failed." << rc << dendl;
     return rc;

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -682,7 +682,6 @@ class MotrObject : public Object {
     virtual int set_obj_attrs(const DoutPrefixProvider* dpp, RGWObjectCtx* rctx, Attrs* setattrs, Attrs* delattrs, optional_yield y, rgw_obj* target_obj = NULL) override;
     virtual int get_obj_attrs(RGWObjectCtx* rctx, optional_yield y, const DoutPrefixProvider* dpp, rgw_obj* target_obj = NULL) override;
     int fetch_obj_entry_and_key(const DoutPrefixProvider* dpp, rgw_bucket_dir_entry& ent, std::string& bname, std::string& key, rgw_obj* target_obj);
-    void read_bucket_info(const DoutPrefixProvider* dpp, std::string& bname, std::string& key, rgw_obj* target_obj = NULL);
     virtual int modify_obj_attrs(RGWObjectCtx* rctx, const char* attr_name, bufferlist& attr_val, optional_yield y, const DoutPrefixProvider* dpp) override;
     virtual int delete_obj_attrs(const DoutPrefixProvider* dpp, RGWObjectCtx* rctx, const char* attr_name, optional_yield y) override;
     virtual bool is_expired() override;
@@ -756,6 +755,7 @@ class MotrObject : public Object {
                                     std::string delete_key, std::string bucket_index_iname,
                                     std::string bucket_name);
     uint64_t get_processed_bytes() { return processed_bytes; }
+    std::string get_key_str();
 };
 
 // A placeholder locking class for multipart upload.


### PR DESCRIPTION
Currently, the format of null-version objects keys stored in
bucket index in Motr does not have any suffix. But versioned
objects do have the suffix: "key[instance]". This leads to the
situations when null-objects can be fetched separately from
their versioned objects, in case there are some other objects
with the same key prefix. For example, consider the following
case:

    obj1
    obj1-2
    obj1[instance]

It's because "-" symbol goes before "[" in the ASCII-table.
As a result, the output of list-object-versions command for such
cases will be broken.

This also may affect the correct setting of IsLatest flag for
the object versions in the versioned bucket, when the new
version is put into the bucket or some existing one is deleted
from the bucket. It's because when we find the latest object
version to update, we fetch two versions using the NEXT Motr
index operation starting from the object name key (see
fetch_latest_obj()). So in the above example, obj1 will always
be returned as the latest version, which may be wrong.

Solution: append '\a' symbol to the null-version object keys,
and use it to separate key name from the instance hash.
'\a' non-printable symbol in the ASCII-table goes before all
the allowed printable symbols in the key name. So the above
example will be fetched from Motr KV like this:

    obj1\a
    obj1\ainstance
    obj1-2\a

Kudos to Sining Wu <sining.wu@seagate.com> for reporting this.

Closes #324.

Signed-off-by: Andriy Tkachuk <andriy.tkachuk@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
