### PR TITLE
rgw_sal_motr, motr_gc: [CORTX-33180] GC thread processing logic

### DIFF
--- a/src/rgw/motr/gc/gc.h
+++ b/src/rgw/motr/gc/gc.h
@@ -22,8 +22,9 @@
 #include <condition_variable>
 #include <atomic>
 
-const uint64_t GC_DEFAULT_QUEUES = 64;
-const uint64_t GC_MAX_QUEUES = 4096;
+const uint32_t GC_DEFAULT_QUEUES = 64;
+const uint32_t GC_DEFAULT_COUNT = 256;
+const uint32_t GC_MAX_QUEUES = 4096;
 static std::string gc_index_prefix = "motr.rgw.gc";
 static std::string gc_thread_prefix = "motr_gc_";
 
@@ -117,7 +118,8 @@ class MotrGC : public DoutPrefixProvider {
  private:
   CephContext *cct;
   rgw::sal::Store *store;
-  int max_indices = 0;
+  uint32_t max_indices = 0;
+  uint32_t max_count = 0;
   std::vector<std::string> index_names;
   std::atomic<bool> down_flag = false;
 
@@ -159,6 +161,7 @@ class MotrGC : public DoutPrefixProvider {
   void start_processor();
   void stop_processor();
   int dequeue(const DoutPrefixProvider* dpp, std::string iname, motr_gc_obj_info obj);
+  int get_locked_gc_index(uint32_t& rand_ind);
   bool going_down();
 
   // Set Up logging prefix for GC


### PR DESCRIPTION
    GC thread processing logic

    The GC thread will acquire GC index and process the object entries for
    deletion either up-to the count governed by "rgw_gc_max_trim_chunk" or
    time allowed by "rgw_gc_processor_max_time".


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
