### PR TITLE
rgw_op : [CORTX-33109] Handled tagging permissions in IAM policy for Copy Object API

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -5232,6 +5232,74 @@ int RGWCopyObj::verify_permission(optional_yield y)
 					      RGW_PERM_READ)) { 
 	  return -EACCES;
 	}
+
+  // Check for tagging permissions
+  auto tag_directive_in_req = s->info.env->get("HTTP_X_AMZ_TAGGING_DIRECTIVE");
+  
+  TaggingDirective tag_directive_type = TaggingDirective::NO_TAGGING_DIRECTIVE;
+  if (tag_directive_in_req) {
+    std::string tagging_directive_str(tag_directive_in_req);
+    if (tagging_directive_str.compare("COPY") == 0)
+      tag_directive_type = TaggingDirective::COPY_TAGGING_DIRECTIVE;
+    else if (tagging_directive_str.compare("REPLACE") == 0)
+      tag_directive_type = TaggingDirective::REPLACE_TAGGING_DIRECTIVE;
+    else{
+      ldpp_dout(this, 0) << "ERROR: Invalid tagging directive " << dendl;
+      s->err.message = "Unknown tagging directive.";
+      return -EINVAL;
+    }
+  }
+  TaggingPermission tagging_permission = TaggingPermission::NO_TAGGING_PERM;
+
+  if(Effect::Allow == eval_identity_or_session_policies(s->iam_user_policies,
+                                                                  s->env,
+                                                                  rgw::IAM::s3PutObjectTagging,
+                                                                  obj_arn)) {
+      tagging_permission |= TaggingPermission::PUT_TAGGING_PERM;
+                                                                  }
+
+  if(Effect::Allow == eval_identity_or_session_policies(s->iam_user_policies,
+                                                                  s->env,
+                                                                  rgw::IAM::s3GetObjectTagging,
+                                                                  obj_arn)) {
+      tagging_permission |= TaggingPermission::GET_TAGGING_PERM;
+                                                                  }
+
+  op_ret = s->src_object->get_obj_attrs(s->obj_ctx, y, this);
+  if (op_ret == 0) {
+      attrs = s->src_object->get_attrs();
+      auto tags = attrs.find(RGW_ATTR_TAGS);
+
+      // Check if either of PutObjectTagging or GetObjectTagging permissions with respective tags are not present.
+      if (tagging_permission != (TaggingPermission::GET_TAGGING_PERM | TaggingPermission::PUT_TAGGING_PERM)) {
+        if (tags != attrs.end()) {
+          //tags present on source object
+          if ((tag_directive_type != TaggingDirective::REPLACE_TAGGING_DIRECTIVE) &&
+              (tagging_permission == TaggingPermission::PUT_TAGGING_PERM)) {
+            //Deny copy operation if tagging directive is either "COPY" or No tagging directive
+            //since getObjectTagging permission is also required to get the tags of source object.
+            s->err.message = "Access Denied";
+            return -EACCES;
+          } else if ((tagging_permission == TaggingPermission::GET_TAGGING_PERM) ||
+                     (tagging_permission == TaggingPermission::NO_TAGGING_PERM)) {
+            //Deny copy operation if tags are present on source object and both
+            //(PutObjectTagging & getObjectTagging) permissions are missing.
+            s->err.message = "Access Denied";
+            return -EACCES;
+          }
+        } else {
+          //tags not present on source object
+          if ((tag_directive_type == TaggingDirective::REPLACE_TAGGING_DIRECTIVE) &&
+              (tagging_permission != TaggingPermission::PUT_TAGGING_PERM)) {
+            //If tags are not present on source object and tagging-directive specified as "REPLACE" then
+            //deny copy operation since PutObjectTagging permission is required.
+            s->err.message = "Access Denied";
+            return -EACCES;
+          }
+        }
+      }
+   } //op_ret end
+
       //remove src object tags as it may interfere with policy evaluation of destination obj
       if (has_s3_existing_tag || has_s3_resource_tag)
         rgw_iam_remove_objtags(this, s, s->src_object.get(), has_s3_existing_tag, has_s3_resource_tag);

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -1477,6 +1477,28 @@ public:
   dmc::client_id dmclock_client() override { return dmc::client_id::data; }
 };
 
+enum class TaggingPermission : short {
+NO_TAGGING_PERM,
+PUT_TAGGING_PERM,
+GET_TAGGING_PERM
+};
+
+enum class TaggingDirective {
+NO_TAGGING_DIRECTIVE,
+COPY_TAGGING_DIRECTIVE,
+REPLACE_TAGGING_DIRECTIVE
+};
+
+constexpr TaggingPermission& operator|=(TaggingPermission& lhs, TaggingPermission rhs) {
+    using TaggingPermissionType = std::underlying_type<TaggingPermission>::type;
+    return lhs = TaggingPermission( static_cast<TaggingPermissionType>(lhs) | static_cast<TaggingPermissionType>(rhs));
+}
+
+constexpr TaggingPermission operator|(TaggingPermission lhs, TaggingPermission rhs) {
+    TaggingPermission tg = TaggingPermission::NO_TAGGING_PERM;
+    using TaggingPermissionType = std::underlying_type<TaggingPermission>::type;
+    return  tg = TaggingPermission( static_cast<TaggingPermissionType>(lhs) | static_cast<TaggingPermissionType>(rhs));
+}
 class RGWCopyObj : public RGWOp {
 protected:
   RGWAccessControlPolicy dest_policy;


### PR DESCRIPTION
Problem : Tagging permissions are not handled in IAM policy for Copy object API

Solution : Handled tagging permissions in IAM policy in common code rgw_op.cc in RGWCopyObj::verify_permission() function.
Performed several use cases, linked in - https://jts.seagate.com/browse/CORTX-34135?focusedCommentId=2424677&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-2424677

Signed-off-by: shraddhaghatol <shraddha.j.ghatol@seagate.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
