### PR TITLE
rgw, rgw_sal: [CORTX-34059] store size_rounded with object metadata

### DIFF
--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -199,12 +199,14 @@ struct rgw_bucket_dir_entry_meta {
   std::string owner_display_name;
   std::string content_type;
   uint64_t accounted_size;
+  uint64_t size_rounded;
   std::string user_data;
   std::string storage_class;
   bool appendable;
 
   rgw_bucket_dir_entry_meta() :
-    category(RGWObjCategory::None), size(0), accounted_size(0), appendable(false) { }
+    category(RGWObjCategory::None), size(0), accounted_size(0),
+    size_rounded(0), appendable(false) { }
 
   void encode(ceph::buffer::list &bl) const {
     ENCODE_START(7, 3, bl);
@@ -216,6 +218,9 @@ struct rgw_bucket_dir_entry_meta {
     encode(owner_display_name, bl);
     encode(content_type, bl);
     encode(accounted_size, bl);
+    #ifdef WITH_RADOSGW_MOTR
+      encode(size_rounded, bl);
+    #endif
     encode(user_data, bl);
     encode(storage_class, bl);
     encode(appendable, bl);
@@ -236,6 +241,9 @@ struct rgw_bucket_dir_entry_meta {
       decode(accounted_size, bl);
     else
       accounted_size = size;
+    #ifdef WITH_RADOSGW_MOTR
+      decode(size_rounded, bl);
+    #endif
     if (struct_v >= 5)
       decode(user_data, bl);
     if (struct_v >= 6)

--- a/src/rgw/motr/gc/gc.cc
+++ b/src/rgw/motr/gc/gc.cc
@@ -396,7 +396,6 @@ int MotrGC::un_lock_gc_index(uint32_t& index) {
 }
 
 int MotrGC::list(std::vector<std::unordered_map<std::string, std::string>> &gc_entries) {
-  int rc = 0;
   int max_entries = 1000;
   max_indices = get_max_indices();
   for (uint32_t i = 0; i < max_indices; i++) {
@@ -411,7 +410,7 @@ int MotrGC::list(std::vector<std::unordered_map<std::string, std::string>> &gc_e
       if (!marker.empty()) {
         keys[0] = marker;
       }
-      rc = store->next_query_by_name(iname, keys, vals, obj_tag_prefix);
+      int rc = store->next_query_by_name(iname, keys, vals, obj_tag_prefix);
       if (rc < 0) {
         ldout(cct, 0) <<__func__<<": ERROR: NEXT query failed. rc="
           << rc << dendl;

--- a/src/rgw/rgw_multi.h
+++ b/src/rgw/rgw_multi.h
@@ -35,7 +35,9 @@ struct RGWUploadPartInfo {
     ENCODE_START(4, 2, bl);
     encode(num, bl);
     encode(size, bl);
-    encode(size_rounded, bl);
+    #ifdef WITH_RADOSGW_MOTR
+      encode(size_rounded, bl);
+    #endif
     encode(etag, bl);
     encode(modified, bl);
     encode(manifest, bl);
@@ -47,7 +49,9 @@ struct RGWUploadPartInfo {
     DECODE_START_LEGACY_COMPAT_LEN(4, 2, 2, bl);
     decode(num, bl);
     decode(size, bl);
-    decode(size_rounded, bl);
+    #ifdef WITH_RADOSGW_MOTR
+      decode(size_rounded, bl);
+    #endif
     decode(etag, bl);
     decode(modified, bl);
     if (struct_v >= 3)

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -749,7 +749,7 @@ class MotrObject : public Object {
     int read_multipart_obj(const DoutPrefixProvider* dpp,
                            int64_t off, int64_t end, RGWGetDataCB* cb,
                            std::map<int, std::unique_ptr<MotrObject>>& part_objs);
-    int delete_part_objs(const DoutPrefixProvider* dpp, uint64_t* size_rounded);
+    int delete_part_objs(const DoutPrefixProvider* dpp);
     void set_category(RGWObjCategory _category) {category = _category;}
     int get_bucket_dir_ent(const DoutPrefixProvider *dpp, rgw_bucket_dir_entry& ent);
     int fetch_latest_obj(const DoutPrefixProvider *dpp, bufferlist& bl);
@@ -974,7 +974,7 @@ public:
 			  const rgw_placement_rule *ptail_placement_rule,
 			  uint64_t part_num,
 			  const std::string& part_num_str) override;
-  int delete_parts(const DoutPrefixProvider *dpp, std::string version_id="", uint64_t* size_rounded = nullptr);
+  int delete_parts(const DoutPrefixProvider *dpp, std::string version_id="");
 };
 
 class MotrStore : public Store {


### PR DESCRIPTION
The object's actual size on a disk is unavailable with the object metadata,
so it is calculated at run-time with the help of layout-id and
the size of an object.

For simple objects, the time complexity of the calculation is O(1), but
for multipart objects, the complexity increases to O(number of parts)

Storing the actual size of objects with object metadata will save this time by
avoiding the iterations over each part info.

Signed-off-by: Sumedh Anantrao Kulkarni <sumedh.a.kulkarni@seagate.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
