### PR TITLE
motr_sync, rgw_sal_motr: [CORTX-34177] refactor Motr Locking code

### DIFF
--- a/src/rgw/motr/sync/motr_sync.h
+++ b/src/rgw/motr/sync/motr_sync.h
@@ -85,7 +85,8 @@ public:
   virtual int unlock(const std::string& lock_name, MotrLockType lock_type,
                      const std::string& locker_id) = 0;
   virtual int check_lock(const std::string& lock_name,
-                         const std::string& locker_id) = 0;                     
+                         const std::string& locker_id) = 0;
+  virtual ~MotrSync() {};                  
 };
 
 // Abstract interface for entity that implements backend for lock objects
@@ -99,6 +100,8 @@ public:
   virtual int write_lock(const std::string& lock_name,
                          motr_lock_info_t* lock_info, bool update) = 0;
   virtual int remove_lock(const std::string& lock_name,
-                          const std::string& locker_id) = 0;
+                          const std::string& locker_id = "") = 0;
+  virtual const DoutPrefixProvider* get_dpp() = 0;
+  virtual ~MotrLockProvider() {};
 };
 #endif __MOTR_SYNCHROZATION__

--- a/src/rgw/motr/sync/motr_sync_impl.h
+++ b/src/rgw/motr/sync/motr_sync_impl.h
@@ -70,6 +70,7 @@ and do not pass locker_id.
 
 class MotrLock : public MotrSync {
 private:
+  const DoutPrefixProvider* _dpp;
   std::unique_ptr<MotrLockProvider> _lock_provider;
 
 public:
@@ -99,8 +100,10 @@ public:
                          motr_lock_info_t* lock_info,
                          bool update = false) override;
   virtual int remove_lock(const std::string& lock_name,
-                          const std::string& locker_id) override;
+                          const std::string& locker_id = "") override;
+  const DoutPrefixProvider* get_dpp() override { return _dpp; };
 };
+
 extern std::unique_ptr<MotrLockProvider> g_lock_provider;
 std::shared_ptr<MotrSync>& get_lock_instance(
     std::unique_ptr<MotrLockProvider>& lock_provider = g_lock_provider);

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -127,13 +127,6 @@ static std::string motr_global_indices[] = {
 #define TS_LEN 8
 #define UUID_LEN 23
 
-// log level mapping for RGW SAL
-#define LOG_CRITICAL 0
-#define LOG_ERROR 0
-#define LOG_WARNING 5
-#define LOG_INFO 10
-#define LOG_DEBUG 20
-
 static uint64_t roundup(uint64_t x, uint64_t by)
 {
   if (x == 0)

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -49,6 +49,13 @@ class MotrStore;
 #define RGW_IAM_MOTR_ACCESS_KEY       "motr.rgw.accesskeys"
 #define RGW_IAM_MOTR_EMAIL_KEY        "motr.rgw.emails"
 
+// log level mapping for RGW SAL
+#define LOG_CRITICAL 0
+#define LOG_ERROR 0
+#define LOG_WARNING 5
+#define LOG_INFO 10
+#define LOG_DEBUG 20
+
 //#define RGW_MOTR_BUCKET_ACL_IDX_NAME  "motr.rgw.bucket.acls"
 
 // A simplified metadata cache implementation.


### PR DESCRIPTION
- Add `dpp` in `MotrLock` class as a private member and initialize it.
- Refactor the method and the call to the method `remove_lock(...)`.
- Add virtual destructors in MotrSync & MotrLockProvider classes.
- Move the log level declarations from the `rgw_sal_motr.cc` to the `rgw_sal_motr.h` file.

Signed-off-by: Sumedh Anantrao Kulkarni <sumedh.a.kulkarni@seagate.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
