### PR TITLE
rgw_sal_motr: [CORTX-32395] fix rgw crash

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -181,7 +181,7 @@ int static update_bucket_stats(const DoutPrefixProvider *dpp, MotrStore *store,
                                uint64_t size, uint64_t actual_size,
                                uint64_t num_objects = 1, bool add_stats = true) {
   uint64_t multiplier = add_stats ? 1 : -1;
-  bufferlist bl;
+  bufferlist bl, update_bl;
   std::string user_stats_iname = "motr.rgw.user.stats." + owner;
   rgw_bucket_dir_header bkt_header;
   int rc = store->do_idx_op_by_name(user_stats_iname,
@@ -199,9 +199,8 @@ int static update_bucket_stats(const DoutPrefixProvider *dpp, MotrStore *store,
   bkt_stat.total_size += multiplier * size;
   bkt_stat.actual_size += multiplier * actual_size;
 
-  bl.clear();
-  bkt_header.encode(bl);
-  rc = store->do_idx_op_by_name(user_stats_iname, M0_IC_PUT, bucket_name, bl);
+  bkt_header.encode(update_bl);
+  rc = store->do_idx_op_by_name(user_stats_iname, M0_IC_PUT, bucket_name, update_bl);
   return rc;
 }
 


### PR DESCRIPTION
Problem:
rgw server is crashing with 'ceph::buffer::v15_2_0::end_of_buffer' exception
during delete object flow becuase bl.clear() is called on ceph::bufferlist
object just before encoding new data in the same bl object.

Caused-by: PR [#291](https://github.com/Seagate/cortx-rgw/pull/291/)

Solution:
Use another bl object to encode new data instead of re-using the old one.

Signed-off-by: saurabh jain <saurabh.jain2@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
