### PR TITLE
rgw_sal_motr: [CORTX-33766] Fix for CopyObject API for zero byte object.

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -2420,11 +2420,14 @@ int MotrObject::copy_object_same_zone(RGWObjectCtx& obj_ctx,
     return rc;
   }
 
-  // read::iterate -> handle_data() -> write::process
-  rc = read_op->iterate(dpp, cur_ofs, cur_end, filter, y);
-  if (rc < 0){
-    ldpp_dout(dpp, 20) << "ERROR: read op iterate failed rc=" << rc << dendl;
-    return rc;
+  // read from/write to motr, if source object is non empty object.
+  if (obj_size > 0) {
+    // read::iterate -> handle_data() -> write::process
+    rc = read_op->iterate(dpp, cur_ofs, cur_end, filter, y);
+    if (rc < 0) {
+      ldpp_dout(dpp, 0) << "ERROR: read op iterate failed rc=" << rc << dendl;
+      return rc;
+    }
   }
 
   real_time time = ceph::real_clock::now();


### PR DESCRIPTION
Problem:
CopyObject operation fails for zero byte object with 'NoSuchKey' error.

Solution:
Read/write to Motr only if object size is greater than zero.

Signed-off-by: Shriya Deshmukh <shriya.deshmukh@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
