### PR TITLE
rgw_sal_motr : [CORTX-32966] Fix memory leaks in RGW

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1140,6 +1140,7 @@ int MotrBucket::check_quota(const DoutPrefixProvider *dpp,
   int rc = quota_handler->check_quota(dpp, info.owner, info.bucket,
                                       user_quota, bucket_quota,
                                       check_size_only ? 0 : 1, obj_size, y);
+  RGWQuotaHandler::free_handler(quota_handler);
   return rc;
 }
 


### PR DESCRIPTION
JIRA ticket : https://jts.seagate.com/browse/CORTX-32966

Problem Description:
Pointer variable was not freed at one the place in SAL layer (int MotrBucket::check_quota) which was leaking the memory.

Problem Solution:
Freeing the pointer after its use.

Signed-off-by: Pranav Diliprao Pawar <pranav.pawar@seagate.com>

WORKLOAD:
numSamples : 1
numClients : 1
objectSize : 80MB

## Testing Done
<details><summary> Leak Summary Before: </summary>

LEAK SUMMARY:
definitely lost: 61,650 bytes in 52 blocks
indirectly lost: 5,535 bytes in 1,069 blocks
possibly lost: 0 bytes in 0 blocks
still reachable: 6,766 bytes in 22 blocks
suppressed: 0 bytes in 0 blocks

</details>

<details><summary> Leak Summary After: </summary>

LEAK SUMMARY:
definitely lost: 1,650 bytes in 16 blocks
indirectly lost: 288 bytes in 3 blocks
possibly lost: 0 bytes in 0 blocks
still reachable: 6,766 bytes in 22 blocks
suppressed: 0 bytes in 0 blocks
</details>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
