### PR TITLE
CORTX-32900 : RGW-SAL: Enable flag M0_ENF_GEN_DI for checksum generation in Motr client

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1985,6 +1985,7 @@ int MotrObject::write_mobj(const DoutPrefixProvider *dpp, bufferlist&& in_buffer
     attr.ov_vec.v_count[0] = 0;
 
     op = nullptr;
+    this->mobj->ob_entity.en_flags |= M0_ENF_GEN_DI;
     rc = m0_obj_op(this->mobj, M0_OC_WRITE, &ext, &buf, &attr, 0, 0, &op);
     if (rc != 0)
       goto out;
@@ -2068,7 +2069,7 @@ int MotrObject::read_mobj(const DoutPrefixProvider* dpp, int64_t off, int64_t en
     }
     if( bloff != 0 )
 	bloff = start - block_start_off;
-
+    this->mobj->ob_entity.en_flags |= M0_ENF_GEN_DI;
     rc = m0_obj_op(this->mobj, M0_OC_READ, &ext, &buf, &attr, 0, 0, &op);
     ldpp_dout(dpp, 20) << "MotrObject::read_mobj(): init read op rc=" << rc << dendl;
     if (rc != 0) {
@@ -2486,6 +2487,7 @@ int MotrAtomicWriter::write()
     left -= this->populate_bvec(bs, bi);
 
     op = nullptr;
+    obj.mobj->ob_entity.en_flags |= M0_ENF_GEN_DI;
     rc = m0_obj_op(obj.mobj, M0_OC_WRITE, &ext, &buf, &attr, 0, 0, &op);
     if (rc != 0)
       goto err;

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -2527,7 +2527,7 @@ int MotrObject::create_mobj(const DoutPrefixProvider *dpp, uint64_t sz)
   m0_obj_init(mobj, &store->container.co_realm, &meta.oid, lid);
 
   struct m0_op *op = nullptr;
-   mobj->ob_entity.en_flags |= (M0_ENF_META | M0_ENF_GEN_DI);
+  mobj->ob_entity.en_flags |= (M0_ENF_META | M0_ENF_GEN_DI);
   rc = m0_entity_create(nullptr, &mobj->ob_entity, &op);
   if (rc != 0) {
     ADDB(RGW_ADDB_REQUEST_ID, addb_logger.get_id(),
@@ -2798,7 +2798,6 @@ int MotrObject::write_mobj(const DoutPrefixProvider *dpp, bufferlist&& in_buffer
   start = data.c_str();
   for (p = start; left > 0; left -= bs, p += bs, offset += bs) {
     if (left < bs) {
-      mobj->ob_entity.en_flags |= M0_ENF_GEN_DI;
       bs = this->get_optimal_bs(left, true);
       flags |= M0_OOF_LAST;
     }

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1772,7 +1772,7 @@ int MotrObject::create_mobj(const DoutPrefixProvider *dpp, uint64_t sz)
   m0_obj_init(mobj, &store->container.co_realm, &meta.oid, lid);
 
   struct m0_op *op = nullptr;
-  mobj->ob_entity.en_flags |= M0_ENF_META;
+   mobj->ob_entity.en_flags |= (M0_ENF_META | M0_ENF_GEN_DI);
   rc = m0_entity_create(nullptr, &mobj->ob_entity, &op);
   if (rc != 0) {
     this->close_mobj();
@@ -1830,7 +1830,7 @@ int MotrObject::open_mobj(const DoutPrefixProvider *dpp)
   struct m0_op *op = nullptr;
   mobj->ob_attr.oa_layout_id = meta.layout_id;
   mobj->ob_attr.oa_pver      = meta.pver;
-  mobj->ob_entity.en_flags  |= M0_ENF_META;
+  mobj->ob_entity.en_flags  |= (M0_ENF_META | M0_ENF_GEN_DI);
   rc = m0_entity_open(&mobj->ob_entity, &op);
   if (rc != 0) {
     ldpp_dout(dpp, 0) << "ERROR: m0_entity_open() failed: rc=" << rc << dendl;
@@ -1874,7 +1874,7 @@ int MotrObject::delete_mobj(const DoutPrefixProvider *dpp)
 
   // Create an DELETE op and execute it (sync version).
   struct m0_op *op = nullptr;
-  mobj->ob_entity.en_flags |= M0_ENF_META;
+  mobj->ob_entity.en_flags |= (M0_ENF_META | M0_ENF_GEN_DI);
   rc = m0_entity_delete(&mobj->ob_entity, &op);
   if (rc != 0) {
     ldpp_dout(dpp, 0) << "ERROR: m0_entity_delete() failed: " << rc << dendl;
@@ -1969,7 +1969,7 @@ int MotrObject::write_mobj(const DoutPrefixProvider *dpp, bufferlist&& in_buffer
       // This is the last I/O.
       // Pad to allign with unit size (and not the group size) and 
       // set M0_ENF_NO_RMW flag to force no RMW
-      mobj->ob_entity.en_flags |= M0_ENF_NO_RMW;
+      mobj->ob_entity.en_flags |= (M0_ENF_NO_RMW | M0_ENF_GEN_DI);
       uint64_t lid = M0_OBJ_LAYOUT_ID(meta.layout_id);
       unsigned unit_sz = m0_obj_layout_id_to_unit_size(lid);
 
@@ -2466,7 +2466,7 @@ int MotrAtomicWriter::write()
     if (left < bs) {
       // Pad to allign with unit size (and not the group size) and 
       // set M0_ENF_NO_RMW flag to force no RMW
-      obj.mobj->ob_entity.en_flags |= M0_ENF_NO_RMW;
+      obj.mobj->ob_entity.en_flags |= (M0_ENF_NO_RMW | M0_ENF_GEN_DI);
       uint64_t lid = M0_OBJ_LAYOUT_ID(obj.meta.layout_id);
       unsigned unit_sz = m0_obj_layout_id_to_unit_size(lid);
 


### PR DESCRIPTION

  - RGW-SAL: Enable flag M0_ENF_GEN_DI for checksum generation in Motr client

    [Support is added in Motr client to generate checksum; If M0_ENF_GEN_DI is set then Motr client will generate DI for data 
     units along with Parity units. while If M0_ENF_GEN_DI is not set then Motr will not generate the checksum for data units.]

      Signed-off-by: Rajat Patil <rajat.r.patil@seagate.com>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [X] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
