### PR TITLE
rgw_sal_motr : [CORTX-34220]copy-object API : Invalid tagging directive case handled.

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -2501,18 +2501,23 @@ int MotrObject::copy_object_same_zone(RGWObjectCtx& obj_ctx,
 
   bufferlist tags_bl;
   if (tagging_drctv) {
-    if (strcasecmp(tagging_drctv, "COPY") == 0) {
+    std::string tagging_directive_str(tagging_drctv);
+    if (tagging_directive_str.compare("COPY") == 0) {
       rc = read_op->get_attr(dpp, RGW_ATTR_TAGS, tags_bl, y);
       if (rc < 0) {
         ldpp_dout(dpp, LOG_DEBUG) <<__func__ << ": DEBUG: No tags present for source object rc=" << rc << dendl;
       }
-    } else if (strcasecmp(tagging_drctv, "REPLACE") == 0) {
+    } else if (tagging_directive_str.compare("REPLACE") == 0) {
       ldpp_dout(dpp, LOG_INFO) <<__func__ << ": INFO: Parse tag values for object: " << dest_object->get_key().to_str() << dendl;
       int r = parse_tags(dpp, tags_bl, s);
       if (r < 0) {
         ldpp_dout(dpp, LOG_ERROR) <<__func__ << ": ERROR: Parsing object tags failed rc=" << rc << dendl;
         return r;
       }
+    } else {
+      ldpp_dout(this, 0) << "ERROR: Invalid tagging directive " << dendl;
+      s->err.message = "Unknown tagging directive.";
+      return -EINVAL;
     }
   attrs[RGW_ATTR_TAGS] = tags_bl;
   }


### PR DESCRIPTION
Problem :: Invalid tagging directive was not handled while doing copy operation.
Solution: Handled invalid tagging directives. Now it throws error <InvalidArgument>.


Signed-off-by: shraddhaghatol <shraddha.j.ghatol@seagate.com>
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
