### PR TITLE
rgw_sal_motr: [CORTX-32487]  update stats behavior on multipart upload

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -3690,7 +3690,6 @@ int MotrMultipartUpload::delete_parts(const DoutPrefixProvider *dpp, std::string
 {
   int rc;
   int max_parts = 1000;
-  int total_parts_fetched = 0;
   uint64_t total_size = 0, total_size_rounded = 0;
   int marker = 0;
   bool truncated = false;
@@ -3707,7 +3706,6 @@ int MotrMultipartUpload::delete_parts(const DoutPrefixProvider *dpp, std::string
       return rc;
 
     std::map<uint32_t, std::unique_ptr<MultipartPart>>& parts = this->get_parts();
-    total_parts_fetched += parts.size();
     for (auto part_iter = parts.begin(); part_iter != parts.end(); ++part_iter) {
 
       MultipartPart *mpart = part_iter->second.get();
@@ -3753,10 +3751,10 @@ int MotrMultipartUpload::delete_parts(const DoutPrefixProvider *dpp, std::string
     *size_rounded = total_size_rounded;
 
   if (get_upload_id().length()) {
-    // Subtract size & count of all the parts if multipart is not completed.
+    // Subtract size & object count if multipart is not completed.
     rc = update_bucket_stats(dpp, store,
                              bucket->get_owner()->get_id().to_str(), tenant_bkt_name,
-                             total_size, total_size_rounded, total_parts_fetched, false);
+                             total_size, total_size_rounded, 1, false);
     if (rc != 0) {
       ldpp_dout(dpp, 20) <<__func__<< ": Failed stats substraction for the "
         << "bucket/obj=" << tenant_bkt_name << "/" << mp_obj.get_key()
@@ -3922,10 +3920,19 @@ int MotrMultipartUpload::init(const DoutPrefixProvider *dpp, optional_yield y,
   rc = store->create_motr_idx_by_name(obj_part_iname);
   if (rc == -EEXIST)
     rc = 0;
-  if (rc < 0)
+  if (rc < 0) {
     // TODO: clean the bucket index entry
     ldpp_dout(dpp, 0) << "Failed to create object multipart index  " << obj_part_iname << dendl;
+    return rc;
+  }
 
+  // initialize with size=0 & object count=1 
+  rc = update_bucket_stats(dpp, store, owner.get_id().to_str(), tenant_bkt_name, 0, 0, 1, true);
+  if (rc != 0) {
+    ldpp_dout(dpp, 20) <<__func__<< ": Failed stats substraction for the "
+      << "bucket/obj=" << tenant_bkt_name << "/" << mp_obj.get_key()
+      << ", rc=" << rc << dendl;
+  }
   return rc;
 }
 
@@ -4267,20 +4274,6 @@ int MotrMultipartUpload::complete(const DoutPrefixProvider *dpp,
   }
   store->get_obj_meta_cache()->put(dpp, tobj_key, update_bl);
 
-  // Increment size & count for new multipart obj in bucket stats entry.
-  std::string bkt_owner = target_obj->get_bucket()->get_owner()->get_id().to_str();
-  rc = update_bucket_stats(dpp, store, bkt_owner, tenant_bkt_name,
-                           0, 0, total_parts - 1, false);
-  if (rc != 0) {
-    ldpp_dout(dpp, 20) <<__func__<< ": Failed stats update for the "
-      << "bucket/obj=" << tenant_bkt_name << "/" << target_obj->get_key().to_str()
-      << ", rc=" << rc << dendl;
-    return rc;
-  }
-  ldpp_dout(dpp, 70) <<__func__<< ": Updated stats successfully for the "
-      << "bucket/obj=" << tenant_bkt_name << "/" << target_obj->get_key().to_str()
-      << ", rc=" << rc << dendl;
-
   ldpp_dout(dpp, 20) <<__func__<< ": remove from bucket multipart index " << dendl;
   return store->do_idx_op_by_name(bucket_multipart_iname,
                                   M0_IC_DEL, meta_obj->get_key().to_str(), bl);
@@ -4427,7 +4420,6 @@ int MotrMultipartWriter::complete(size_t accounted_size, const std::string& etag
   info.accounted_size = accounted_size;
   info.modified = real_clock::now();
   uint64_t old_part_size = 0, old_part_size_rounded = 0;
-  bool old_part_exist = false;
 
   bool compressed;
   int rc = rgw_compression_info_from_attrset(attrs, compressed, info.cs_info);
@@ -4477,7 +4469,6 @@ int MotrMultipartWriter::complete(size_t accounted_size, const std::string& etag
     ldpp_dout(dpp, 20) <<__func__<< ": Old part with oid [" << oid_str << "] exists" << dendl;
     old_part_size = old_part_info.accounted_size;
     old_part_size_rounded = old_part_info.size_rounded;
-    old_part_exist = true;
     // Delete old object
     rc = old_mobj->delete_mobj(dpp);
     if (rc == 0) {
@@ -4493,13 +4484,13 @@ int MotrMultipartWriter::complete(size_t accounted_size, const std::string& etag
     ldpp_dout(dpp, 0) <<__func__<< ": failed to add part obj in part index, rc=" << rc << dendl;
     return rc == -ENOENT ? -ERR_NO_SUCH_UPLOAD : rc;
   }
-
-   rc = update_bucket_stats(dpp, store,
+   
+  // update size without changing the object count
+  rc = update_bucket_stats(dpp, store,
                            head_obj->get_bucket()->get_owner()->get_id().to_str(),
                            tenant_bkt_name,
                            actual_part_size - old_part_size,
-                           size_rounded - old_part_size_rounded,
-                           1 - old_part_exist);
+                           size_rounded - old_part_size_rounded, 0, true);
   if (rc != 0) {
     ldpp_dout(dpp, 20) <<__func__<< ": Failed stats update for the "
       << "obj/part=" << head_obj->get_key().to_str() << "/" << part_num


### PR DESCRIPTION
Update Stats behaviour for multipart upload sessions

#### Earlier Behaviour
Increment object count in a bucket per part upload in a multipart session.
At the multipart complete stage adjust the object count so that only one
object is added in the end.

#### Problem
If the user quota is of 3 objects then the user can not upload more than 3 parts 
for a single multipart object. (This is because we are updating the object count
for each part.)

#### Resolution
Increment the object count only at a multipart init stage. 
Increment the object size on the upload of each part. (no update for obj_count).

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
