### PR TITLE
rgw_sal_motr: [CORTX-32463] handle _ (underscore) in object key name

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -3583,9 +3583,7 @@ int MotrAtomicWriter::complete(size_t accounted_size, const std::string& etag,
   // and RGWRados::Object::Write::write_meta() in rgw_rados.cc for what and
   // how to set the dir entry. Only set the basic ones for POC, no ACLs and
   // other attrs.
-  rgw_obj_key key = obj.get_key();
-  ent.key.name = key.name;
-  ent.key.instance = key.instance;
+  obj.get_key().get_index_key(&ent.key);
   ent.meta.size = total_data_size;
   ent.meta.accounted_size = total_data_size;
   ent.meta.mtime = real_clock::is_zero(set_mtime)? ceph::real_clock::now() : set_mtime;
@@ -3874,9 +3872,7 @@ int MotrMultipartUpload::init(const DoutPrefixProvider *dpp, optional_yield y,
     // size, etag etc.
     bufferlist bl;
     rgw_bucket_dir_entry ent;
-    rgw_obj_key key = obj->get_key();
-    ent.key.name = key.name;
-    ent.key.instance = key.instance;
+    obj->get_key().get_index_key(&ent.key);
     ent.meta.owner = owner.get_id().to_str();
     ent.meta.category = RGWObjCategory::MultiMeta;
     ent.meta.mtime = ceph::real_clock::now();
@@ -4111,6 +4107,23 @@ int MotrMultipartUpload::complete(const DoutPrefixProvider *dpp,
       hash.Update((const unsigned char *)petag, sizeof(petag));
       ldpp_dout(dpp, 20) <<__func__<< ": calc etag " << dendl;
 
+      string oid = mp_obj.get_part(part->num);
+      rgw_obj src_obj;
+      src_obj.init_ns(bucket->get_key(), oid, mp_ns);
+
+#if 0 // does Motr backend need it?
+      /* update manifest for part */
+      if (part->manifest.empty()) {
+        ldpp_dout(dpp, 0) <<__func__<< ": ERROR: empty manifest for object part: obj="
+			 << src_obj << dendl;
+        rc = -ERR_INVALID_PART;
+        return rc;
+      } else {
+        manifest.append(dpp, part->manifest, store->get_zone());
+      }
+      ldpp_dout(dpp, 0) <<__func__<< ": manifest " << dendl;
+#endif
+
       bool part_compressed = (part->cs_info.compression_type != "none");
       if ((handled_parts > 0) &&
           ((part_compressed != compressed) ||
@@ -4141,6 +4154,14 @@ int MotrMultipartUpload::complete(const DoutPrefixProvider *dpp,
         cs_info.orig_size += part->cs_info.orig_size;
         compressed = true;
       }
+
+      // We may not need to do the following as remove_objs are those
+      // don't show when listing a bucket. As we store in-progress uploaded
+      // object's metadata in a separate index, they are not shown when
+      // listing a bucket.
+      rgw_obj_index_key remove_key;
+      src_obj.key.get_index_key(&remove_key);
+      remove_objs.push_back(remove_key);
 
       off += part_size;
       accounted_size += part->accounted_size;
@@ -4194,9 +4215,7 @@ int MotrMultipartUpload::complete(const DoutPrefixProvider *dpp,
   // Update the dir entry and insert it to the bucket index so
   // the object will be seen when listing the bucket.
   bufferlist update_bl, old_check_bl;
-  rgw_obj_key key = target_obj->get_key();
-  ent.key.name = key.name;
-  ent.key.instance = key.instance;
+  target_obj->get_key().get_index_key(&ent.key);  // Change to offical name :)
   ent.meta.size = off;
   ent.meta.accounted_size = accounted_size;
   ldpp_dout(dpp, 20) <<__func__<< ": obj size=" << ent.meta.size

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1306,22 +1306,23 @@ int MotrBucket::list(const DoutPrefixProvider *dpp, ListParams& params, int max,
         rgw_bucket_dir_entry ent;
         auto iter = vals[i].cbegin();
         ent.decode(iter);
+        rgw_obj_key key(ent.key);
         if (params.list_versions || ent.is_visible()) {
-          if (ent.key.name == params.marker.name &&
+          if (key.name == params.marker.name &&
               // filter out versions which go before marker.instance
               ((!null_ent.key.empty() && params.marker.instance == "null" &&
                  null_ent.meta.mtime < ent.meta.mtime) ||
-               (ent.key.instance != "" &&
-                ent.key.instance < params.marker.instance)))
+               (key.instance != "" &&
+                key.instance < params.marker.instance)))
             continue;
 check_keycount:
           if (keycount >= max) {
             if (!null_ent.key.empty() &&
                 (null_ent.key.name != ent.key.name ||
                  null_ent.meta.mtime > ent.meta.mtime))
-              results.next_marker = rgw_obj_key(ent.key.name, "null");
+              results.next_marker = rgw_obj_key(key.name, "null");
             else
-              results.next_marker = rgw_obj_key(ent.key.name, ent.key.instance);
+              results.next_marker = rgw_obj_key(key.name, key.instance);
             results.is_truncated = true;
             break;
           }
@@ -1332,7 +1333,7 @@ check_keycount:
               (null_ent.key.name != ent.key.name ||
                null_ent.meta.mtime > ent.meta.mtime)) {
             if (params.marker.instance != "" &&
-                ent.key.instance == params.marker.instance)
+                key.instance == params.marker.instance)
               null_ent.key = {}; // filtered out by the marker
             else {
               results.objs.emplace_back(std::move(null_ent));
@@ -1340,7 +1341,7 @@ check_keycount:
               goto check_keycount;
             }
           }
-          if (ent.key.instance == "")
+          if (key.instance == "")
             null_ent = std::move(ent);
           else {
             results.objs.emplace_back(std::move(ent));
@@ -1426,7 +1427,7 @@ int MotrBucket::list_multiparts(const DoutPrefixProvider *dpp,
     if (prefix.size() &&
         (0 != key.name.compare(0, prefix.size(), prefix))) {
       ldpp_dout(dpp, 20) <<__func__<<
-        ": skippping \"" << ent.key <<
+        ": skippping \"" << key <<
         "\" because doesn't match prefix" << dendl;
       continue;
     }
@@ -1591,7 +1592,8 @@ int MotrObject::fetch_obj_entry_and_key(const DoutPrefixProvider* dpp, rgw_bucke
   else
     bname = get_bucket_name(this->get_bucket()->get_tenant(), this->get_bucket()->get_name());
 
-  key = ent.key.name + '\a' + ent.key.instance;
+  rgw_obj_key objkey(ent.key);
+  key = objkey.name + '\a' + objkey.instance;
 
   ldpp_dout(dpp, 20) <<__func__<< ": bucket=" << bname << " key=" << key << dendl;
 
@@ -1967,7 +1969,8 @@ int MotrObject::MotrDeleteOp::delete_obj(const DoutPrefixProvider* dpp, optional
   // we should consider adding object entry to GC before deleting the metadata.
   // Delete from the cache first.
   source->store->get_obj_meta_cache()->remove(dpp, delete_key);
-
+  ldpp_dout(dpp, 20) << __func__ << ": Deleting key " << delete_key << " from "
+                            << tenant_bkt_name << dendl;
   // Remove the motr object.
   // versioning enabled and suspended case.
   if (info.versioned()) {
@@ -1976,20 +1979,18 @@ int MotrObject::MotrDeleteOp::delete_obj(const DoutPrefixProvider* dpp, optional
       result.version_id = ent.key.instance;
       if (ent.is_delete_marker())
         result.delete_marker = true;
-      ldpp_dout(dpp, 20) << "delete " << delete_key << " from "
-                            << tenant_bkt_name << dendl;
 
       rc = source->remove_mobj_and_index_entry(
           dpp, ent, delete_key, bucket_index_iname, tenant_bkt_name);
       if (rc < 0) {
-        ldpp_dout(dpp, 0) << "Failed to delete the object from Motr."
-	                          <<" key=" << delete_key << dendl;
+        ldpp_dout(dpp, 0) << __func__ << ": Failed to delete the object from Motr."
+                          <<" key=" << delete_key << dendl;
         return rc;
       }
       // if deleted object version is the latest version,
       // then update is-latest flag to true for previous version.
       if (ent.is_current()) {
-        ldpp_dout(dpp, 20) << "Updating previous version entries " << dendl;
+        ldpp_dout(dpp, 20) << __func__ << ": Updating previous version entries " << dendl;
         bool set_is_latest=true;
         rc = source->update_version_entries(dpp, set_is_latest);
         if (rc < 0)
@@ -2005,7 +2006,7 @@ int MotrObject::MotrDeleteOp::delete_obj(const DoutPrefixProvider* dpp, optional
       if (!info.versioning_enabled()) {
         result.version_id = "";
         if (ent.is_delete_marker() && ent.key.instance == "") {
-          ldpp_dout(dpp, 0) << "null-delete-marker is already present." << dendl;
+          ldpp_dout(dpp, 0) << __func__ << ": null-delete-marker is already present." << dendl;
           return 0;
         }
         // if latest version is null version, then delete the null version-object and
@@ -2016,7 +2017,7 @@ int MotrObject::MotrDeleteOp::delete_obj(const DoutPrefixProvider* dpp, optional
           rc = source->remove_mobj_and_index_entry(
             dpp, ent, delete_key, bucket_index_iname, tenant_bkt_name);
           if (rc < 0) {
-            ldpp_dout(dpp, 0) << "Failed to delete the object from Motr, key="<< delete_key << dendl;
+            ldpp_dout(dpp, 0) <<  __func__ << ": Failed to delete the object from Motr, key="<< delete_key << dendl;
             return rc;
           }
         }
@@ -2024,7 +2025,7 @@ int MotrObject::MotrDeleteOp::delete_obj(const DoutPrefixProvider* dpp, optional
 
       source->set_instance(result.version_id);
       // update is-latest=false for current version entry.
-      ldpp_dout(dpp, 20) << "Updating previous version entries " << dendl;
+      ldpp_dout(dpp, 20) << __func__ << ": Updating previous version entries " << dendl;
       rc = source->update_version_entries(dpp);
       if (rc < 0)
         return rc;
@@ -2036,8 +2037,6 @@ int MotrObject::MotrDeleteOp::delete_obj(const DoutPrefixProvider* dpp, optional
       result.version_id = "null"; // show it as "null" in the reply
   } else {
     // Unversioned flow
-    // handling empty size object case
-    ldpp_dout(dpp, 20) << "delete " << delete_key << " from " << tenant_bkt_name << dendl;
     rc = source->remove_mobj_and_index_entry(
         dpp, ent, delete_key, bucket_index_iname, tenant_bkt_name);
     if (rc < 0) {
@@ -3039,10 +3038,10 @@ int MotrObject::fetch_latest_obj(const DoutPrefixProvider *dpp, bufferlist& bl_o
 
     auto iter = bl.cbegin();
     ent.decode(iter);
-
-    ldpp_dout(dpp, 20) <<__func__<< ": ent.key=" << ent.key.to_string()
+    rgw_obj_key key(ent.key);
+    ldpp_dout(dpp, 20) <<__func__<< ": key=" << key.to_str()
                        << " is_current=" << ent.is_current() << dendl;
-    if (ent.key.name != this->get_name())
+    if (key.name != this->get_name())
       break;
 
     if (null_ent.key.empty())
@@ -3064,6 +3063,7 @@ int MotrObject::get_bucket_dir_ent(const DoutPrefixProvider *dpp, rgw_bucket_dir
   string bucket_index_iname = "motr.rgw.bucket.index." + tenant_bkt_name;
   bufferlist bl;
   bufferlist::const_iterator iter;
+  rgw_obj_key key;
   std::string obj_key = this->get_key_str();
 
   if (this->have_instance()) {
@@ -3091,8 +3091,8 @@ int MotrObject::get_bucket_dir_ent(const DoutPrefixProvider *dpp, rgw_bucket_dir
 
   iter = bl.cbegin();
   ent.decode(iter);
-
-  obj_key = ent.key.name + '\a' + ent.key.instance;
+  key.set(ent.key);
+  obj_key = key.name + '\a' + key.instance;
 
   // Put into the cache
   this->store->get_obj_meta_cache()->put(dpp, obj_key, bl);
@@ -3163,8 +3163,8 @@ int MotrObject::update_version_entries(const DoutPrefixProvider *dpp, bool set_i
     else
       ent.flags = rgw_bucket_dir_entry::FLAG_VER;
   }
-
-  string key = ent.key.name + '\a' + ent.key.instance;
+  rgw_obj_key objkey(ent.key);
+  string key = objkey.name + '\a' + objkey.instance;
 
   // Remove from the cache.
   store->get_obj_meta_cache()->remove(dpp, key);
@@ -3957,7 +3957,8 @@ int MotrMultipartUpload::list_parts(const DoutPrefixProvider *dpp, CephContext *
       return ret_rc;
 
     if (!ent.is_delete_marker()) {
-      key_name = ent.key.name + '\a' + ent.key.instance;
+      rgw_obj_key key(ent.key);
+      key_name = key.name + '\a' + key.instance;
       rc = store->get_upload_id(tenant_bkt_name, key_name, upload_id);
       if (rc < 0) {
         ldpp_dout(dpp, 0) <<__func__<< ": ERROR: get_upload_id failed. rc=" << rc << dendl;
@@ -4107,23 +4108,6 @@ int MotrMultipartUpload::complete(const DoutPrefixProvider *dpp,
       hash.Update((const unsigned char *)petag, sizeof(petag));
       ldpp_dout(dpp, 20) <<__func__<< ": calc etag " << dendl;
 
-      string oid = mp_obj.get_part(part->num);
-      rgw_obj src_obj;
-      src_obj.init_ns(bucket->get_key(), oid, mp_ns);
-
-#if 0 // does Motr backend need it?
-      /* update manifest for part */
-      if (part->manifest.empty()) {
-        ldpp_dout(dpp, 0) <<__func__<< ": ERROR: empty manifest for object part: obj="
-			 << src_obj << dendl;
-        rc = -ERR_INVALID_PART;
-        return rc;
-      } else {
-        manifest.append(dpp, part->manifest, store->get_zone());
-      }
-      ldpp_dout(dpp, 0) <<__func__<< ": manifest " << dendl;
-#endif
-
       bool part_compressed = (part->cs_info.compression_type != "none");
       if ((handled_parts > 0) &&
           ((part_compressed != compressed) ||
@@ -4154,14 +4138,6 @@ int MotrMultipartUpload::complete(const DoutPrefixProvider *dpp,
         cs_info.orig_size += part->cs_info.orig_size;
         compressed = true;
       }
-
-      // We may not need to do the following as remove_objs are those
-      // don't show when listing a bucket. As we store in-progress uploaded
-      // object's metadata in a separate index, they are not shown when
-      // listing a bucket.
-      rgw_obj_index_key remove_key;
-      src_obj.key.get_index_key(&remove_key);
-      remove_objs.push_back(remove_key);
 
       off += part_size;
       accounted_size += part->accounted_size;


### PR DESCRIPTION
## Problem:
        rgw_obj_key::get_index_key() api has some specially handling for ns (namespace) which is spefic to rados backend.
        If obejct key starts from '_' then get_index_key appends one more '_' to the key name.
        This causes issue during lookup for the same key.

## Solution:
        Convert cls_rgw_obj_key type to rgw_obj_key before comparing object keys or creating index keys.


## Revert PR #345 
       "rgw_motr_sal: [CORTX-32463] fix GET api for object starting from '_'"
        This reverts commit a1584461394babb5183c9f21806be64ccacb27b2.
        Reason: We have to use rgw_obj_key::get_index_key() function to support rgw framework.


Signed-off-by: Saurabh Jain <saurabh.jain2@seagate.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
