### PR TITLE
rgw_sal_motr : [CORTX-34167] Modify error code and error message of GET/HEAD object API

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1940,11 +1940,12 @@ int MotrObject::MotrReadOp::prepare(optional_yield y, const DoutPrefixProvider* 
   // Else, return "NoSuchKey" error
   if (ent.is_delete_marker()) {
     if (source->get_instance() == ent.key.instance && ent.key.instance != "") {
+      ldpp_dout(dpp, LOG_DEBUG) <<__func__ << "The GET/HEAD object with version-id of "
+                                            "delete-marker is not allowed." << dendl;
       s->err.message = "The specified method is not allowed against this resource.";
       return -ERR_METHOD_NOT_ALLOWED;
     }
-    else
-      return -ENOENT;
+    return -ENOENT;
   }
 
   // Set source object's attrs. The attrs is key/value map and is used

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1940,7 +1940,7 @@ int MotrObject::MotrReadOp::prepare(optional_yield y, const DoutPrefixProvider* 
   // Else, return "NoSuchKey" error
   if (ent.is_delete_marker()) {
     if (source->get_instance() == ent.key.instance && ent.key.instance != "") {
-      ldpp_dout(dpp, LOG_DEBUG) <<__func__ << "The GET/HEAD object with version-id of "
+      ldpp_dout(dpp, LOG_DEBUG) <<__func__ << ": DEBUG: The GET/HEAD object with version-id of "
                                             "delete-marker is not allowed." << dendl;
       s->err.message = "The specified method is not allowed against this resource.";
       return -ERR_METHOD_NOT_ALLOWED;


### PR DESCRIPTION
Problem Statement:
GET/HEAD Object API with version id of a delete marker gives `404 (NoSuchKey)` error in the response.

Solution: 
Modified the error code and error message of GET/HEAD object API response to `405 (MethodNotAllowed)` in case of delete-marker.

Signed-off-by: Priyanka Salunke <priyanka.s.salunke@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
