### PR TITLE
rgw_sal_motr : [CORTX-31446] Copy-object: send keep alive to client to avoid req timeout

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -2210,7 +2210,7 @@ int MotrObject::copy_object_same_zone(RGWObjectCtx& obj_ctx,
   ldpp_dout(dpp, 20) << "Dest Object Name : " << dest_object->get_key().get_oid() << dendl;
 
   //similar src and dest object name is not supported as of now
-  if(this->get_key().get_oid() == dest_object->get_key().get_oid())
+  if(this->get_obj() == dest_object->get_obj())
     return -ERR_NOT_IMPLEMENTED;
 
   std::unique_ptr<rgw::sal::Object::ReadOp> read_op = this->get_read_op(&obj_ctx);

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -32,6 +32,7 @@ extern "C" {
 #include "rgw_role.h"
 #include "rgw_multi.h"
 #include "rgw_putobj_processor.h"
+typedef void (*progress_cb)(off_t, void*);
 
 namespace rgw::sal {
 
@@ -503,10 +504,23 @@ struct AccumulateIOCtxt{
 };
 
 class MotrCopyObj_Filter : public RGWGetDataCB {
+private:
+  progress_cb _progress_cb;
+  void *progress_data;
 public:
   virtual int handle_data(bufferlist& bl, off_t bl_ofs, off_t bl_len) override { return 0; }
   MotrCopyObj_Filter() {}
   virtual ~MotrCopyObj_Filter() override {}
+  void set_progress_callback(progress_cb progressCB, void *progressData){
+    this->_progress_cb = progressCB;
+    this->progress_data = progressData;
+  }
+  progress_cb get_progress_cb(){
+    return this->_progress_cb;
+  }
+  void *get_progress_data(){
+    return this->progress_data;
+  }
 };
 
 class MotrCopyObj_CB : public MotrCopyObj_Filter


### PR DESCRIPTION
…
Ticket: https://jts.seagate.com/browse/CORTX-31446

Problem Description:
Timeout error for large-sized(more than 3GB) copy-object operation.

Problem Solution:
Call the RGWCopyObj::progress_cb after writing every part, which sends the partial response to the client so that it does not time out.

Signed-off-by: Pranav Diliprao Pawar <pranav.pawar@seagate.com>



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
