### PR TITLE
rgw_sal_motr: [CORTX-31442] Enable tagging for copy-object

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -145,7 +145,7 @@ int parse_tags(const DoutPrefixProvider* dpp, bufferlist& tags_bl, struct req_st
     obj_tags = std::make_unique<RGWObjTags>();
     int ret = obj_tags->set_from_string(tag_str);
     if (ret < 0) {
-      ldpp_dout(dpp, 0) <<__func__<< "setting obj tags failed with rc=" << ret << dendl;
+      ldpp_dout(dpp, 0) <<__func__<< ": setting obj tags failed with rc=" << ret << dendl;
       if (ret == -ERR_INVALID_TAG) {
         ret = -EINVAL; //s3 returns only -EINVAL for PUT requests
       }
@@ -2328,7 +2328,7 @@ int MotrObject::copy_object_same_zone(RGWObjectCtx& obj_ctx,
   bufferlist bl;
   rc = read_op->get_attr(dpp, RGW_ATTR_ETAG, bl, y);
   if (rc < 0){
-    ldpp_dout(dpp, 0) <<__func__<< "ERROR: read op for etag failed rc=" << rc << dendl;
+    ldpp_dout(dpp, 0) <<__func__<< ": ERROR: read op for etag failed rc=" << rc << dendl;
     return rc;
   }
   string etag_str;
@@ -2347,14 +2347,14 @@ int MotrObject::copy_object_same_zone(RGWObjectCtx& obj_ctx,
     if (strcasecmp(tagging_drctv, "COPY") == 0) {
       rc = read_op->get_attr(dpp, RGW_ATTR_TAGS, tags_bl, y);
       if (rc < 0) {
-        ldpp_dout(dpp, 0) <<__func__<< "ERROR: read op for object tags failed rc=" << rc << dendl;
+        ldpp_dout(dpp, 0) <<__func__<< ": ERROR: read op for object tags failed rc=" << rc << dendl;
         return rc;
       }
     } else if (strcasecmp(tagging_drctv, "REPLACE") == 0) {
-      ldpp_dout(dpp, 20) <<__func__<< "Parse tag values for object: " << dest_object->get_key().get_oid() << dendl;
+      ldpp_dout(dpp, 20) <<__func__<< ": Parse tag values for object: " << dest_object->get_key().to_str() << dendl;
       int r = parse_tags(dpp, tags_bl, s);
       if (r < 0) {
-        ldpp_dout(dpp, 0) <<__func__<< "ERROR: Parsing object tags failed rc=" << rc << dendl;
+        ldpp_dout(dpp, 0) <<__func__<< ": ERROR: Parsing object tags failed rc=" << rc << dendl;
         return r;
       }
     }
@@ -3921,7 +3921,7 @@ int MotrMultipartUpload::init(const DoutPrefixProvider *dpp, optional_yield y,
     ent.encode(bl);
     req_state *s = (req_state *) obj_ctx->get_private();
     bufferlist tags_bl;
-    ldpp_dout(dpp, 20) <<__func__<< "Parse tag values for object: " << obj->get_key().to_str() << dendl;
+    ldpp_dout(dpp, 20) <<__func__<< ": Parse tag values for object: " << obj->get_key().to_str() << dendl;
     int r = parse_tags(dpp, tags_bl, s);
     if (r < 0) {
       ldpp_dout(dpp, 0) <<__func__<< "ERROR: Parsing object tags failed rc=" << r << dendl;

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -2328,7 +2328,7 @@ int MotrObject::copy_object_same_zone(RGWObjectCtx& obj_ctx,
   bufferlist bl;
   rc = read_op->get_attr(dpp, RGW_ATTR_ETAG, bl, y);
   if (rc < 0){
-    ldpp_dout(dpp, 20) <<__func__<< "ERROR: read op for etag failed rc=" << rc << dendl;
+    ldpp_dout(dpp, 0) <<__func__<< "ERROR: read op for etag failed rc=" << rc << dendl;
     return rc;
   }
   string etag_str;
@@ -2340,20 +2340,21 @@ int MotrObject::copy_object_same_zone(RGWObjectCtx& obj_ctx,
 
   //Set object tags based on tagging-directive
   struct req_state* s = static_cast<req_state*>(obj_ctx.get_private());
-  auto tagging_dir = s->info.env->get("HTTP_X_AMZ_TAGGING_DIRECTIVE");
+  auto tagging_drctv = s->info.env->get("HTTP_X_AMZ_TAGGING_DIRECTIVE");
 
   bufferlist tags_bl;
-  if (tagging_dir) {
-    if (strcasecmp(tagging_dir, "COPY") == 0) {
+  if (tagging_drctv) {
+    if (strcasecmp(tagging_drctv, "COPY") == 0) {
       rc = read_op->get_attr(dpp, RGW_ATTR_TAGS, tags_bl, y);
       if (rc < 0) {
-        ldpp_dout(dpp, 20) <<__func__<< "ERROR: read op for object tags failed rc=" << rc << dendl;
+        ldpp_dout(dpp, 0) <<__func__<< "ERROR: read op for object tags failed rc=" << rc << dendl;
         return rc;
       }
-    } else if (strcasecmp(tagging_dir, "REPLACE") == 0) {
+    } else if (strcasecmp(tagging_drctv, "REPLACE") == 0) {
       int r = parse_tags(dpp, tags_bl, s);
+      ldpp_dout(dpp, 20) <<__func__<< "Parse tag values for object: " << dest_object->get_key().get_oid() << dendl;
       if (r < 0) {
-        ldpp_dout(dpp, 20) <<__func__<< "ERROR: Parsing object tags failed rc=" << rc << dendl;
+        ldpp_dout(dpp, 0) <<__func__<< "ERROR: Parsing object tags failed rc=" << rc << dendl;
         return r;
       }
     }
@@ -3920,9 +3921,10 @@ int MotrMultipartUpload::init(const DoutPrefixProvider *dpp, optional_yield y,
     ent.encode(bl);
     req_state *s = (req_state *) obj_ctx->get_private();
     bufferlist tags_bl;
+    ldpp_dout(dpp, 20) <<__func__<< "Parse tag values for object: " << obj->get_key().to_str() << dendl;
     int r = parse_tags(dpp, tags_bl, s);
     if (r < 0) {
-      ldpp_dout(dpp, 20) <<__func__<< "ERROR: Parsing object tags failed rc=" << r << dendl;
+      ldpp_dout(dpp, 0) <<__func__<< "ERROR: Parsing object tags failed rc=" << r << dendl;
       return r;
     }
     attrs[RGW_ATTR_TAGS] = tags_bl;

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -41,7 +41,6 @@ extern "C" {
 #include "rgw_bucket.h"
 #include "rgw_quota.h"
 #include "motr/addb/rgw_addb.h"
-#include "rgw_tag_s3.h"
 
 #define dout_subsys ceph_subsys_rgw
 

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -2351,8 +2351,8 @@ int MotrObject::copy_object_same_zone(RGWObjectCtx& obj_ctx,
         return rc;
       }
     } else if (strcasecmp(tagging_drctv, "REPLACE") == 0) {
-      int r = parse_tags(dpp, tags_bl, s);
       ldpp_dout(dpp, 20) <<__func__<< "Parse tag values for object: " << dest_object->get_key().get_oid() << dendl;
+      int r = parse_tags(dpp, tags_bl, s);
       if (r < 0) {
         ldpp_dout(dpp, 0) <<__func__<< "ERROR: Parsing object tags failed rc=" << rc << dendl;
         return r;


### PR DESCRIPTION
problem:
Tagging is not enabled for copy-object API with motr as backend.

solution:
Enabled tagging support for copy-object with --tagging-directive as COPY and REPLACE

Signed-off-by: Selvakumar <selva.k.nambi@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
