### PR TITLE
rgw_sal_motr : [CORTX-33538] Fix cephs3test issues of list-objects API

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1345,34 +1345,26 @@ int MotrBucket::list(const DoutPrefixProvider *dpp, ListParams& params, int max,
         auto iter = vals[i].cbegin();
         ent.decode(iter);
         rgw_obj_key key(ent.key);
-        // v1 (latest) - v2 - null - v3 - v4, marker=v3 (expected here - v3,v4)
         if (params.list_versions || ent.is_visible()) {
           if (key.name == params.marker.name) {
-            // skip the object for non versioned bucket
+            // skip the object for non-versioned bucket
             if (!(ent.flags & rgw_bucket_dir_entry::FLAG_VER)) 
               continue;
             // filter out versions which go before marker.instance
-            // null_ent is not yet populated
             if (params.marker.instance != "") {
-              // null and older versions
+              // Check if params.marker.instance is null
               if (params.marker.instance == "null") {  
-                ldpp_dout(dpp, 0) << "**** 1373 : params.marker.instance is null " << dendl;
                   if ((!null_ent.key.empty() && null_ent.meta.mtime < ent.meta.mtime))
                     continue;               
               } else {
-                // version-id-marker contains version
                 if (key.instance != "" && key.instance < params.marker.instance) {
-                  ldpp_dout(dpp, 0) << "**** 1381 : params.marker.instance is not null " << dendl;
                   if(null_ent.meta.mtime >= ent.meta.mtime)
                     marker_mtime = null_ent.meta.mtime;
-                  
                   continue;
-                } // nested if
-              } // else
-            
-            } // if not empty
+                }
+              }
+            }
           }
-        //}
 check_keycount:
           if (keycount >= max) {
             if (!null_ent.key.empty() &&


### PR DESCRIPTION
Problem Statement:
List-objects API returning number of objects with
version-id-marker attribute is mismatching in s3tests test suite.

```
bucket_name = _create_objects(keys=['foo', 'bar', 'baz'])
client = get_client()
response = client.list_objects(Bucket=bucket_name, Marker='baz', MaxKeys=2)
Keys - ['baz', 'foo'] 
```
Here, we should get only foo

Below ceph s3tests are failing with assertion
errors on setup with motr as backend. number of objects
returning are mismatching with s3test.
```
's3tests_boto3.functional.test_s3:test_bucket_list_many',
's3tests_boto3.functional.test_s3:test_bucket_list_maxkeys_one',
's3tests_boto3.functional.test_s3:test_bucket_listv2_many',
's3tests_boto3.functional.test_s3:test_bucket_listv2_maxkeys_one'
```

Solution:
In the list_objects(MotrBucket::list) function of sal_motr code,
modified the logic for listing objects with marker.
Output for above s3tests is at the end of PR template

Signed-off-by: Priyanka Salunke priyanka.s.salunke@seagate.com

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
