### PR TITLE
rgw_sal_motr: [CORTX-32482] don't multiply delete markers

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1963,8 +1963,13 @@ int MotrObject::MotrDeleteOp::delete_obj(const DoutPrefixProvider* dpp, optional
           return rc;
       }
     } else {
-      // generate version-id for delete marker.
       result.delete_marker = true;
+      if (ent.is_delete_marker()) {
+        ldpp_dout(dpp, 20) << " delete-marker is already present, do nothing" << dendl;
+        result.version_id = ent.key.instance;
+        return 0;
+      }
+      // generate version-id for delete marker.
       source->gen_rand_obj_instance_name();
       std::string del_marker_ver_id = source->get_instance();
       result.version_id = del_marker_ver_id;


### PR DESCRIPTION
On deletion of an object in the versioned bucket, don't create
additional delete markers if there is one created already and
it's the latest version of the object.

This behaviour was changed recently at 09c5da2aa2b, but after
discussion, it seems more appropriate performance-wise to keep
the old behavior.

Note: AWS S3 specifies the creation of additional delete markers,
(see the note at
https://docs.aws.amazon.com/AmazonS3/latest/userguide/ManagingDelMarkers.html)
but we prefer to behave similar to Ceph RGW in this particular case.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
