### PR TITLE
rgw_sal_motr : [CORTX-32361] Fix invalid version-id-marker issue in a List Object Versions API

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1306,9 +1306,10 @@ int MotrBucket::list(const DoutPrefixProvider *dpp, ListParams& params, int max,
   std::string marker_key;
   ceph::real_time marker_mtime;
 
-  marker_key = params.marker.name + '\a' + params.marker.instance;
   if (params.marker.instance == "null")
-     marker_key = params.marker.name + '\a';
+    marker_key = params.marker.name + '\a';
+  else
+    marker_key = params.marker.name + '\a' + params.marker.instance;
 
   if (params.marker.instance != "") {
     ret_code = store->do_idx_op_by_name(bucket_index_iname, M0_IC_GET, marker_key, bl);

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1352,7 +1352,7 @@ int MotrBucket::list(const DoutPrefixProvider *dpp, ListParams& params, int max,
               ((!null_ent.key.empty() && params.marker.instance == "null" &&
                  null_ent.meta.mtime < ent.meta.mtime) ||
                (key.instance != "" &&
-                key.instance <= params.marker.instance))) {
+                key.instance < params.marker.instance))) {
               // Store the modified time of null version entry
               if(null_ent.meta.mtime >= ent.meta.mtime)
                 marker_mtime = null_ent.meta.mtime;
@@ -1379,8 +1379,7 @@ check_keycount:
                 key.instance == params.marker.instance)
               null_ent.key = {}; // filtered out by the marker
             else {
-              // Skip the null entry if params.marker.instance is null
-              if (params.marker.instance != "null" && null_ent.meta.mtime != marker_mtime) {
+              if (null_ent.meta.mtime != marker_mtime) {
                 results.objs.emplace_back(std::move(null_ent));
                 keycount++;
                 goto check_keycount;
@@ -1409,7 +1408,7 @@ check_keycount:
 
   if (!null_ent.key.empty() && !results.is_truncated) {
     if (keycount < max) {
-      if (params.marker.instance != "null" && null_ent.meta.mtime != marker_mtime)
+      if (null_ent.meta.mtime != marker_mtime)
           results.objs.emplace_back(std::move(null_ent));
     }
     else { // there was no more records in the bucket

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1300,6 +1300,24 @@ int MotrBucket::list(const DoutPrefixProvider *dpp, ListParams& params, int max,
     }
   }
 
+  // Return an error in case of invalid version-id-marker
+  int ret_code;
+  bufferlist bl;
+  std::string marker_key;
+  ceph::real_time marker_mtime;
+
+  marker_key = params.marker.name + '\a' + params.marker.instance;
+  if (params.marker.instance == "null")
+     marker_key = params.marker.name + '\a';
+
+  if (params.marker.instance != "") {
+    ret_code = store->do_idx_op_by_name(bucket_index_iname, M0_IC_GET, marker_key, bl);
+    if (ret_code < 0) {
+      ldpp_dout(dpp, 0) <<__func__<< ": ERROR: invalid version-id-marker, ret_code=" << ret_code << dendl;
+      return -EINVAL;
+    }
+  }
+
   results.is_truncated = false;
   int keycount=0; // how many keys we've put to the results so far
   std::string next_key;
@@ -1333,8 +1351,12 @@ int MotrBucket::list(const DoutPrefixProvider *dpp, ListParams& params, int max,
               ((!null_ent.key.empty() && params.marker.instance == "null" &&
                  null_ent.meta.mtime < ent.meta.mtime) ||
                (key.instance != "" &&
-                key.instance < params.marker.instance)))
-            continue;
+                key.instance <= params.marker.instance))) {
+              // Store the modified time of null version entry
+              if(null_ent.meta.mtime >= ent.meta.mtime)
+                marker_mtime = null_ent.meta.mtime;
+              continue;
+          }
 check_keycount:
           if (keycount >= max) {
             if (!null_ent.key.empty() &&
@@ -1356,9 +1378,12 @@ check_keycount:
                 key.instance == params.marker.instance)
               null_ent.key = {}; // filtered out by the marker
             else {
-              results.objs.emplace_back(std::move(null_ent));
-              keycount++;
-              goto check_keycount;
+              // Skip the null entry if params.marker.instance is null
+              if (params.marker.instance != "null" && null_ent.meta.mtime != marker_mtime) {
+                results.objs.emplace_back(std::move(null_ent));
+                keycount++;
+                goto check_keycount;
+              }
             }
           }
           if (key.instance == "")
@@ -1382,8 +1407,10 @@ check_keycount:
   }
 
   if (!null_ent.key.empty() && !results.is_truncated) {
-    if (keycount < max)
-      results.objs.emplace_back(std::move(null_ent));
+    if (keycount < max) {
+      if (params.marker.instance != "null" && null_ent.meta.mtime != marker_mtime)
+          results.objs.emplace_back(std::move(null_ent));
+    }
     else { // there was no more records in the bucket
       results.next_marker = rgw_obj_key(null_ent.key.name, "null");
       results.is_truncated = true;

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1301,7 +1301,6 @@ int MotrBucket::list(const DoutPrefixProvider *dpp, ListParams& params, int max,
   }
 
   // Return an error in case of invalid version-id-marker
-  int ret_code;
   bufferlist bl;
   std::string marker_key;
   ceph::real_time marker_mtime;
@@ -1312,9 +1311,9 @@ int MotrBucket::list(const DoutPrefixProvider *dpp, ListParams& params, int max,
     marker_key = params.marker.name + '\a' + params.marker.instance;
 
   if (params.marker.instance != "") {
-    ret_code = store->do_idx_op_by_name(bucket_index_iname, M0_IC_GET, marker_key, bl);
-    if (ret_code < 0) {
-      ldpp_dout(dpp, 0) <<__func__<< ": ERROR: invalid version-id-marker, ret_code=" << ret_code << dendl;
+    rc = store->do_idx_op_by_name(bucket_index_iname, M0_IC_GET, marker_key, bl);
+    if (rc < 0) {
+      ldpp_dout(dpp, 0) <<__func__<< ": ERROR: invalid version-id-marker, rc=" << rc << dendl;
       return -EINVAL;
     }
   }


### PR DESCRIPTION
Problem Statement:
In List Object Versions API : 
- For invalid version-id-marker value, it is showing all object versions.

Solution:
- Return `InvalidArgument` error in case of invalid version-id-marker. 
- Handle valid null version object entry in list response if user passes key-marker and version-id-marker parameter in ListObjectVersions request.

Signed-off-by: Priyanka Salunke <priyanka.s.salunke@seagate.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
