### PR TITLE
rgw_sal_motr :[CORTX-33109] Fixed noSuchKey error in CopyObject API for IAM Policy

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -2396,10 +2396,11 @@ int MotrObject::copy_object_same_zone(RGWObjectCtx& obj_ctx,
     req_id = *tag;
   }
 
+  struct req_state* s = static_cast<req_state*>(obj_ctx.get_private());
   // prepare write op
   std::shared_ptr<rgw::sal::Writer> dst_writer = store->get_atomic_writer(dpp, y,
         dest_object->clone(),
-        user->get_id(), obj_ctx,
+        s->bucket_owner.get_id(), obj_ctx,
         &dest_placement, olh_epoch, req_id);
 
   rc = dst_writer->prepare(y);
@@ -2450,7 +2451,6 @@ int MotrObject::copy_object_same_zone(RGWObjectCtx& obj_ctx,
   }
 
   //Set object tags based on tagging-directive
-  struct req_state* s = static_cast<req_state*>(obj_ctx.get_private());
   auto tagging_drctv = s->info.env->get("HTTP_X_AMZ_TAGGING_DIRECTIVE");
 
   bufferlist tags_bl;


### PR DESCRIPTION
Problem : 
"NoSuchKey" error was returning when tried copyObject API after applying valid IAM policy on IAM user.

Solution : 
Previously in copy object API it was considering owner of destination bucket as "user id" and not the actual owner of the bucket. Fixed that by changing owner as destination bucket owner.

Sample policy example with command is given in - https://jts.seagate.com/browse/CORTX-33109?focusedCommentId=2421624&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-2421624

Signed-off-by: shraddhaghatol <shraddha.j.ghatol@seagate.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
