### PR TITLE
rgw_sal_motr: [CORTX-34122] support versioned multipart delete using GC

### DIFF
--- a/src/rgw/motr/gc/gc.cc
+++ b/src/rgw/motr/gc/gc.cc
@@ -283,8 +283,7 @@ int MotrGC::process_parts(motr_gc_obj_info ginfo, std::time_t end_time) {
     mobj.decode(iter);
     ldout(cct, 20) <<__func__<< ": part_num=" << info.num
                              << " part_size=" << info.size << dendl;
-    std::string tag = PRIx64 + std::to_string(mobj.oid.u_hi) + ":" +
-                      PRIx64 + std::to_string(mobj.oid.u_lo);
+    std::string tag = mobj.oid_str();
     std::string part_name = "part.";
     char buff[32];
     snprintf(buff, sizeof(buff), "%08d", (int)info.num);
@@ -323,14 +322,14 @@ int MotrGC::process_parts(motr_gc_obj_info ginfo, std::time_t end_time) {
 int MotrGC::delete_motr_obj(Meta motr_obj) {
   int rc;
   struct m0_op *op = nullptr;
-  char fid_str[M0_FID_STR_LEN];
-  snprintf(fid_str, ARRAY_SIZE(fid_str), U128X_F, U128_P(&motr_obj.oid));
 
   if (!motr_obj.oid.u_hi || !motr_obj.oid.u_lo) {
-    ldout(cct, 0) <<__func__<< ": invalid motr object oid=" << fid_str << dendl;
+    ldpp_dout(this, 0) <<__func__<< ": invalid motr object oid="
+                       << motr_obj.oid_str() << dendl;
     return -EINVAL;
   }
-  ldout(cct, 10) <<__func__<< ": deleting motr object oid=" << fid_str << dendl;
+  ldpp_dout(this, 10) <<__func__<< ": deleting motr object oid="
+                      << motr_obj.oid_str() << dendl;
 
   // Open the object.
   if (motr_obj.layout_id == 0) {

--- a/src/rgw/motr/gc/gc.h
+++ b/src/rgw/motr/gc/gc.h
@@ -41,6 +41,13 @@ struct Meta {
   struct m0_fid pver = {};
   uint64_t layout_id = 0;
 
+  std::string oid_str() {
+    std::ostringstream oid_stream;
+    oid_stream << "0x" << std::hex << oid.u_hi
+               << ":0x" << oid.u_lo;
+    return oid_stream.str();
+  }
+
   void encode(bufferlist &bl) const {
     ENCODE_START(5, 5, bl);
     encode(oid.u_hi, bl);

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -2228,11 +2228,10 @@ int MotrObject::remove_mobj_and_index_entry(
         if (rc < 0) {
           ldpp_dout(dpp, 0) <<__func__<< ": ERROR: get_upload_id failed. rc=" << rc << dendl;
         } else {
-          std::string obj_key = delete_key;
-          obj_key = obj_key.erase(obj_key.size() - 1, 2);
-          std::string obj_fqdn = bucket_name + "/" + obj_key;
+          std::string obj_fqdn = bucket_name + "/" + delete_key;
           std::string obj_part_iname = "motr.rgw.object." + bucket_name + "." +
-                                       obj_key + "." + upload_id + ".parts";
+                                       this->get_name() + "." + upload_id +
+                                       ".parts";
           ldpp_dout(dpp, 20) << __func__ << ": object part index=" << obj_part_iname << dendl;
           ::Meta *mobj = reinterpret_cast<::Meta*>(&this->meta);
           motr_gc_obj_info gc_obj(upload_id, obj_fqdn, *mobj, std::time(nullptr),

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -2262,8 +2262,7 @@ int MotrObject::remove_mobj_and_index_entry(
       }
       size_rounded = roundup(ent.meta.size, get_unit_sz());
       if (store->gc_enabled()) {
-        std::string tag = PRIx64 + std::to_string(this->meta.oid.u_hi) + ":" +
-                          PRIx64 + std::to_string(this->meta.oid.u_lo);
+        std::string tag = this->meta.oid_str();
         std::string obj_fqdn = bucket_name + "/" + delete_key;
         ::Meta *mobj = reinterpret_cast<::Meta*>(&this->meta);
         motr_gc_obj_info gc_obj(tag, obj_fqdn, *mobj, std::time(nullptr),

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -33,6 +33,7 @@ extern "C" {
 #include "rgw_multi.h"
 #include "rgw_putobj_processor.h"
 #include "motr/gc/gc.h"
+#include <sstream>
 typedef void (*progress_cb)(off_t, void*);
 
 class MotrGC;
@@ -574,6 +575,13 @@ class MotrObject : public Object {
       struct m0_uint128 oid = {};
       struct m0_fid pver = {};
       uint64_t layout_id = 0;
+
+      std::string oid_str() {
+        std::ostringstream oid_stream;
+        oid_stream << "0x" << std::hex << oid.u_hi
+                   << ":0x" << oid.u_lo;
+        return oid_stream.str();
+      }
 
       void encode(bufferlist& bl) const
       {


### PR DESCRIPTION
Commit 1:
Fixing the part index table name to make it work for both
versioned and unversioned multipart objects.

Commit 2:
Added a utility function in the Meta class to get the string version of OID.

Signed-off-by: Sumedh Anantrao Kulkarni <sumedh.a.kulkarni@seagate.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
