### PR TITLE
rgw_sal_motr: [CORTX-33105] - Handle errors for copy object operation

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1552,12 +1552,16 @@ int MotrObject::get_obj_state(const DoutPrefixProvider* dpp, RGWObjectCtx* rctx,
   if (state == nullptr)
     state = new RGWObjState();
   *_state = state;
-
+  req_state* s = static_cast<req_state*>(rctx->get_private());
   // Get object's metadata (those stored in rgw_bucket_dir_entry).
   rgw_bucket_dir_entry ent;
   int rc = this->get_bucket_dir_ent(dpp, ent);
-  if (rc < 0)
+  if (rc < 0) {
+    if(rc == -ENOENT) {
+        s->err.message = "The specified key does not exist.";
+    }
     return rc;
+  }
 
   // Set object's type.
   this->category = ent.meta.category;
@@ -1849,6 +1853,8 @@ int MotrObject::MotrReadOp::prepare(optional_yield y, const DoutPrefixProvider* 
   source->category = ent.meta.category;
   *params.lastmod = ent.meta.mtime;
 
+  req_state* s = static_cast<req_state*>(rctx->get_private());
+
   if (params.mod_ptr || params.unmod_ptr) {
     // Convert all times go GMT to make them compatible
     obj_time_weight src_weight;
@@ -1864,7 +1870,8 @@ int MotrObject::MotrReadOp::prepare(optional_yield y, const DoutPrefixProvider* 
       ldpp_dout(dpp, 10) <<__func__<< ": If-Modified-Since: " << dest_weight << " & "
                          << "Last-Modified: " << src_weight << dendl;
       if (!(dest_weight < src_weight)) {
-        return -ERR_NOT_MODIFIED;
+        s->err.message = "At least one of the pre-conditions you specified did not hold ";
+        return -ERR_PRECONDITION_FAILED;
       }
     }
 
@@ -1874,6 +1881,7 @@ int MotrObject::MotrReadOp::prepare(optional_yield y, const DoutPrefixProvider* 
       ldpp_dout(dpp, 10) <<__func__<< ": If-UnModified-Since: " << dest_weight << " & "
                          << "Last-Modified: " << src_weight << dendl;
       if (dest_weight < src_weight) {
+        s->err.message = "At least one of the pre-conditions you specified did not hold ";
         return -ERR_PRECONDITION_FAILED;
       }
     }
@@ -1884,6 +1892,7 @@ int MotrObject::MotrReadOp::prepare(optional_yield y, const DoutPrefixProvider* 
     ldpp_dout(dpp, 10) <<__func__<< ": ETag: " << etag << " & "
                        << "If-Match: " << if_match_str << dendl;
     if (if_match_str.compare(etag) != 0) {
+     s->err.message = "At least one of the pre-conditions you specified did not hold ";
       return -ERR_PRECONDITION_FAILED;
     }
   }
@@ -1893,7 +1902,8 @@ int MotrObject::MotrReadOp::prepare(optional_yield y, const DoutPrefixProvider* 
     ldpp_dout(dpp, 10) <<__func__<< ": ETag: " << etag << " & "
                        << "If-NoMatch: " << if_nomatch_str << dendl;
     if (if_nomatch_str.compare(etag) == 0) {
-      return -ERR_NOT_MODIFIED;
+      s->err.message = "At least one of the pre-conditions you specified did not hold ";
+      return -ERR_PRECONDITION_FAILED;
     }
   }
   return 0;


### PR DESCRIPTION
Problem statement: Handle errors for copy object operation

Solution: Added detailed error message and changed some error codes to make it AWS compliance. 

Signed-off-by: shraddhaghatol <shraddha.j.ghatol@seagate.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
