### PR TITLE
rgw_sal_motr: Fix Codacy warning in ADDB readme file

### DIFF
--- a/src/rgw/motr/addb/README.md
+++ b/src/rgw/motr/addb/README.md
@@ -2,7 +2,8 @@ ADDB is Motr sub-system, which provides convenient way for system events logging
 rgw_sal_motr.cc is instumented with ADDB() calls, which add entries into so-called ADDB storage object (ADDB stob). Entries are added in binary format and can be parsed to human-readable format by invoking `m0addb2dump` utility and RGW ADDB plugin, that allows to map binary entries to corresponding layer ID and parameters.
 `m0addb2utility` can found after standard installation of cortx-motr rpm, and RGW ADDB plugin (rgw_addb_plugin.so) is installed during cortx-rgw-integration rpm installation to /opt/seagate/cortx/rgw/bin path.
 RGW ADDB plugin can be compiled manually:
-```
+
+```console
 # git clone https://github.com/Seagate/cortx-rgw-integration
 # cd cortx-rgw-integration
 # cd src/addb_plugin


### PR DESCRIPTION
Problem:
Codacy throws warning in src/rgw/motr/addb/README.md on inlined code block.

Solution:
Label code block with `console` attribute.

Signed-off-by: Maxim Malezhin <maxim.malezhin@seagate.com>



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [Y] Doc update (no ticket needed)
  - [Y] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [Y] No impact that needs to be tracked
- Documentation (select at least one)
  - [Y] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [Y] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>


-----
[View rendered src/rgw/motr/addb/README.md](https://github.com/maximalezhin/cortx-rgw/blob/fix-codacy/src/rgw/motr/addb/README.md)