### PR TITLE
rgw_sal_motr: CORTX-33747: send data in chunks during get api

### DIFF
--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -514,6 +514,20 @@ struct AccumulateIOCtxt{
   uint64_t total_bufer_sz = 0;
 };
 
+class MotrGetDataCB_Wrapper : public RGWGetDataCB {
+  RGWGetDataCB* cb;
+  struct req_state *s;
+  bufferlist bl_tmp;
+  bool last;
+  public:
+  MotrGetDataCB_Wrapper(RGWGetDataCB* _cb, RGWObjectCtx* obj_ctx) : cb(_cb), last(false) {
+    s = static_cast<req_state*>(obj_ctx->get_private());
+  }
+  ~MotrGetDataCB_Wrapper() {}
+  virtual int handle_data(bufferlist& bl, off_t bl_ofs, off_t bl_len) override;
+  void set_last(bool is_last) { last = is_last; }
+};
+
 class MotrCopyObj_Filter : public RGWGetDataCB {
 private:
   progress_cb _progress_cb;


### PR DESCRIPTION
Problem: When network IO is very slow, rgw connection gets timed out while writing data on the network. There is chuck size defined for the data to sent on the connection which causes large to written on the connection in one go.

Solution: Limit data to be sent over the connection from rgw motr sal. Only data euqal to chuck_size (configurable paramter, default value is 4Mb) to written on the connection at a time.

Signed-off-by: Saurabh Jain <saurabh.jain2@seagate.com>

Test: Tested it on dev setup with get-object of 5Gb object size. The get-object request completes in 45 seconds is same as taken for the same operation without this change.

With this change
```
2022-09-12T23:52:20.403-0600 7f1651cde700  1 beast: 0x7f167ac96780: ::1 - user [12/Sep/2022:23:51:34.558 -0600] "GET /buck/5g HTTP/1.1" 200 5368709120 - "aws-cli/1.22.45 Python/3.6.8 Linux/4.18.0-348.2.1.el8_5.x86_64 botocore/1.24.27" - latency=45.843971252s
```

Without this change
```
2022-09-14T05:40:13.252-0600 7facaa8a9700  1 beast: 0x7facd3861780: ::1 - user [14/Sep/2022:05:39:27.378 -0600] "GET /buck/5g HTTP/1.1" 200 5368709120 - "aws-cli/1.22.45 Python/3.6.8 Linux/4.18.0-348.2.1.el8_5.x86_64 botocore/1.24.27" - latency=45.871978760s
```



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
