### PR TITLE
rgw: [CORTX-32037] Fix for IAM policy document with no statement being accepted

### DIFF
--- a/src/rgw/rgw_rest_user_policy.cc
+++ b/src/rgw/rgw_rest_user_policy.cc
@@ -143,6 +143,12 @@ void RGWPutUserPolicy::execute(optional_yield y)
 
   try {
     const Policy p(s->cct, s->user->get_tenant(), bl);
+    if(p.statements.empty())
+    {
+      ldpp_dout(this, 20) << "Empty statements in policy document." << dendl;
+      op_ret = -ERR_MALFORMED_DOC;
+      return;
+    }
     uint32_t pol_size_occupied = user->get_user_policy_size();
     uint32_t pol_size = policy.size();
 


### PR DESCRIPTION
Problem : Put user policy with no statement is accepted
Solution : Checked if policy document doesn't contain any statement then returned "MalformedPolicyDocument".