### PR TITLE
rgw_sal_motr:[CORTX-33799] Handle progress_cb response in case of copy-object operation failure.

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -41,6 +41,7 @@ extern "C" {
 #include "rgw_bucket.h"
 #include "rgw_quota.h"
 #include "motr/addb/rgw_addb.h"
+#include "rgw_rest.h"
 
 #define dout_subsys ceph_subsys_rgw
 
@@ -2230,12 +2231,12 @@ int MotrObject::delete_obj_aio(const DoutPrefixProvider* dpp, RGWObjState* astat
 
 int MotrCopyObj_CB::handle_data(bufferlist& bl, off_t bl_ofs, off_t bl_len)
 {
-  progress_cb progress_CB = this->get_progress_cb();
   int rc = 0;
   ldpp_dout(m_dpp, 20) << "Offset=" << bl_ofs << " Length = "
                        << " Write Offset=" << write_offset << bl_len << dendl;
 
 
+  struct req_state* s = static_cast<req_state*>(obj_ctx->get_private());
   //offset is zero and bufferlength is equal to bl_len
   if (!bl_ofs && bl_len == bl.length()) {
     bufferptr bptr(bl.c_str(), bl_len);
@@ -2248,9 +2249,7 @@ int MotrCopyObj_CB::handle_data(bufferlist& bl, off_t bl_ofs, off_t bl_len)
                           write_offset << "failed rc=" << rc << dendl;
     }
     write_offset += bl_len;
-    if(progress_CB){
-      progress_CB(write_offset, this->get_progress_data());
-    }
+    dump_continue(s);
     return rc;
   }
 
@@ -2264,6 +2263,7 @@ int MotrCopyObj_CB::handle_data(bufferlist& bl, off_t bl_ofs, off_t bl_len)
                          << " Write Offset=" << write_offset << dendl;
     return rc;
   }
+  dump_continue(s);
   write_offset += bl_len;
 
   ldpp_dout(m_dpp, 20) << "MotrCopyObj_CB handle_data called rc=" << rc << dendl;
@@ -2346,7 +2346,7 @@ int MotrObject::copy_object_same_zone(RGWObjectCtx& obj_ctx,
   }
 
   // Create filter object.
-  MotrCopyObj_CB cb(dpp, dst_writer);
+  MotrCopyObj_CB cb(dpp, dst_writer, &obj_ctx);
   MotrCopyObj_Filter* filter = &cb;
 
   // Get offsets.
@@ -2357,9 +2357,7 @@ int MotrObject::copy_object_same_zone(RGWObjectCtx& obj_ctx,
     return rc;
   }
 
-  //setting the values of progress_cb and progress_data in MotrCopyObj_Filter class 
-  filter->set_progress_callback(progress_cb, progress_data);
-
+  struct req_state* s = static_cast<req_state*>(obj_ctx.get_private());
   // read::iterate -> handle_data() -> write::process
   rc = read_op->iterate(dpp, cur_ofs, cur_end, filter, y);
   if (rc < 0){
@@ -2387,7 +2385,7 @@ int MotrObject::copy_object_same_zone(RGWObjectCtx& obj_ctx,
   }
 
   //Set object tags based on tagging-directive
-  struct req_state* s = static_cast<req_state*>(obj_ctx.get_private());
+  
   auto tagging_drctv = s->info.env->get("HTTP_X_AMZ_TAGGING_DIRECTIVE");
 
   bufferlist tags_bl;

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -2357,7 +2357,6 @@ int MotrObject::copy_object_same_zone(RGWObjectCtx& obj_ctx,
     return rc;
   }
 
-  struct req_state* s = static_cast<req_state*>(obj_ctx.get_private());
   // read::iterate -> handle_data() -> write::process
   rc = read_op->iterate(dpp, cur_ofs, cur_end, filter, y);
   if (rc < 0){
@@ -2385,7 +2384,7 @@ int MotrObject::copy_object_same_zone(RGWObjectCtx& obj_ctx,
   }
 
   //Set object tags based on tagging-directive
-  
+  struct req_state* s = static_cast<req_state*>(obj_ctx.get_private());
   auto tagging_drctv = s->info.env->get("HTTP_X_AMZ_TAGGING_DIRECTIVE");
 
   bufferlist tags_bl;

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -2235,8 +2235,6 @@ int MotrCopyObj_CB::handle_data(bufferlist& bl, off_t bl_ofs, off_t bl_len)
   ldpp_dout(m_dpp, 20) << "Offset=" << bl_ofs << " Length = "
                        << " Write Offset=" << write_offset << bl_len << dendl;
 
-
-  struct req_state* s = static_cast<req_state*>(obj_ctx->get_private());
   //offset is zero and bufferlength is equal to bl_len
   if (!bl_ofs && bl_len == bl.length()) {
     bufferptr bptr(bl.c_str(), bl_len);
@@ -2346,7 +2344,7 @@ int MotrObject::copy_object_same_zone(RGWObjectCtx& obj_ctx,
   }
 
   // Create filter object.
-  MotrCopyObj_CB cb(dpp, dst_writer, &obj_ctx);
+  MotrCopyObj_CB cb(dpp, dst_writer, obj_ctx);
   MotrCopyObj_Filter* filter = &cb;
 
   // Get offsets.

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -528,13 +528,16 @@ class MotrCopyObj_CB : public MotrCopyObj_Filter
   const DoutPrefixProvider* m_dpp;
   std::shared_ptr<rgw::sal::Writer> m_dst_writer;
   off_t write_offset;
+  RGWObjectCtx* obj_ctx;
 
 public:
   explicit MotrCopyObj_CB(const DoutPrefixProvider* dpp, 
-                         std::shared_ptr<rgw::sal::Writer> dst_writer) : 
+                         std::shared_ptr<rgw::sal::Writer> dst_writer, RGWObjectCtx* obj_ctx_1) :
                          m_dpp(dpp),
                          m_dst_writer(dst_writer),
-                         write_offset(0) {}
+                         write_offset(0) {
+                          obj_ctx = obj_ctx_1;
+                         }
   virtual ~MotrCopyObj_CB() override {}
   int handle_data(bufferlist& bl, off_t bl_ofs, off_t bl_len) override;
 };

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -528,15 +528,14 @@ class MotrCopyObj_CB : public MotrCopyObj_Filter
   const DoutPrefixProvider* m_dpp;
   std::shared_ptr<rgw::sal::Writer> m_dst_writer;
   off_t write_offset;
-  RGWObjectCtx* obj_ctx;
-
+  struct req_state *s;
 public:
   explicit MotrCopyObj_CB(const DoutPrefixProvider* dpp, 
-                         std::shared_ptr<rgw::sal::Writer> dst_writer, RGWObjectCtx* obj_ctx_1) :
+                         std::shared_ptr<rgw::sal::Writer> dst_writer, RGWObjectCtx& obj_ctx) :
                          m_dpp(dpp),
                          m_dst_writer(dst_writer),
                          write_offset(0) {
-                          obj_ctx = obj_ctx_1;
+                          s = static_cast<req_state*>(obj_ctx.get_private());
                          }
   virtual ~MotrCopyObj_CB() override {}
   int handle_data(bufferlist& bl, off_t bl_ofs, off_t bl_len) override;


### PR DESCRIPTION
 Problem:
If copy operation failed after copying some data, its throwing an invalid XML error due to partial progress response. i.e rgw was not closing 'CopyObjectResult' tag in case of failure.

progress_cb() is not sending copy progress percentage or the total size of the object being copied during the copy operation,  but periodically keeps sending copied bytes till now, which is not enough to know copy progress anyways as total obj size not known, and in negative cases, no proper response is sent by Copy object, instead progress_cb() response is seen, which is originally meant as partial response only.


Solution:
Replace progress_cb() call from rgw_sal_motr layer, with dump_continue() signal, which responds with HTTP 100 Continue header to avoid client timeout during the long copy operation.

Behavior comparison with AWS S3 & RGW(RADOS)

1. AWS/RGW not sending the copy progress during copy operation, still no client connection timeout seen.
2. In MGW(Motr) case, progress_cb() is using chunked encoding, which is keeping the client connection alive, though error handling in in negative cases is missing.


Signed-off-by: Shriya Deshmukh <shriya.deshmukh@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
