### PR TITLE
rgw: [CORTX-34081] Add `count` and `inaccessible_queues` in GC list output

### DIFF
--- a/src/rgw/motr/gc/gc.cc
+++ b/src/rgw/motr/gc/gc.cc
@@ -493,7 +493,8 @@ int MotrGC::un_lock_gc_index(uint32_t& index) {
   return rc;
 }
 
-int MotrGC::list(std::vector<std::unordered_map<std::string, std::string>> &gc_entries) {
+int MotrGC::list(std::vector<std::unordered_map<std::string, std::string>> &gc_entries,
+                              std::vector<std::string>& inac_queues) {
   int max_entries = 1000;
   max_indices = get_max_indices();
   for (uint32_t i = 0; i < max_indices; i++) {
@@ -512,6 +513,7 @@ int MotrGC::list(std::vector<std::unordered_map<std::string, std::string>> &gc_e
       if (rc < 0) {
         ldout(cct, 0) << __func__ << ": ERROR: next query failed for " << iname
                       << " with rc=" << rc << dendl;
+        inac_queues.push_back(iname);
         continue;
       }
       if (rc == max_entries + 1) {

--- a/src/rgw/motr/gc/gc.h
+++ b/src/rgw/motr/gc/gc.h
@@ -173,7 +173,8 @@ class MotrGC : public DoutPrefixProvider {
   int enqueue(motr_gc_obj_info obj);
   int dequeue(std::string iname, motr_gc_obj_info obj);
 
-  int list(std::vector<std::unordered_map<std::string, std::string>> &gc_entries);
+  int list(std::vector<std::unordered_map<std::string, std::string>> &gc_entries,
+                        std::vector<std::string>& inac_queues);
   int delete_obj_from_gc(motr_gc_obj_info ginfo);
   int process_parts(motr_gc_obj_info ginfo, std::time_t end_time);
   int delete_motr_obj(Meta motr_obj);

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -4893,10 +4893,11 @@ int MotrStore::store_email_info(const DoutPrefixProvider *dpp, optional_yield y,
   return rc;
 }
 
-int MotrStore::list_gc_objs(std::vector<std::unordered_map<std::string, std::string>>& gc_entries)
+int MotrStore::list_gc_objs(std::vector<std::unordered_map<std::string, std::string>>& gc_entries,
+                                            std::vector<std::string>& inac_queues)
 {
   auto gc = new MotrGC(cctx, this);
-  int rc = gc->list(gc_entries);
+  int rc = gc->list(gc_entries, inac_queues);
   if (rc < 0) {
     ldout(cctx, LOG_ERROR) <<__func__ << ": ERROR: failed to list gc items: rc=" << rc << dendl;
   }

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -1136,7 +1136,8 @@ class MotrStore : public Store {
       luarocks_path = path;
     }
     
-    int list_gc_objs(std::vector<std::unordered_map<std::string, std::string>>& gc_entries);
+    int list_gc_objs(std::vector<std::unordered_map<std::string, std::string>>& gc_entries,
+                                    std::vector<std::string>& inac_queues);
     void close_idx(struct m0_idx *idx) { m0_idx_fini(idx); }
     int do_idx_op(struct m0_idx *, enum m0_idx_opcode opcode,
       std::vector<uint8_t>& key, std::vector<uint8_t>& val, bool update = false);


### PR DESCRIPTION
Add `count` as number of entries in all GC queues and `inaccessible_queues` as list of GC queues which are inaccessible.

Sample Output: 
```
$ bin/radosgw-admin gc list --no-mon-config
2022-09-06T02:10:47.457-0600 7fdb3dc8f680 -1 WARNING: all dangerous and experimental features are enabled.
2022-09-06T02:10:47.458-0600 7fdb3dc8f680 -1 WARNING: all dangerous and experimental features are enabled.
2022-09-06T02:10:47.459-0600 7fdb3dc8f680 -1 WARNING: all dangerous and experimental features are enabled.
2022-09-06T02:10:47.459-0600 7fdb3dc8f680  1 RGW CONF BACKEND STORE = motr
2022-09-06T02:10:47.459-0600 7fdb3dc8f680  1 RGW BACKEND STORE = motr
{
    "entries": [
        {
            "tag": "0x11a119a:0xefa4000000300009",
            "name": "testbkt1/test_50m_obj-0\u0007.part.00000004",
            "deletion_time": "2022-09-06T02:08:32-0600MDT",
            "size": "8388608",
            "is_multipart": "false"
        },
        {
            "tag": "0x11a119a:0xefa400000030000c",
            "name": "testbkt1/test_50m_obj-0\u0007.part.00000005",
            "deletion_time": "2022-09-06T02:08:32-0600MDT",
            "size": "8388608",
            "is_multipart": "false"
        },
        {
            "tag": "0x11a119a:0xefa4000000300008",
            "name": "testbkt1/test_50m_obj-0\u0007.part.00000002",
            "deletion_time": "2022-09-06T02:08:32-0600MDT",
            "size": "8388608",
            "is_multipart": "false"
        },
        {
            "tag": "0x11a119a:0xefa400000030000b",
            "name": "testbkt1/test_50m_obj-0\u0007.part.00000006",
            "deletion_time": "2022-09-06T02:08:32-0600MDT",
            "size": "8388608",
            "is_multipart": "false"
        },
        {
            "tag": "0x11a119a:0xefa4000000300007",
            "name": "testbkt1/test_50m_obj-0\u0007.part.00000007",
            "deletion_time": "2022-09-06T02:08:32-0600MDT",
            "size": "2097152",
            "is_multipart": "false"
        },
        {
            "tag": "0x11a119a:0xefa400000030000d",
            "name": "testbkt1/test_50m_obj-0\u0007.part.00000003",
            "deletion_time": "2022-09-06T02:08:32-0600MDT",
            "size": "8388608",
            "is_multipart": "false"
        }
    ],
    "count": "6",
    "inaccessible_queues": [
        "motr.rgw.gc.4",
        "motr.rgw.gc.5"
    ]
}
```

Signed-off-by: Jeet Jain <jeet.jain@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
