### PR TITLE
[WIP]rgw_rest_user_policy.cc[CORTX-32036]:Get non existing user policy returns invalid XML

### DIFF
--- a/src/rgw/rgw_rest_user_policy.cc
+++ b/src/rgw/rgw_rest_user_policy.cc
@@ -223,30 +223,36 @@ void RGWGetUserPolicy::execute(optional_yield y)
   }
 
   if (op_ret == 0) {
-    s->formatter->open_object_section("GetUserPolicyResponse");
-    s->formatter->open_object_section("ResponseMetadata");
-    s->formatter->dump_string("RequestId", s->trans_id);
-    s->formatter->close_section();
-    s->formatter->open_object_section("GetUserPolicyResult");
     map<string, string> policies;
     if (auto it = user->get_attrs().find(RGW_ATTR_USER_POLICY); it != user->get_attrs().end()) {
       bufferlist bl = it->second;
       decode(policies, bl);
       if (auto it = policies.find(policy_name); it != policies.end()) {
         policy = policies[policy_name];
-        dump(s->formatter);
       } else {
         ldpp_dout(this, 0) << "ERROR: policy not found" << policy << dendl;
         op_ret = -ERR_NO_SUCH_ENTITY;
-        return;
       }
     } else {
       ldpp_dout(this, 0) << "ERROR: RGW_ATTR_USER_POLICY not found" << dendl;
       op_ret = -ERR_NO_SUCH_ENTITY;
-      return;
     }
-    s->formatter->close_section();
-    s->formatter->close_section();
+    if (op_ret == 0) {
+       s->formatter->open_object_section("GetUserPolicyResponse");
+       s->formatter->open_object_section("ResponseMetadata");
+       s->formatter->dump_string("RequestId", s->trans_id);
+       s->formatter->close_section();
+       s->formatter->open_object_section("GetUserPolicyResult");
+       dump(s->formatter);
+       s->formatter->close_section();
+       s->formatter->close_section();
+    }
+    else
+    {
+        s->formatter->dump_string("Response", "NoSuchEntity" );
+        op_ret = 0;
+    }
+    return;
   }
   if (op_ret < 0) {
     op_ret = -ERR_INTERNAL_ERROR;


### PR DESCRIPTION
Problem : Get non existing user policy returns invalid XML
Solution : object_section() was not properly closed in case of policy does not exist and  get user policy was returning Invalid XML

Signed-off-by: Diwakar92 <diwakar.kumar@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
