### PR TITLE
rgw_sal_motr: [CORTX-32697] support user remove with purge data

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -2071,7 +2071,17 @@ MotrObject::MotrDeleteOp::MotrDeleteOp(MotrObject *_source, RGWObjectCtx *_rctx)
   source(_source),
   rctx(_rctx)
 {
-  addb_logger.set_id(rctx);
+  // - In case of the operation remove_user with --purge-data, we don't 
+  //   have access to the `req_state* s` via `RGWObjectCtx* rctx`.
+  // - In this case, we are generating a new req_id per obj deletion operation.
+  //   This will retrict us from traking all delete req per user_remove req in ADDB
+  //   untill we make changes to access req_state without using RGWObjectCtx ptr.
+
+  if (rctx->get_private()) {
+    addb_logger.set_id(rctx);
+  } else {
+    addb_logger.set_id(_source->store->get_new_req_id());
+  }
 }
 
 // Implementation of DELETE OBJ also requires MotrObject::get_obj_state()


### PR DESCRIPTION
Problem: 
During the Remove User code flow till the DeleteOp is instantiated for each obj from a bucket, we don't have the access to req_state ptr via RGWObjectCtx. This causes the addb.set_id(rctx) to fail, as it tries to access the req_id from null req_state ptr. 

Solution:
To avoid the above situation, guarded the addb.set_id() call by checking if we have the req_state ptr accessible.
If inaccessible then generate the new req_id for each delete req.

Signed-off-by: Sumedh Anantrao Kulkarni <sumedh.a.kulkarni@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
